### PR TITLE
fix(menu-bar): prevent icon drift during fast restore with unresolved sourcePIDs

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -3683,20 +3683,6 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard appState != nil else { return false }
 
-        // Skip when any hideable item has an unresolved sourcePID. Without
-        // sourcePID resolution, third-party items hosted by Control Center
-        // fall back to namespace "com.apple.controlcenter", which prevents
-        // matching against savedSectionOrder (real bundle IDs) and
-        // bundleIDsWithSavedHiddenItems. In that state, existing items can be
-        // misclassified as "new" and relocated. The next cache pass with
-        // resolved sourcePIDs will handle relocation safely.
-        if items.contains(where: { !$0.isControlItem && $0.sourcePID == nil }) {
-            MenuBarItemManager.diagLog.debug(
-                "relocateNewLeftmostItems: skipping, items have unresolved sourcePIDs"
-            )
-            return false
-        }
-
         if suppressNextNewLeftmostItemRelocation {
             // Seed known identifiers so these baseline items won't be treated as "new"
             // on subsequent cache passes, then clear the suppression flag.
@@ -3822,6 +3808,22 @@ extension MenuBarItemManager {
         // tag/namespace) and not already placed/pinned in hidden areas.
         let hideableLeftmost = leftmostItems.filter(\.canBeHidden)
         let previousIDs = Set(previousWindowIDs)
+
+        // Skip when any hideable item has an unresolved sourcePID. Without
+        // sourcePID resolution, third-party items hosted by Control Center
+        // fall back to namespace "com.apple.controlcenter", which prevents
+        // matching against savedSectionOrder (real bundle IDs) and
+        // bundleIDsWithSavedHiddenItems. In that state, existing items can be
+        // misclassified as "new" and relocated. The next cache pass with
+        // resolved sourcePIDs will handle relocation safely. The Thaw-icon
+        // and non-hideable-system-item branches above use windowID-based
+        // logic and run before this guard so they remain unaffected.
+        if hideableLeftmost.contains(where: { $0.sourcePID == nil }) {
+            MenuBarItemManager.diagLog.debug(
+                "relocateNewLeftmostItems: skipping, hideable items have unresolved sourcePIDs"
+            )
+            return false
+        }
 
         // Build lookup for saved sections (same logic as restoreItemsToSavedSections).
         var savedSectionForIdentifier = [String: MenuBarSection.Name]()

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1371,8 +1371,10 @@ extension MenuBarItemManager {
         // com.apple.controlcenter:Item-0:4 to pl.maketheweb.cleanshotx:Item-0),
         // the new identifier won't be in knownItemIdentifiers. Seed it now so
         // the item isn't treated as a "new" item by relocateNewLeftmostItems.
+        // Skip items with unresolved sourcePID so the placeholder
+        // "com.apple.controlcenter" namespace never enters the persisted set.
         if !previousWindowIDs.isEmpty {
-            for item in items where previousWindowIDs.contains(item.windowID) {
+            for item in items where previousWindowIDs.contains(item.windowID) && item.sourcePID != nil {
                 let identifier = "\(item.tag.namespace):\(item.tag.title)"
                 if !knownItemIdentifiers.contains(identifier) {
                     knownItemIdentifiers.insert(identifier)
@@ -3681,11 +3683,27 @@ extension MenuBarItemManager {
     ) async -> Bool {
         guard appState != nil else { return false }
 
+        // Skip when any hideable item has an unresolved sourcePID. Without
+        // sourcePID resolution, third-party items hosted by Control Center
+        // fall back to namespace "com.apple.controlcenter", which prevents
+        // matching against savedSectionOrder (real bundle IDs) and
+        // bundleIDsWithSavedHiddenItems. In that state, existing items can be
+        // misclassified as "new" and relocated. The next cache pass with
+        // resolved sourcePIDs will handle relocation safely.
+        if items.contains(where: { !$0.isControlItem && $0.sourcePID == nil }) {
+            MenuBarItemManager.diagLog.debug(
+                "relocateNewLeftmostItems: skipping, items have unresolved sourcePIDs"
+            )
+            return false
+        }
+
         if suppressNextNewLeftmostItemRelocation {
             // Seed known identifiers so these baseline items won't be treated as "new"
             // on subsequent cache passes, then clear the suppression flag.
+            // Skip items with unresolved sourcePID so the placeholder
+            // "com.apple.controlcenter" namespace never enters the persisted set.
             let identifiers = items
-                .filter { !$0.isControlItem }
+                .filter { !$0.isControlItem && $0.sourcePID != nil }
                 .map { "\($0.tag.namespace):\($0.tag.title)" }
             knownItemIdentifiers.formUnion(identifiers)
             persistKnownItemIdentifiers()
@@ -3702,8 +3720,10 @@ extension MenuBarItemManager {
         // Seed identifiers and skip relocation; the settling-end restore pass
         // will handle correct placement.
         if isInStartupSettling {
+            // Skip items with unresolved sourcePID so the placeholder
+            // "com.apple.controlcenter" namespace never enters the persisted set.
             let identifiers = items
-                .filter { !$0.isControlItem }
+                .filter { !$0.isControlItem && $0.sourcePID != nil }
                 .map { "\($0.tag.namespace):\($0.tag.title)" }
             knownItemIdentifiers.formUnion(identifiers)
             persistKnownItemIdentifiers()


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in 2.0.0-beta.3 where existing menu bar items (notably OneDrive and items belonging to Stats.app) drift into the "New Items" section after a fresh login, even when `savedSectionOrder` already records their correct placement.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

After the startup settling period ends, `performSetup` runs a final `cacheItemsRegardless` pass with `resolveSourcePID=false` for a quick layout refresh. In that pass, third-party items hosted by Control Center fall back to the placeholder namespace `com.apple.controlcenter` with title `Item-0`, and `assignStableInstanceIndices` groups them and assigns `instanceIndex` 0..N by windowID sort, producing uniqueIdentifiers like `com.apple.controlcenter:Item-0:11`. Those keys do not match anything in `savedSectionOrder` (which stores real bundle IDs like `com.microsoft.OneDrive:Item-0`), so `hasSavedSection` returns false. The `bundleIDsWithSavedHiddenItems` guard also fails because `bundleID(for:)` returns `com.apple.controlcenter` when `sourceApplication` is nil. With both protection layers bypassed, `isNewID=true` wins the relocation predicate in `relocateNewLeftmostItems` and existing items are moved into the visible section, drifting away from the user's saved layout. Multi-icon apps such as Stats and OneDrive are consistently affected, and `restoreItemsToSavedSections` cannot rescue them because it skips items with `instanceIndex != 0`.

Issue Number: #462

## What is the new behavior?

`relocateNewLeftmostItems` now returns early when any non-control item has an unresolved `sourcePID`, avoiding destructive relocation while namespaces are unreliable. The next cache pass with `resolveSourcePID=true` carries trustworthy namespaces and handles relocation correctly. The Thaw-icon and non-hideable system-item branches use windowID-based logic and continue to fire only after the guard, so they remain unaffected. Additionally, the three `knownItemIdentifiers` seeding sites (`cacheItemsRegardless`, `suppressNextNewLeftmostItemRelocation`, and `isInStartupSettling`) now skip items with `sourcePID == nil`, preventing the placeholder `com.apple.controlcenter` namespace from polluting the persisted identifier set.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Reproduction: on a Mac with several Control Center-hosted third-party items (OneDrive, Stats.app), set up a known layout with items in hidden, sign out, reboot, and sign back in. On stock 2.0.0-beta.3 one or more items appear in visible that should have been hidden. With this patch the items land in their saved sections after the post-settling pass completes, and the log contains `relocateNewLeftmostItems: skipping, items have unresolved sourcePIDs` instead of `Relocating new item ... to visible section`.

### Notes for reviewers

Please pay particular attention to mid-session new-app launches (open a fresh menu-bar app for the first time after Thaw is fully running) to confirm the auto-relocate-to-visible behavior still fires. By that point all items have resolved sourcePIDs, so the new guard should not trip. Multi-icon apps (Stats, Hammerspoon, iStat Menus) should also retain placement across reboots without shuffling.

Fixes #462.                                      

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Menu bar items of unknown origin are no longer saved into persisted layouts or used when seeding identifiers, preventing transient items from corrupting saved state.
  * Automatic relocation of newly added items is skipped if any placeholder/unresolvable items are present, avoiding incorrect rearrangements during startup or special-case scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->