### PR TITLE
fix(display): skip relaunch wave on resolution-only screen-parameters changes

### DIFF
--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -40,6 +40,12 @@ final class DisplaySettingsManager: ObservableObject {
     /// active-display configuration changes. Held weakly to avoid retain cycles.
     private weak var appState: AppState?
 
+    /// UUID of the active menu bar display the last time spacing was applied.
+    /// Used to skip didChangeScreenParametersNotification fires that only
+    /// reflect a resolution or other-parameter change on the same display.
+    /// Internal access so unit tests in ThawTests can seed and assert it.
+    var lastAppliedActiveDisplayUUID: String?
+
     /// Performs the initial setup of the manager.
     func performSetup(with appState: AppState) {
         self.appState = appState
@@ -162,6 +168,14 @@ final class DisplaySettingsManager: ObservableObject {
                 guard let self else { return }
                 diagLog.info("Screen parameters changed — \(NSScreen.screens.count) screen(s) connected")
                 captureCurrentlyConnectedDisplays()
+                let currentUUID = Bridging.getActiveMenuBarDisplayUUID()
+                if Self.shouldSkipSpacingApply(
+                    currentActiveDisplayUUID: currentUUID,
+                    lastAppliedActiveDisplayUUID: lastAppliedActiveDisplayUUID
+                ) {
+                    diagLog.info("Active menu bar display unchanged (\(currentUUID ?? "nil")); skipping spacing apply")
+                    return
+                }
                 applyActiveDisplaySpacing(reason: "screenParametersChanged")
             }
             .store(in: &c)
@@ -191,6 +205,22 @@ final class DisplaySettingsManager: ObservableObject {
         cancellables = c
     }
 
+    /// Returns true when a didChangeScreenParametersNotification fire should
+    /// be ignored because the active menu bar display has not changed
+    /// identity since the last spacing apply. A resolution change, lid
+    /// open/close, GPU/sleep transition, or other display-parameter event
+    /// that leaves the active display UUID the same is not a reason to
+    /// re-apply spacing (and risk a relaunch wave when on-disk values drift).
+    ///
+    /// Pure on its inputs, separated from the sink so it can be unit tested
+    /// without spinning up AppState or driving real screen events.
+    static func shouldSkipSpacingApply(
+        currentActiveDisplayUUID currentUUID: String?,
+        lastAppliedActiveDisplayUUID lastUUID: String?
+    ) -> Bool {
+        currentUUID == lastUUID
+    }
+
     /// Reads the active display's spacing offset, syncs it into
     /// spacingManager.offset, and triggers applyOffset. The no-op guard
     /// inside applyOffset skips when on-disk values already match, so this
@@ -200,6 +230,7 @@ final class DisplaySettingsManager: ObservableObject {
     /// moving them.
     private func applyActiveDisplaySpacing(reason: String) {
         guard let appState else { return }
+        lastAppliedActiveDisplayUUID = Bridging.getActiveMenuBarDisplayUUID()
         let desired = Int(configurationForActiveDisplay().itemSpacingOffset.rounded())
         appState.spacingManager.offset = desired
         Task { [weak self] in

--- a/ThawTests/DisplaySettingsManagerSpacingGateTests.swift
+++ b/ThawTests/DisplaySettingsManagerSpacingGateTests.swift
@@ -1,0 +1,81 @@
+//
+//  DisplaySettingsManagerSpacingGateTests.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+@testable import Thaw
+import XCTest
+
+@MainActor
+final class DisplaySettingsManagerSpacingGateTests: XCTestCase {
+
+    // MARK: - Predicate
+
+    func testPredicateSkipsWhenUUIDsMatch() {
+        XCTAssertTrue(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: "UUID-A",
+            lastAppliedActiveDisplayUUID: "UUID-A"
+        ))
+    }
+
+    func testPredicateDoesNotSkipWhenUUIDsDiffer() {
+        XCTAssertFalse(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: "UUID-B",
+            lastAppliedActiveDisplayUUID: "UUID-A"
+        ))
+    }
+
+    func testPredicateDoesNotSkipOnFirstApply() {
+        XCTAssertFalse(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: "UUID-A",
+            lastAppliedActiveDisplayUUID: nil
+        ))
+    }
+
+    func testPredicateDoesNotSkipWhenCurrentBecomesNil() {
+        XCTAssertFalse(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: nil,
+            lastAppliedActiveDisplayUUID: "UUID-A"
+        ))
+    }
+
+    func testPredicateSkipsWhenBothNil() {
+        XCTAssertTrue(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: nil,
+            lastAppliedActiveDisplayUUID: nil
+        ))
+    }
+
+    func testPredicateIsStableAcrossRepeatedCalls() {
+        for _ in 0..<10 {
+            XCTAssertTrue(DisplaySettingsManager.shouldSkipSpacingApply(
+                currentActiveDisplayUUID: "UUID-A",
+                lastAppliedActiveDisplayUUID: "UUID-A"
+            ))
+        }
+    }
+
+    // MARK: - Field semantics
+
+    func testFreshManagerHasNilLastAppliedUUID() {
+        let manager = DisplaySettingsManager()
+        XCTAssertNil(manager.lastAppliedActiveDisplayUUID)
+    }
+
+    func testSeededFieldDrivesPredicate() {
+        let manager = DisplaySettingsManager()
+        manager.lastAppliedActiveDisplayUUID = "UUID-A"
+
+        XCTAssertTrue(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: "UUID-A",
+            lastAppliedActiveDisplayUUID: manager.lastAppliedActiveDisplayUUID
+        ))
+        XCTAssertFalse(DisplaySettingsManager.shouldSkipSpacingApply(
+            currentActiveDisplayUUID: "UUID-B",
+            lastAppliedActiveDisplayUUID: manager.lastAppliedActiveDisplayUUID
+        ))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Stops `DisplaySettingsManager.applyActiveDisplaySpacing` from firing on `NSApplication.didChangeScreenParametersNotification` events that only reflect resolution or other-parameter changes on the same display, so a resolution flip no longer risks triggering a full menu-bar-app relaunch wave.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

PR #529 (commit `1ed2ce67`) wired the spacing apply to `didChangeScreenParametersNotification`. That notification fires on every screen-parameter event, including resolution changes, lid open/close, and GPU/sleep transitions on an already-connected display. Each fire armed a preflight settling window and ran `applyOffset`. When the on-disk `NSStatusItem` byHost values disagreed with the target (Control Center restart, sleep/wake clobber, mid-flight oscillation across profiles) the call escalated to a full relaunch wave even though the user had only changed a setting of the display, not changed to a different one.

Issue Number: #551

## What is the new behavior?

`DisplaySettingsManager` now caches the active menu bar display UUID at every `applyActiveDisplaySpacing` call and the `didChangeScreenParametersNotification` sink consults a pure static predicate `shouldSkipSpacingApply(currentActiveDisplayUUID:lastAppliedActiveDisplayUUID:)` before falling through. When the UUIDs match (resolution change, lid event, or GPU transition on the same display) the sink logs "Active menu bar display unchanged" and returns. When they differ (laptop docked, active menu bar moved to another monitor, first event after launch) the existing apply path runs as before. The `$configurations` sink and external Settings-URI path are unchanged because those reflect deliberate user intent and already rely on the no-op guard inside `MenuBarItemSpacingManager.applyOffset` to short-circuit when target equals on-disk.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Adds `ThawTests/DisplaySettingsManagerSpacingGateTests` with eight cases pinning the predicate (matching, differing, either-nil, both-nil, repeated-stable) and the field semantics on a fresh `DisplaySettingsManager` instance. The file is picked up automatically by the `ThawTests` synchronized-folder reference, so `Thaw.xcodeproj/project.pbxproj` requires no edits.

### Notes for reviewers

The predicate is intentionally a static pure function so it can be unit-tested without `AppState`, `Bridging`, or live `NSScreen` state. End-to-end driving of the notification sink would depend on the host machine's display topology and the 1 s `.debounce`, so the manual verification steps below cover that surface instead:

1. Change the active display's resolution in System Settings: log shows "Active menu bar display unchanged"; no relaunch wave.
2. Move the active menu bar to a different physical display: apply runs as before.
3. Drag the per-display spacing slider in Settings > Displays: configurations sink fires and re-applies.
4. Drive a per-display setting via the Settings URI scheme: external path runs as before.
5. Unplug/replug the active display: `Bridging.getActiveMenuBarDisplayUUID()` returns the same UUID, so no redundant wave on reconnect.

Fixes #551

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved display spacing handling to prevent unnecessary recalculations when screen parameters change.

* **Tests**
  * Added comprehensive test coverage for display spacing behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/569)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->