### PR TITLE
fix(profile): capture new items badge position in profiles

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -504,6 +504,50 @@ final class MenuBarItemManager: ObservableObject {
         MenuBarItemManager.diagLog.debug("Updated new item destination to \(resolvedSection.logString) at relation \(updatedPlacement.relation.rawValue)")
     }
 
+    /// Applies a previously captured ``NewItemsPlacement`` (from a profile),
+    /// clamping to the hidden section when the always-hidden section is
+    /// disabled. Persists the updated preference.
+    ///
+    /// When clamping from `alwaysHidden` to `hidden`, the original anchor
+    /// references an alwaysHidden item that won't resolve in the hidden
+    /// section. Rather than letting the badge fall through to the
+    /// `.hidden`/always-hidden-disabled default (which is the leftmost
+    /// slot, farthest from the clock), we re-anchor to the rightmost
+    /// existing hidden item with `.leftOfAnchor` so the badge lands on
+    /// the clock-side edge of the section — the spot users reach first
+    /// when they expand the hidden section.
+    func applyNewItemsPlacement(_ placement: NewItemsPlacement) {
+        let preferredSection = sectionName(for: placement.sectionKey) ?? .hidden
+        let alwaysHiddenDisabled = appState?.settings.advanced.enableAlwaysHiddenSection != true
+        let clampedToHidden = preferredSection == .alwaysHidden && alwaysHiddenDisabled
+        let resolvedSection: MenuBarSection.Name = clampedToHidden ? .hidden : preferredSection
+
+        let adjusted: NewItemsPlacement
+        if clampedToHidden,
+           let rightmostHiddenItem = itemCache[.hidden].first(
+               where: { !$0.isControlItem && $0.tag.instanceIndex == 0 }
+           )
+        {
+            adjusted = NewItemsPlacement(
+                sectionKey: sectionKey(for: resolvedSection),
+                anchorIdentifier: persistedNewItemsAnchorIdentifier(for: rightmostHiddenItem),
+                relation: .leftOfAnchor
+            )
+        } else {
+            adjusted = NewItemsPlacement(
+                sectionKey: sectionKey(for: resolvedSection),
+                anchorIdentifier: placement.anchorIdentifier,
+                relation: placement.relation
+            )
+        }
+
+        guard newItemsPlacement != adjusted else { return }
+
+        newItemsPlacement = adjusted
+        persistNewItemsPlacementPreference()
+        MenuBarItemManager.diagLog.debug("Applied profile new item destination to \(resolvedSection.logString) at relation \(adjusted.relation.rawValue)")
+    }
+
     /// Returns the move destination that inserts a new item into the preferred section.
     private func newItemsMoveDestination(
         for controlItems: ControlItemPair,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -523,16 +523,25 @@ final class MenuBarItemManager: ObservableObject {
         let resolvedSection: MenuBarSection.Name = clampedToHidden ? .hidden : preferredSection
 
         let adjusted: NewItemsPlacement
-        if clampedToHidden,
-           let rightmostHiddenItem = itemCache[.hidden].first(
-               where: { !$0.isControlItem && $0.tag.instanceIndex == 0 }
-           )
-        {
-            adjusted = NewItemsPlacement(
-                sectionKey: sectionKey(for: resolvedSection),
-                anchorIdentifier: persistedNewItemsAnchorIdentifier(for: rightmostHiddenItem),
-                relation: .leftOfAnchor
-            )
+        if clampedToHidden {
+            if let rightmostHiddenItem = itemCache[.hidden].first(
+                where: { !$0.isControlItem && $0.tag.instanceIndex == 0 }
+            ) {
+                adjusted = NewItemsPlacement(
+                    sectionKey: sectionKey(for: resolvedSection),
+                    anchorIdentifier: persistedNewItemsAnchorIdentifier(for: rightmostHiddenItem),
+                    relation: .leftOfAnchor
+                )
+            } else {
+                // Clamping, but the hidden section is empty. Drop the
+                // stale alwaysHidden anchor and fall back to the section
+                // default so a later re-save doesn't resurface it.
+                adjusted = NewItemsPlacement(
+                    sectionKey: sectionKey(for: resolvedSection),
+                    anchorIdentifier: nil,
+                    relation: .sectionDefault
+                )
+            }
         } else {
             adjusted = NewItemsPlacement(
                 sectionKey: sectionKey(for: resolvedSection),

--- a/Thaw/Settings/Models/Profile.swift
+++ b/Thaw/Settings/Models/Profile.swift
@@ -154,6 +154,10 @@ struct MenuBarLayoutSnapshot: Codable {
     /// Ordered list of uniqueIdentifiers per section, capturing the visual
     /// order of items at save time. Used to restore within-section ordering.
     var itemOrder: [String: [String]]?
+
+    /// Placement preference for the New Items badge (section and anchor).
+    /// Absent in profiles saved before this field was introduced.
+    var newItemsPlacement: MenuBarItemManager.NewItemsPlacement?
 }
 
 // MARK: - ProfileContent

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -253,6 +253,12 @@ final class ProfileManager: ObservableObject {
             forKey: .menuBarItemCustomNames
         )
 
+        // Apply the New Items badge placement before starting the layout
+        // task, so late-arriving items land in the profile-defined spot.
+        if let placement = profile.menuBarLayout.newItemsPlacement {
+            appState.itemManager.applyNewItemsPlacement(placement)
+        }
+
         // Cancel any in-flight layout task before starting a new one.
         // Prevents two profile applies from fighting over item positions.
         layoutTask?.cancel()
@@ -424,7 +430,8 @@ final class ProfileManager: ObservableObject {
             pinnedAlwaysHiddenBundleIDs: pinnedAlwaysHiddenBundleIDs,
             customNames: customNames,
             itemSectionMap: itemSectionMap,
-            itemOrder: itemOrder
+            itemOrder: itemOrder,
+            newItemsPlacement: appState.itemManager.newItemsPlacement
         )
     }
 


### PR DESCRIPTION
## What does this PR do?

Fixes the "New Items" badge placement not being captured in profile saves. The badge's section + anchor + relation are now stored on each profile's menu bar layout snapshot, so they are restored on profile switch instead of remaining global to the app.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A. `MenuBarLayoutSnapshot.newItemsPlacement` is optional, so profiles saved before this change decode cleanly with the field set to `nil`. Existing profiles will pick up the current placement the next time they are saved or updated.

## What is the current behavior?

The New Items badge placement is persisted only to `UserDefaults` (`NewItemsPlacementData` / `NewItemsSection`) via `MenuBarItemManager.newItemsPlacement`, which is global to the app. Switching between profiles does not restore the badge's section or anchor, and none of the existing saved profiles on disk contain a `newItemsPlacement` field in their `menuBarLayout`.

Issue Number: N/A

## What is the new behavior?

- `MenuBarLayoutSnapshot` gains an optional `newItemsPlacement: MenuBarItemManager.NewItemsPlacement?` field (forward-compatible; older profiles decode with `nil`).
- `ProfileManager.captureCurrentLayout` reads `appState.itemManager.newItemsPlacement` into the snapshot on save.
- `MenuBarItemManager.applyNewItemsPlacement(_:)` restores a saved placement. When the saved section is `alwaysHidden` but the always-hidden section is disabled on the current machine, the badge is re-anchored to the rightmost existing hidden item with `.leftOfAnchor`, so it lands on the clock-side edge of the hidden section rather than falling through to the far-from-clock default.
- `ProfileManager.applyProfile` applies the saved placement before kicking off the layout task, so late-arriving items land in the profile-defined spot.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Verified against the three existing profiles on disk (`~/Library/Application Support/Thaw/Profiles/*.json`) — none contained a `newItemsPlacement` field prior to this change, confirming the gap. After this change, re-saving a profile writes the field and switching profiles restores it.

### Notes for reviewers

- Confirm the clamp behaviour in `applyNewItemsPlacement(_:)` is on the correct side of the hidden section. The intent is "closer to the clock" (rightmost cache slot, index 0) rather than the `defaultNewItemsBadgeIndex(.hidden, …)` behaviour with always-hidden disabled, which lands at the leftmost slot (far from clock). The implementation re-anchors to the rightmost managed item in `.hidden` with `.leftOfAnchor`; if the hidden section is empty, it falls back to `sectionDefault` (which on an empty section is already index 0).
- Confirm the placement is applied *before* `layoutTask` is spawned in `applyProfile`; the ordering matters so that any re-sort / late-arrival handling during the layout task sees the right destination.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * "New Items" badge placement is now saved in profiles and applied immediately when loading a profile, keeping your preferred placement as new items appear.
* **Bug Fixes / Behavior Improvements**
  * If a saved placement targets an unavailable section, the app now adjusts the placement to a visible anchor or falls back to the section default so badges remain visible and sensible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->