### PR TITLE
fix(controlitem): allow icon double-click to open always-hidden when option-click setting is on

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -567,7 +567,6 @@ final class ControlItem {
             // responsiveness of the status item's button.
             Task { [appState] in
                 if
-                    !appState.settings.advanced.useOptionClickToShowAlwaysHiddenSection,
                     event.clickCount > 1,
                     identifier == .visible,
                     let alwaysHidden = menuBarManager.section(withName: .alwaysHidden),


### PR DESCRIPTION
## What does this PR do?

Restores the Thaw icon double-click affordance for opening the always-hidden section when "Use option-click to open always-hidden section" is enabled.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] i18n/l10n (Translation/Localization)
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

With "Use option-click to open always-hidden section" enabled in Advanced settings, double-clicking the Thaw icon does not expand the always-hidden section. Each click is processed as an independent single click and falls through to `section.toggle()`, so the user sees the hidden section toggle on each click but never the always-hidden section. The bug is in the double-click guard inside `ControlItem.performAction` (`Thaw/MenuBar/ControlItem/ControlItem.swift`): its first condition is `!useOptionClickToShowAlwaysHiddenSection`, which short-circuits the entire double-click branch as soon as the option-click setting is turned on.

Issue Number: N/A

## What is the new behavior?

Double-click on the visible Thaw icon expands the always-hidden section regardless of the `useOptionClickToShowAlwaysHiddenSection` setting, as long as the always-hidden section itself is enabled. The option-click branch lower in `performAction` is unchanged, so option-click continues to toggle always-hidden only when its setting is on; the two affordances are now independent.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed
- [ ] I've verified localized strings work correctly (if i18n/l10n changes)

## Other information

Single-line change in `ControlItem.performAction`: removed the `!useOptionClickToShowAlwaysHiddenSection` condition from the double-click guard.

### Notes for reviewers

Worth confirming the four-way matrix on the always-hidden affordances still behaves as expected: option-click setting on/off crossed with double-click on the icon. After this change, double-click always opens always-hidden when the section is enabled; option-click opens it only when its setting is on. The control-click and plain single-click paths are untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar section toggling behavior when clicking control items, including fixes for multi-click interactions and modifier key handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->