### PR TITLE
fix(layout-bar): correct notch indicator size and position in layout settings

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBar.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBar.swift
@@ -45,12 +45,6 @@ struct LayoutBar: View {
                 backgroundShape
                     .strokeBorder(.quaternary)
             }
-            .overlay {
-                if section == .visible, NSScreen.main?.hasNotch == true {
-                    NotchIndicatorOverlay(averageColorInfo: appState.menuBarManager.averageColorInfo)
-                        .allowsHitTesting(false)
-                }
-            }
     }
 
     @ViewBuilder

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -16,6 +16,13 @@ final class LayoutBarPaddingView: NSView {
     private let container: LayoutBarContainer
     private var isStabilizing = false
 
+    private var notchView: NotchIndicatorView?
+    private var notchWidthConstraint: NSLayoutConstraint?
+    private var notchTrailingConstraint: NSLayoutConstraint?
+    private var minWidthConstraint: NSLayoutConstraint?
+    private var containerLeadingAfterNotchConstraint: NSLayoutConstraint?
+    private var notchObservers = Set<AnyCancellable>()
+
     private func layoutWatchdogDuration() -> Duration? {
         switch MenuBarItemManager.layoutWatchdogTimeout {
         case let .seconds(s):
@@ -53,6 +60,9 @@ final class LayoutBarPaddingView: NSView {
         ])
 
         registerForDraggedTypes([.layoutBarItem])
+
+        configureNotchObservers(appState: appState)
+        updateNotchPresentation()
     }
 
     @available(*, unavailable)
@@ -327,5 +337,116 @@ final class LayoutBarPaddingView: NSView {
             appState.imageCache.performCacheCleanup()
         }
         await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            updateNotchPresentation()
+        }
+    }
+
+    private func configureNotchObservers(appState: AppState) {
+        guard container.section == .visible else {
+            return
+        }
+
+        NotificationCenter.default
+            .publisher(for: NSApplication.didChangeScreenParametersNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updateNotchPresentation()
+            }
+            .store(in: &notchObservers)
+
+        NotificationCenter.default
+            .publisher(for: NSWindow.didChangeScreenNotification)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] notification in
+                guard let self,
+                      let notifyingWindow = notification.object as? NSWindow,
+                      notifyingWindow === self.window
+                else { return }
+                self.updateNotchPresentation()
+            }
+            .store(in: &notchObservers)
+
+        appState.menuBarManager.$averageColorInfo
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] colorInfo in
+                self?.notchView?.averageColorInfo = colorInfo
+            }
+            .store(in: &notchObservers)
+    }
+
+    private func updateNotchPresentation() {
+        guard
+            container.section == .visible,
+            let screen = NSScreen.screenWithActiveMenuBar ?? NSScreen.main,
+            screen.hasNotch,
+            let notch = screen.frameOfNotch
+        else {
+            tearDownNotchPresentation()
+            return
+        }
+
+        let notchIndicatorWidth = notch.width + MenuBarSection.notchGap
+        // Distance from the bar's trailing edge to the notch indicator's
+        // trailing edge — equals the real-world items area (everything
+        // right of `notch.maxX + notchGap` in the menu bar) plus the 7.5pt
+        // cosmetic inset that sits between items and the rounded edge.
+        let notchTrailingOffset = max(0, screen.frame.maxX - notch.maxX - MenuBarSection.notchGap) + 7.5
+        // Bar must always be wide enough to represent the real-world span
+        // from `notch.minX` to `screen.maxX`, plus 7.5pt cosmetic inset on
+        // each side. When the Settings pane is wider, the bar grows past
+        // this and the empty area is shown to the LEFT of the notch.
+        let barMinWidth = max(0, screen.frame.maxX - notch.minX) + 15
+        let colorInfo = container.appState?.menuBarManager.averageColorInfo
+
+        if let notchView {
+            notchView.isHidden = false
+            notchView.averageColorInfo = colorInfo
+            notchWidthConstraint?.constant = notchIndicatorWidth
+            notchTrailingConstraint?.constant = -notchTrailingOffset
+            minWidthConstraint?.constant = barMinWidth
+            return
+        }
+
+        let view = NotchIndicatorView(averageColorInfo: colorInfo)
+        addSubview(view, positioned: .below, relativeTo: container)
+        self.notchView = view
+
+        let widthConstraint = view.widthAnchor.constraint(equalToConstant: notchIndicatorWidth)
+        let trailingConstraint = view.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -notchTrailingOffset)
+        let containerLeading = container.leadingAnchor.constraint(greaterThanOrEqualTo: view.trailingAnchor)
+        let minWidth = widthAnchor.constraint(greaterThanOrEqualToConstant: barMinWidth)
+
+        NSLayoutConstraint.activate([
+            trailingConstraint,
+            view.topAnchor.constraint(equalTo: topAnchor),
+            view.bottomAnchor.constraint(equalTo: bottomAnchor),
+            widthConstraint,
+            containerLeading,
+            minWidth,
+        ])
+
+        notchWidthConstraint = widthConstraint
+        notchTrailingConstraint = trailingConstraint
+        containerLeadingAfterNotchConstraint = containerLeading
+        minWidthConstraint = minWidth
+    }
+
+    private func tearDownNotchPresentation() {
+        notchWidthConstraint?.isActive = false
+        notchTrailingConstraint?.isActive = false
+        containerLeadingAfterNotchConstraint?.isActive = false
+        minWidthConstraint?.isActive = false
+        notchWidthConstraint = nil
+        notchTrailingConstraint = nil
+        containerLeadingAfterNotchConstraint = nil
+        minWidthConstraint = nil
+        notchView?.removeFromSuperview()
+        notchView = nil
     }
 }

