### PR TITLE
fix(events): only expand sections on Cmd+drag when cursor is over a menu bar item

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -1127,7 +1127,7 @@ extension HIDEventManager {
         guard
             !isDraggingMenuBarItem,
             event.modifierFlags.contains(.command),
-            isMouseInsideMenuBar(appState: appState, screen: screen)
+            isMouseInsideMenuBarItem(appState: appState, screen: screen)
         else {
             return
         }


### PR DESCRIPTION
## What does this PR do?

Restricts the Cmd+drag "show all sections" gesture to drags that actually begin on a menu bar item, instead of firing for any Cmd+drag anywhere in the menu bar (including empty space).

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

Holding Command and click-dragging anywhere inside the menu bar expands every section and reveals its dividers, even when the drag begins over empty menu bar space rather than on an icon. The drag-start guard in `handleMenuBarItemDragStart` calls `isMouseInsideMenuBar`, which only checks that the cursor is within the menu bar's vertical bounds, so empty regions still satisfy it and trigger the `showAllSectionsOnUserDrag` expansion.
Issue Number: N/A

## What is the new behavior?

`handleMenuBarItemDragStart` now guards on `isMouseInsideMenuBarItem`, which consults the cached menu bar item bounds (with a Window Server fallback) and filters out the oversized expanded section dividers. Sections only flip to `.showSection` when the Cmd+drag actually starts on a real menu bar item; Cmd+drags that begin over empty space are ignored. The drag-stop path is already gated on `isDraggingMenuBarItem`, so it stays a no-op when the start path bails.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Verified by Cmd+click-dragging on empty menu bar regions (no expansion) and on real icons (expansion as before). The `showAllSectionsOnUserDrag` advanced setting still controls whether expansion happens at all; this change only narrows when it triggers.

### Notes for reviewers

The single-line change is in `Thaw/Events/HIDEventManager.swift` inside `handleMenuBarItemDragStart`. Worth a quick sanity check that `isMouseInsideMenuBarItem`'s cache+fallback path is fast enough for the drag-start hot path; it's the same helper already used by hover/click hit testing, so no new IPC patterns are introduced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Menu-bar drag precision - Menu-bar item dragging now activates only when dragging directly on an item, rather than anywhere within the menu bar area. This improves interaction accuracy and reduces unintended drag operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->