### PR TITLE
fix(controlitem): restore double-click to expand always-hidden section

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -566,6 +566,17 @@ final class ControlItem {
             // Running this from a Task seems to improve the visual
             // responsiveness of the status item's button.
             Task { [appState] in
+                if
+                    !appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
+                    event.clickCount > 1,
+                    identifier == .visible,
+                    let alwaysHidden = menuBarManager.section(withName: .alwaysHidden),
+                    alwaysHidden.isEnabled
+                {
+                    alwaysHidden.show()
+                    return
+                }
+
                 if modifierFlags.contains(.control) {
                     showMenu()
                     return


### PR DESCRIPTION
## What does this PR do?

Restores the double-click gesture on the visible Thaw status-bar icon so that it once again expands the always-hidden section when the option-click setting is disabled.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

With "Use option-click to show always-hidden section" turned off, both single- and double-clicking the Thaw icon do the same thing — they just toggle the regular hidden section, and there is no way to reveal the always-hidden section from the icon. Regression introduced in 3cbd24e2, where the click-handler half of an unrelated settings-pane fix removed the double-click branch from `ControlItem.performAction()` without replacement.

Issue Number: N/A

## What is the new behavior?

When the option-click setting is off and the always-hidden section is enabled, double-clicking the visible Thaw icon expands the always-hidden section again, matching the pre-regression UX. Single-click still toggles the hidden section, option-click handling is unchanged when that setting is on, and the right-click context menu path is untouched. Implemented by re-inserting the original guard at the top of the `.leftMouseDown` Task in `Thaw/MenuBar/ControlItem/ControlItem.swift`, gated on `!useOptionClickToShowAlwaysHiddenSection`, `event.clickCount > 1`, `identifier == .visible`, and `alwaysHidden.isEnabled`.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

No automated coverage exists for the status-item click path; verified manually with the option-click setting off (double-click reveals always-hidden), with it on (option-click reveals always-hidden, double-click does not), with the always-hidden section disabled (double-click is a no-op for that branch), and right-click still opens the context menu.

### Notes for reviewers

The change is a straight revert of the click-handler block that 3cbd24e2 removed; the settings-pane half of that commit (hiding the dependent toggle in `AdvancedSettingsPane`/`GeneralSettingsPane` when always-hidden is disabled) is intentionally left in place since it was correct on its own.