### PR TITLE
refactor: migrate captureScreenBelowWindow to ScreenCaptureKit

### DIFF
--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -483,7 +483,7 @@ final class MenuBarOverlayPanel: NSPanel {
         // Use async ScreenCaptureKit method with task context
         updateTaskContext.setTask(
             for: .desktopWallpaper,
-            timeout: .seconds(5)
+            timeout: .seconds(7)
         ) { [weak self] in
             guard let self else { return }
 

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import Combine
+import ScreenCaptureKit
 
 // MARK: - Overlay Panel
 
@@ -478,13 +479,29 @@ final class MenuBarOverlayPanel: NSPanel {
         else {
             return
         }
-        let wallpaper = ScreenCapture.captureScreenBelowWindow(
-            with: menuBarWindow.windowID,
-            screenBounds: menuBarWindow.bounds,
-            option: .nominalResolution
-        )
-        if desktopWallpaper?.dataProvider?.data != wallpaper?.dataProvider?.data {
-            desktopWallpaper = wallpaper
+
+        // Use async ScreenCaptureKit method with task context
+        updateTaskContext.setTask(
+            for: .desktopWallpaper,
+            timeout: .seconds(5)
+        ) { [weak self] in
+            guard let self else { return }
+
+            do {
+                let wallpaper = try await ScreenCapture.captureScreenBelowWindow(
+                    excludingWindowID: menuBarWindow.windowID,
+                    screenBounds: menuBarWindow.bounds,
+                    displayID: display
+                )
+
+                await MainActor.run {
+                    if self.desktopWallpaper?.dataProvider?.data != wallpaper?.dataProvider?.data {
+                        self.desktopWallpaper = wallpaper
+                    }
+                }
+            } catch {
+                self.diagLog.warning("updateDesktopWallpaper: capture failed with error: \(error)")
+            }
         }
     }
 

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -159,13 +159,11 @@ enum ScreenCapture {
             filter = SCContentFilter(display: display, excludingWindows: [])
         }
 
-        // Configure stream for single frame capture
-        // Convert global screenBounds to display-local coordinates and pixel dimensions
+        // Configure stream for single frame capture.
+        // sourceRect is in display-local points; width/height are in pixels.
         let displayFrame = display.frame
-        // Calculate pixel scale from display dimensions (pixels / points)
-        let scale = Double(display.width) / displayFrame.width
+        let scale = Double(filter.pointPixelScale)
 
-        // Display-local coordinates: offset by display origin
         let localSourceRect = CGRect(
             x: screenBounds.origin.x - displayFrame.origin.x,
             y: screenBounds.origin.y - displayFrame.origin.y,
@@ -174,10 +172,10 @@ enum ScreenCapture {
         )
 
         let configuration = SCStreamConfiguration()
-        configuration.captureResolution = .automatic
+        configuration.captureResolution = .best
         configuration.showsCursor = false
-        configuration.width = Int(screenBounds.width * scale)
-        configuration.height = Int(screenBounds.height * scale)
+        configuration.width = Int((screenBounds.width * scale).rounded())
+        configuration.height = Int((screenBounds.height * scale).rounded())
         configuration.sourceRect = localSourceRect
 
         // Create stream and capture frame
@@ -213,15 +211,25 @@ enum ScreenCapture {
 
     /// Helper to get shareable content using async wrapper
     private static func getShareableContent() async throws -> SCShareableContent {
-        try await withCheckedThrowingContinuation { continuation in
-            SCShareableContent.getWithCompletionHandler { content, error in
-                if let error {
-                    continuation.resume(throwing: error)
-                } else if let content {
-                    continuation.resume(returning: content)
-                } else {
-                    continuation.resume(throwing: ScreenCaptureError.noContent)
+        let box = ContinuationBox<SCShareableContent, any Error>()
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { continuation in
+                box.setContinuation(continuation)
+                SCShareableContent.getWithCompletionHandler { content, error in
+                    guard let continuation = box.takeContinuation() else { return }
+                    if let error {
+                        continuation.resume(throwing: error)
+                    } else if let content {
+                        continuation.resume(returning: content)
+                    } else {
+                        continuation.resume(throwing: ScreenCaptureError.noContent)
+                    }
                 }
+            }
+        } onCancel: {
+            // Resume with cancellation error if still pending
+            if let continuation = box.takeContinuation() {
+                continuation.resume(throwing: CancellationError())
             }
         }
     }
@@ -234,6 +242,27 @@ private enum ScreenCaptureError: Error {
 }
 
 /// Helper class to capture frames from SCStream
+/// Thread-safe box for storing and retrieving a continuation across concurrent contexts
+private final class ContinuationBox<T, E: Error>: @unchecked Sendable {
+    private var continuation: CheckedContinuation<T, E>?
+    private let lock = NSLock()
+
+    func setContinuation(_ cont: CheckedContinuation<T, E>) {
+        lock.lock()
+        continuation = cont
+        lock.unlock()
+    }
+
+    /// Returns and clears the continuation atomically, or nil if already taken
+    func takeContinuation() -> CheckedContinuation<T, E>? {
+        lock.lock()
+        let cont = continuation
+        continuation = nil
+        lock.unlock()
+        return cont
+    }
+}
+
 private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
     private var continuation: CheckedContinuation<CGImage?, Never>?
     private var bufferedImage: CGImage?
@@ -281,15 +310,6 @@ private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
         }
     }
 
-    private func resume(with image: CGImage?) {
-        lock.lock()
-        let cont = continuation
-        continuation = nil
-        stream = nil
-        lock.unlock()
-        cont?.resume(returning: image)
-    }
-
     func waitForFrame() async -> CGImage? {
         await withTaskCancellationHandler {
             await withCheckedContinuation { cont in
@@ -306,7 +326,7 @@ private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
                 lock.unlock()
             }
         } onCancel: { [weak self] in
-            Task { @MainActor [weak self] in
+            Task { [weak self] in
                 self?.stopStreamAndResume()
             }
         }

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -78,6 +78,21 @@ enum ScreenCapture {
 
     // MARK: Capture Window(s)
 
+    // NOTE: We intentionally use the deprecated CGWindowList API here instead of
+    // ScreenCaptureKit. SCShareableContent only returns on-screen windows in the
+    // current Space, but we need to capture:
+    //   - Offscreen menu bar items (overflow area)
+    //   - Windows in other Spaces
+    //   - Windows partially clipped by screen edges
+    //
+    // This is an architectural limitation of ScreenCaptureKit (designed for
+    // screen recording/streaming, not arbitrary window capture), not a bug.
+    // Even macOS 15+ does not provide public APIs to enumerate offscreen windows.
+    //
+    // CGWindowList remains the only public API capable of accessing offscreen
+    // and cross-Space window content. We use the hybrid approach:
+    // ScreenCaptureKit for display capture, CGWindowList for window capture.
+
     /// Captures a composite image of an array of windows.
     ///
     /// The windows are composited from front to back, according to the order

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -145,7 +145,7 @@ enum ScreenCapture {
         let excludedWindow = content.windows.first { $0.windowID == windowID }
 
         if excludedWindow == nil {
-            diagLog.warning("captureScreenBelowWindow: window not found for ID=\(windowID), capturing full display")
+            diagLog.debug("captureScreenBelowWindow: window not found for ID=\(windowID), capturing full display")
         }
 
         // Create filter: include display, exclude the specified window
@@ -160,25 +160,47 @@ enum ScreenCapture {
         }
 
         // Configure stream for single frame capture
+        // Convert global screenBounds to display-local coordinates and pixel dimensions
+        let displayFrame = display.frame
+        // Calculate pixel scale from display dimensions (pixels / points)
+        let scale = Double(display.width) / displayFrame.width
+
+        // Display-local coordinates: offset by display origin
+        let localSourceRect = CGRect(
+            x: screenBounds.origin.x - displayFrame.origin.x,
+            y: screenBounds.origin.y - displayFrame.origin.y,
+            width: screenBounds.width,
+            height: screenBounds.height
+        )
+
         let configuration = SCStreamConfiguration()
         configuration.captureResolution = .automatic
         configuration.showsCursor = false
-        configuration.width = Int(screenBounds.width)
-        configuration.height = Int(screenBounds.height)
-        configuration.sourceRect = screenBounds
+        configuration.width = Int(screenBounds.width * scale)
+        configuration.height = Int(screenBounds.height * scale)
+        configuration.sourceRect = localSourceRect
 
         // Create stream and capture frame
         let frameCaptor = FrameCaptor()
         let stream = SCStream(filter: filter, configuration: configuration, delegate: frameCaptor)
+        frameCaptor.setStream(stream)
+
+        // Register FrameCaptor to receive sample buffers
+        try stream.addStreamOutput(frameCaptor, type: .screen, sampleHandlerQueue: DispatchQueue(label: "com.stonerl.Thaw.screencapture"))
 
         try await stream.startCapture()
 
-        // Wait for frame with timeout
-        let image = try await withTimeout(seconds: 5) {
-            await frameCaptor.waitForFrame()
+        // Wait for frame with timeout, ensuring stopCapture() always called
+        let image: CGImage?
+        do {
+            image = try await withTimeout(seconds: 5) {
+                await frameCaptor.waitForFrame()
+            }
+            try? await stream.stopCapture()
+        } catch {
+            try? await stream.stopCapture()
+            throw error
         }
-
-        try await stream.stopCapture()
 
         if let image {
             diagLog.debug("captureScreenBelowWindow: captured below windowID=\(windowID) → \(image.width)×\(image.height)px")
@@ -214,12 +236,20 @@ private enum ScreenCaptureError: Error {
 /// Helper class to capture frames from SCStream
 private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
     private var continuation: CheckedContinuation<CGImage?, Never>?
+    private var bufferedImage: CGImage?
+    private var stream: SCStream?
     private let lock = NSLock()
+
+    func setStream(_ stream: SCStream) {
+        lock.lock()
+        self.stream = stream
+        lock.unlock()
+    }
 
     func stream(_: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
         guard type == .screen else { return }
         guard let imageBuffer = sampleBuffer.imageBuffer else {
-            resume(with: nil)
+            resumeOrBuffer(with: nil)
             return
         }
 
@@ -227,31 +257,75 @@ private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
         let ciImage = CIImage(cvImageBuffer: imageBuffer)
         let context = CIContext()
         guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
-            resume(with: nil)
+            resumeOrBuffer(with: nil)
             return
         }
 
-        resume(with: cgImage)
+        resumeOrBuffer(with: cgImage)
     }
 
     func stream(_: SCStream, didStopWithError _: Error) {
-        resume(with: nil)
+        resumeOrBuffer(with: nil)
+    }
+
+    private func resumeOrBuffer(with image: CGImage?) {
+        lock.lock()
+        if let cont = continuation {
+            continuation = nil
+            stream = nil
+            lock.unlock()
+            cont.resume(returning: image)
+        } else {
+            bufferedImage = image
+            lock.unlock()
+        }
     }
 
     private func resume(with image: CGImage?) {
         lock.lock()
         let cont = continuation
         continuation = nil
+        stream = nil
         lock.unlock()
         cont?.resume(returning: image)
     }
 
     func waitForFrame() async -> CGImage? {
-        await withCheckedContinuation { cont in
-            lock.lock()
-            self.continuation = cont
-            lock.unlock()
+        await withTaskCancellationHandler {
+            await withCheckedContinuation { cont in
+                lock.lock()
+                // Check if frame already buffered
+                if let image = bufferedImage {
+                    bufferedImage = nil
+                    lock.unlock()
+                    cont.resume(returning: image)
+                    return
+                }
+                // Otherwise, install continuation
+                self.continuation = cont
+                lock.unlock()
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.stopStreamAndResume()
+            }
         }
+    }
+
+    private func stopStreamAndResume() {
+        lock.lock()
+        let cont = continuation
+        let currentStream = stream
+        continuation = nil
+        stream = nil
+        lock.unlock()
+
+        if let currentStream {
+            Task {
+                try? await currentStream.stopCapture()
+            }
+        }
+        cont?.resume(returning: nil)
     }
 }
 
@@ -262,7 +336,7 @@ private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async
             try await operation()
         }
         group.addTask {
-            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            try await Task.sleep(for: .seconds(seconds))
             throw TimeoutError()
         }
         guard let result = try await group.next() else {

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -100,7 +100,7 @@ enum ScreenCapture {
         // items, so we unfortunately have to use the deprecated CGWindowList API.
         let image = CGImage(windowListFromArrayScreenBounds: bounds, windowArray: array as CFArray, imageOption: option)
         if let image {
-            diagLog.debug("captureWindows: ✓ captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
+            diagLog.debug("captureWindows: captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
         } else {
             diagLog.warning("captureWindows: CGImage(windowListFromArrayScreenBounds:) returned nil for \(windowIDs.count) windows (IDs: \(windowIDs.prefix(5)))")
         }
@@ -118,19 +118,160 @@ enum ScreenCapture {
         captureWindows(with: [windowID], screenBounds: screenBounds, option: option)
     }
 
-    /// Captures a composite image of all windows below the specified window.
+    // MARK: - ScreenCaptureKit Implementation
+
+    /// Captures a composite image of all windows below the specified window using ScreenCaptureKit.
     ///
     /// - Parameters:
-    ///   - windowID: The identifier of the window to capture below.
+    ///   - windowID: The identifier of the window to exclude (capture everything below it).
     ///   - screenBounds: The bounds to capture, specified in screen coordinates.
-    ///   - option: Options that specify which parts of the windows are captured.
-    static func captureScreenBelowWindow(with windowID: CGWindowID, screenBounds: CGRect, option: CGWindowImageOption = []) -> CGImage? {
-        let image = CGWindowListCreateImage(screenBounds, .optionOnScreenBelowWindow, windowID, option)
-        if let image {
-            diagLog.debug("captureScreenBelowWindow: ✓ captured below windowID=\(windowID) → \(image.width)×\(image.height)px")
-        } else {
-            diagLog.warning("captureScreenBelowWindow: CGWindowListCreateImage returned nil for windowID=\(windowID)")
+    ///   - displayID: The display to capture from.
+    /// - Returns: The captured image, or nil if capture failed.
+    static func captureScreenBelowWindow(
+        excludingWindowID windowID: CGWindowID,
+        screenBounds: CGRect,
+        displayID: CGDirectDisplayID
+    ) async throws -> CGImage? {
+        // Get shareable content (displays and windows)
+        let content = try await getShareableContent()
+
+        // Find the target display
+        guard let display = content.displays.first(where: { $0.displayID == displayID }) else {
+            diagLog.warning("captureScreenBelowWindow: display not found for ID=\(displayID)")
+            return nil
         }
+
+        // Find the window to exclude
+        let excludedWindow = content.windows.first { $0.windowID == windowID }
+
+        if excludedWindow == nil {
+            diagLog.warning("captureScreenBelowWindow: window not found for ID=\(windowID), capturing full display")
+        }
+
+        // Create filter: include display, exclude the specified window
+        let filter: SCContentFilter
+        if let excludedWindow = excludedWindow {
+            filter = SCContentFilter(
+                display: display,
+                excludingWindows: [excludedWindow]
+            )
+        } else {
+            filter = SCContentFilter(display: display, excludingWindows: [])
+        }
+
+        // Configure stream for single frame capture
+        let configuration = SCStreamConfiguration()
+        configuration.captureResolution = .automatic
+        configuration.showsCursor = false
+        configuration.width = Int(screenBounds.width)
+        configuration.height = Int(screenBounds.height)
+        configuration.sourceRect = screenBounds
+
+        // Create stream and capture frame
+        let frameCaptor = FrameCaptor()
+        let stream = SCStream(filter: filter, configuration: configuration, delegate: frameCaptor)
+
+        try await stream.startCapture()
+
+        // Wait for frame with timeout
+        let image = try await withTimeout(seconds: 5) {
+            await frameCaptor.waitForFrame()
+        }
+
+        try await stream.stopCapture()
+
+        if let image {
+            diagLog.debug("captureScreenBelowWindow: captured below windowID=\(windowID) → \(image.width)×\(image.height)px")
+        } else {
+            diagLog.warning("captureScreenBelowWindow: failed to capture image below windowID=\(windowID)")
+        }
+
         return image
     }
+
+    /// Helper to get shareable content using async wrapper
+    private static func getShareableContent() async throws -> SCShareableContent {
+        try await withCheckedThrowingContinuation { continuation in
+            SCShareableContent.getWithCompletionHandler { content, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let content {
+                    continuation.resume(returning: content)
+                } else {
+                    continuation.resume(throwing: ScreenCaptureError.noContent)
+                }
+            }
+        }
+    }
 }
+
+// MARK: - Helper Types
+
+private enum ScreenCaptureError: Error {
+    case noContent
+}
+
+/// Helper class to capture frames from SCStream
+private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
+    private var continuation: CheckedContinuation<CGImage?, Never>?
+    private let lock = NSLock()
+
+    func stream(_: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .screen else { return }
+        guard let imageBuffer = sampleBuffer.imageBuffer else {
+            resume(with: nil)
+            return
+        }
+
+        // Convert CVImageBuffer to CGImage
+        let ciImage = CIImage(cvImageBuffer: imageBuffer)
+        let context = CIContext()
+        guard let cgImage = context.createCGImage(ciImage, from: ciImage.extent) else {
+            resume(with: nil)
+            return
+        }
+
+        resume(with: cgImage)
+    }
+
+    func stream(_: SCStream, didStopWithError _: Error) {
+        resume(with: nil)
+    }
+
+    private func resume(with image: CGImage?) {
+        lock.lock()
+        let cont = continuation
+        continuation = nil
+        lock.unlock()
+        cont?.resume(returning: image)
+    }
+
+    func waitForFrame() async -> CGImage? {
+        await withCheckedContinuation { cont in
+            lock.lock()
+            self.continuation = cont
+            lock.unlock()
+        }
+    }
+}
+
+/// Helper to add timeout to async operations
+private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async throws -> T) async throws -> T {
+    try await withThrowingTaskGroup(of: T.self) { group in
+        group.addTask {
+            try await operation()
+        }
+        group.addTask {
+            try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            throw TimeoutError()
+        }
+        guard let result = try await group.next() else {
+            group.cancelAll()
+            throw TimeoutError()
+        }
+        group.cancelAll()
+        return result
+    }
+}
+
+private struct TimeoutError: Error {}

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -187,16 +187,16 @@ enum ScreenCapture {
         )
 
         let configuration = SCStreamConfiguration()
-        configuration.captureResolution = .best
+        // captureResolution is not used here; explicit width/height below take precedence.
         configuration.showsCursor = false
         configuration.width = Int((screenBounds.width * scale).rounded())
         configuration.height = Int((screenBounds.height * scale).rounded())
         configuration.sourceRect = localSourceRect
 
         // Create stream and capture frame
+        // Note: Caller owns the stream and is responsible for stopCapture().
         let frameCaptor = FrameCaptor()
         let stream = SCStream(filter: filter, configuration: configuration, delegate: frameCaptor)
-        frameCaptor.setStream(stream)
 
         // Register FrameCaptor to receive sample buffers
         try stream.addStreamOutput(frameCaptor, type: .screen, sampleHandlerQueue: DispatchQueue(label: "com.stonerl.Thaw.screencapture"))
@@ -341,31 +341,24 @@ private final class FrameCaptor: NSObject, SCStreamOutput, SCStreamDelegate {
                 lock.unlock()
             }
         } onCancel: { [weak self] in
-            Task { [weak self] in
-                self?.stopStreamAndResume()
-            }
+            self?.stopStreamAndResume()
         }
     }
 
     private func stopStreamAndResume() {
         lock.lock()
         let cont = continuation
-        let currentStream = stream
         continuation = nil
         stream = nil
         lock.unlock()
 
-        if let currentStream {
-            Task {
-                try? await currentStream.stopCapture()
-            }
-        }
+        // Resume with nil on cancellation; caller remains responsible for stopCapture().
         cont?.resume(returning: nil)
     }
 }
 
 /// Helper to add timeout to async operations
-private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async throws -> T) async throws -> T {
+private func withTimeout<T>(seconds: TimeInterval, operation: sending @escaping () async throws -> T) async throws -> T {
     try await withThrowingTaskGroup(of: T.self) { group in
         group.addTask {
             try await operation()
@@ -374,6 +367,8 @@ private func withTimeout<T>(seconds: TimeInterval, operation: @escaping () async
             try await Task.sleep(for: .seconds(seconds))
             throw TimeoutError()
         }
+        // group.next() returning nil is unreachable in this context (always at least one task),
+        // but the guard serves as defensive documentation.
         guard let result = try await group.next() else {
             group.cancelAll()
             throw TimeoutError()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,6 +18,7 @@ sonar.coverage.exclusions = \
   **/AppNavigationState.swift,\
   **/SettingsURIHandler.swift,\
   **/Extensions.swift,\
+  **/ScreenCapture.swift,\
   **/*Settings.swift,\
   **/*SettingsPane.swift,\
   **/*SettingsView.swift,\


### PR DESCRIPTION
## What does this PR do?

Replace deprecated CGWindowListCreateImage API with modern ScreenCaptureKit:

- Use SCShareableContent to enumerate displays and windows
- Use SCContentFilter to capture display while excluding menu bar window
- Use SCStream for async single-frame capture
- Remove old sync function (macOS 14+ requirement)

Updates MenuBarOverlayPanel to use new async method with existing UpdateTaskContext infrastructure.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## What is the current behavior?

We currently use a deprecated API, `CGWindowListCreateImage`, to get the background color of the menu bar.

## What is the new behavior?

We now use `ScreenCaptureKit` instead.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [x] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

This is the first step of migrating Thaw away from the old APIs. We need to check whether we can also migrate `captureWindows()` to the new API.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Wallpaper capture reworked to an asynchronous, cancellable flow for improved responsiveness and reliability.

* **Bug Fixes**
  * Capture operations now enforce timeouts, surface failures as warnings, and update the desktop wallpaper only when the captured image differs.

* **Chores**
  * Screen capture implementation excluded from coverage checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->