--- a/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
+++ b/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
@@ -6,53 +6,57 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import Cocoa
 import SwiftUI
 
-/// A visual indicator overlay showing the notch dead zone in the Layout Bar.
+/// A non-interactive view that visualises the notch dead zone at the
+/// leading edge of the visible Layout Bar.
 ///
-/// Displayed at the left edge of the visible section's bar to represent
-/// the area where menu bar items cannot be placed on notched displays.
-struct NotchIndicatorOverlay: View {
-    let averageColorInfo: MenuBarAverageColorInfo?
-
-    /// Trigger to force redraw when screen parameters change.
-    @State private var screenChangeTrigger = UUID()
-
-    var body: some View {
-        GeometryReader { geometry in
-            if let screen = NSScreen.main,
-               let notch = screen.frameOfNotch
-            {
-                let notchGap = MenuBarSection.notchGap
-                let notchTotalWidth = notch.width + 2 * notchGap
-                // Total right-side space: from screen center to right edge,
-                // which includes both the notch area and the usable area.
-                let rightSideTotal = screen.frame.width / 2
-                let notchFraction = notchTotalWidth / max(rightSideTotal, 1)
-
-                // The layout bar represents the right side of the screen.
-                // Scale the notch proportionally.
-                let proportionalWidth = max(30, geometry.size.width * notchFraction)
-                // Cap at 45% of the bar width.
-                let clampedWidth = min(proportionalWidth, geometry.size.width * 0.45)
-
-                HStack(spacing: 0) {
-                    notchIndicator
-                        .frame(width: clampedWidth)
-                        .frame(maxHeight: .infinity)
-                    Spacer()
-                }
-            }
+/// Lives inside the scrollable document view and is sized in real screen
+/// points so it scrolls with the layout content and stays in 1:1 scale
+/// with the menu bar items beside it.
+final class NotchIndicatorView: NSView {
+    /// Colour palette used to keep the indicator legible against the
+    /// current menu bar background.
+    var averageColorInfo: MenuBarAverageColorInfo? {
+        didSet {
+            hosting.rootView = NotchIndicatorContent(averageColorInfo: averageColorInfo)
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)) { _ in
-            screenChangeTrigger = UUID()
-        }
-        .id(screenChangeTrigger)
     }
 
-    private var notchIndicator: some View {
+    private let hosting: NSHostingView<NotchIndicatorContent>
+
+    init(averageColorInfo: MenuBarAverageColorInfo?) {
+        self.averageColorInfo = averageColorInfo
+        self.hosting = NSHostingView(rootView: NotchIndicatorContent(averageColorInfo: averageColorInfo))
+        super.init(frame: .zero)
+        translatesAutoresizingMaskIntoConstraints = false
+        unregisterDraggedTypes()
+
+        hosting.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(hosting)
+        NSLayoutConstraint.activate([
+            hosting.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hosting.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hosting.topAnchor.constraint(equalTo: topAnchor),
+            hosting.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    @available(*, unavailable)
+    required init?(coder _: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+/// SwiftUI body for the notch indicator. Hosted in `NSHostingView` so the
+/// parent `NSView` supplies the frame in real screen points instead of
+/// relying on `GeometryReader` math.
+private struct NotchIndicatorContent: View {
+    let averageColorInfo: MenuBarAverageColorInfo?
+
+    var body: some View {
         ZStack {
-            // Diagonal stripes adapted to menu bar background.
             DiagonalStripes(color: stripeColor)
                 .clipShape(RoundedRectangle(cornerRadius: 6))
                 .padding(3)
@@ -73,25 +77,18 @@ struct NotchIndicatorOverlay: View {
         }
     }
 
-    /// Color for diagonal stripes based on menu bar background brightness.
     private var stripeColor: Color {
-        let isBright = isBrightForActiveScreen()
-        return isBright ? .black.opacity(0.5) : .white.opacity(0.5)
+        isBright ? .black.opacity(0.5) : .white.opacity(0.5)
     }
 
-    /// Border color based on menu bar background brightness.
     private var borderColor: Color {
-        let isBright = isBrightForActiveScreen()
-        return isBright ? .black.opacity(0.65) : .white.opacity(0.65)
+        isBright ? .black.opacity(0.65) : .white.opacity(0.65)
     }
 
-    /// Text color based on menu bar background brightness.
     private var textColor: Color {
-        let isBright = isBrightForActiveScreen()
-        return isBright ? .black : .white
+        isBright ? .black : .white
     }
 
-    /// Background color for the text pill, matching the menu bar background.
     private var textPillBackgroundColor: Color {
         guard let colorInfo = averageColorInfo else {
             return Color(nsColor: .defaultLayoutBar)
@@ -99,14 +96,13 @@ struct NotchIndicatorOverlay: View {
         return Color(cgColor: colorInfo.color)
     }
 
-    /// Helper to check brightness using the same screen used for notch geometry.
-    private func isBrightForActiveScreen() -> Bool {
+    private var isBright: Bool {
         guard let colorInfo = averageColorInfo else { return false }
-        return colorInfo.isBright(for: NSScreen.main)
+        return colorInfo.isBright(for: NSScreen.screenWithActiveMenuBar ?? NSScreen.main)
     }
 }
 
-/// Draws repeating diagonal stripes.
+/// Repeating diagonal stripes used as the notch indicator's fill.
 private struct DiagonalStripes: View {
     let color: Color
 


### PR DESCRIPTION
## What does this PR do?

Fixes the notch indicator's size, position, and the Layout settings bar's behaviour relative to the real menu bar geometry on notched displays. The notch indicator in Settings → Layout previously scaled the notch as a fraction of `screen.frame.width / 2` while menu bar items were drawn at their actual point widths, so the notch appeared far smaller and far further from the icons than reality. The bar also stretched to fill the entire Settings pane, putting items at the pane's right edge (which represents nothing real) rather than at `screen.maxX`, producing a huge dead zone between the notch and the leftmost item. After this change the bar fills the pane width as before, items right-align to the trailing edge (representing `screen.maxX`), and the notch indicator is anchored from the trailing edge at the geometric offset `(screen.maxX − notch.maxX − notchGap) + 7.5`, so its position relative to the icons matches the real menu bar regardless of pane width. A minimum width of `(screen.maxX − notch.minX) + 15` is enforced on the document view so the bar always represents the full real-world span from the notch's left edge to the screen's right edge — the existing `LayoutBarScrollView` horizontal scroller takes over when the pane is narrower than that.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

On a notched MacBook the Layout settings panel renders the notch indicator with proportional-scaling math against `screen.frame.width / 2`, while items inside the bar are sized 1:1 to their actual menu bar widths — the two scales don't agree, so the notch indicator looks several times smaller than it should and sits well to the left of where the leftmost items (Thaw chevron, "New Items" badge) would actually be on the real menu bar. The bar itself stretches to `.frame(maxWidth: .infinity)` and items right-align to the bar's trailing edge, so on a wide Settings pane the chevron ends up pushed hundreds of points away from the notch indicator instead of sitting next to it as it does in reality. There is no horizontal scroller / minimum width enforcement, so a narrow Settings pane silently misrepresents the menu bar's geometry. `NotchIndicatorOverlay` reads `NSScreen.main` rather than the active menu bar screen, so the geometry can be wrong on multi-display setups. Issue Number: N/A

## What is the new behavior?

`NotchIndicatorOverlay` is replaced with an `NSView`-based `NotchIndicatorView` hosted inside the scrollable document view; the view is sized in real points (`notch.width + notchGap`) and its frame is set externally rather than via `GeometryReader` math. `LayoutBarPaddingView` adds the notch view on the leading edge of the visible bar (only when the active menu bar screen has a notch), anchors it from the bar's trailing edge at a fixed offset of `(screen.maxX − notch.maxX − notchGap) + 7.5`, and forces the document view to a minimum width of `(screen.maxX − notch.minX) + 15` so the bar always represents the full real-world span from the notch's left edge to the screen's right edge. The pre-existing `LayoutBarScrollView` horizontal scroller (already configured with `hasHorizontalScroller = true` and `autohidesScrollers = true`) automatically appears when the Settings pane is narrower than the real-world span. Screen lookup is switched from `NSScreen.main` to `NSScreen.screenWithActiveMenuBar ?? NSScreen.main` for consistency with `MenuBarItemManager` and correct multi-display behaviour. `LayoutBarPaddingView` subscribes to `NSApplication.didChangeScreenParametersNotification`, `NSWindow.didChangeScreenNotification`, and `appState.menuBarManager.$averageColorInfo` so the indicator's geometry and colours react to display and wallpaper changes without requiring a Settings reopen. Hidden / Always-Hidden bars and non-notched displays keep their existing fill-to-pane behaviour, completely unchanged.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Verified visually on a 14" notched MacBook: the notch indicator now sits the correct distance from the Thaw chevron / leftmost item, matching the real menu bar above the Settings window. With a wide Settings pane the bar fills the pane and the empty area appears to the LEFT of the notch (representing the unreliable left-of-notch area where icons can technically go but where macOS placement is inconsistent). Narrowing the Settings pane below the real-world span surfaces the existing horizontal scroller without any code changes to `LayoutBarScrollView`. On non-notched and Hidden / Always-Hidden bars behaviour is byte-identical to before.

### Notes for reviewers

The key trick is that `notchView.trailingAnchor.constraint(equalTo: paddingView.trailingAnchor, constant: -((screen.maxX − notch.maxX − notchGap) + 7.5))` keeps the notch indicator at the correct geometric offset from `screen.maxX` regardless of how wide `paddingView` grows — so there is no need to clamp the bar's overall width, and the bar can keep filling the Settings pane the way Hidden / Always-Hidden bars do. The minimum-width constraint and the `container.leadingAnchor ≥ notchView.trailingAnchor` constraint together guarantee the bar can never represent less than the real menu bar, and items can never overlap the notch indicator. Worth checking on a non-notched display + multi-display setup to confirm the screen-change subscriptions tear the notch view down/up correctly when the active menu bar screen changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Enhanced menu bar notch indicator reliability and responsiveness to screen configuration changes.

* **Performance**
  - Improved notch indicator positioning and rendering stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Fixes #449.