### PR TITLE
fix(menubar): stop double-counting NSStatusItemSpacing in notch overflow budget

### DIFF
--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -12,6 +12,9 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      # Issues with other Xcode versions, so we need to specify the version explicitly
+      - run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+
       - name: Configure signing
         uses: ./.github/actions/configure-signing
         with:

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -5540,17 +5540,14 @@ extension MenuBarItemManager {
             let rightBoundary = ccItem.map(\.bounds.minX) ?? screen.frame.maxX
             var availableWidth = rightBoundary - (notch.maxX + notchGap)
 
-            // Read the actual NSStatusItemSpacing applied to the system.
-            // This is the inter-item gap at render time. The width sum
-            // below uses item.bounds.width, which is the button's
-            // clickable rectangle and does NOT include the gap. Without
-            // adding it, the budget under-counts total layout cost by
-            // (count - 1) × spacing px and overflow can be silently
-            // missed once the user has enough items in the menu bar —
-            // most visibly when the spacing has been customised away
-            // from the default 16, since the per-item miscount stops
-            // matching the historical buffer the check happened to
-            // have.
+            // NSStatusItemSpacing is recorded here for diagnostic logging
+            // only. macOS bakes the spacing into each status item's frame
+            // (verified empirically: item.bounds.width grows 1:1 with the
+            // spacing value), so item.bounds.width and the Control Center
+            // item's bounds.minX already account for it. Subtracting a
+            // separate (count - 1) * spacing gap here used to double-count
+            // the spacing and ejected items into hidden when the bar still
+            // had room, most visibly at the macOS default of 16.
             let userSpacing = CGFloat(max(0, 16 + appState.spacingManager.offset))
 
             // Subtract the layout footprint of items that occupy the
@@ -5601,19 +5598,7 @@ extension MenuBarItemManager {
                 }
             }
 
-            // Account for the (count - 1) inter-item gaps across all
-            // items in the visible area, profile and non-profile
-            // combined. Slightly conservative: when items overflow,
-            // the gap count drops by 1 per overflowed item, but using
-            // the pre-overflow total is the right starting point and
-            // the loop below removes overflow items one at a time
-            // until the remaining footprint fits.
-            let totalItemCount = visibleUIDs.count + nonProfileCount
-            if totalItemCount > 1 {
-                availableWidth -= CGFloat(totalItemCount - 1) * userSpacing
-            }
-
-            // Find the Thaw visible control icon — it must always stay visible.
+            // Find the Thaw visible control icon, which must always stay visible.
             let visibleCtrlUID = items.first(where: { $0.tag == .visibleControlItem })?.uniqueIdentifier
             let chevronWidth = visibleCtrlUID.flatMap { uidWidths[$0] } ?? 0
 


### PR DESCRIPTION
## What does this PR do?

Removes a double-count of `NSStatusItemSpacing` in the notch overflow budget so that profile applies at the macOS default spacing (`offset=0`) no longer push items into the hidden section while the menu bar visibly has room.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

When `applyProfileLayout` runs on a notched display with the overflow toggle enabled, it computes `availableWidth = rightBoundary - notchGap - nonProfileFootprint - (count - 1) * userSpacing` and compares against a `profileBaseline` summed from each item's `bounds.width`. macOS bakes `NSStatusItemSpacing` into each status item's frame, so `bounds.width` already includes the spacing padding, and `rightBoundary` (Control Center's `bounds.minX`) already shifts to absorb CC's own spacing growth. The explicit `(count - 1) * userSpacing` subtraction therefore deducts the spacing a second time, under-counting `availableWidth` by `(count - 1) * userSpacing` pixels. At `offset=-12` (spacing `4`) the error is small (around 48px on the typical layout) and absorbed by historical slack; at `offset=0` (spacing `16`) the error grows to roughly 192px and forces six profile items into the hidden section despite a visibly empty bar between the rightmost visible item and Control Center.

Issue Number: N/A

## What is the new behavior?

The `(count - 1) * userSpacing` deduction is removed. The budget now relies on `item.bounds.width` and `ccItem.bounds.minX` to carry the spacing footprint, which the diagnostic log shows they already do. With the fix the Built-in Retina apply at `offset=0` reports `availableWidth=424` against `profileBaseline=419`, well within budget, and the previously-ejected items remain in the visible section. At `offset=-12` and `offset=-6` the budget gains additional slack but profiles that already fit continue to fit, so existing layouts are unchanged.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Empirical width measurements collected from the `Notch overflow budget:` diagnostic log, same 11 profile items each run:

| offset | spacing | rightBoundary | availableWidth (pre-fix) | profileBaseline | avg item width |
  | ------ | ------- | ------------- | ------------------------ | --------------- | -------------- |
| -12    | 4       | 1301          | 404                      | 287             | 24.8           |
| -6     | 10      | 1285          | 316                      | 357             | 31.2           |
|  0     | 16      | 1273          | 232                      | 419             | 36.8           |

Average `item.bounds.width` rises linearly at 1:1 with `userSpacing`, implying an icon-only width of about `20.8` for this profile plus the current spacing. With the fix, `availableWidth` at `offset=0` becomes `232 + 12 * 16 = 424`, exceeding `profileBaseline=419` by 5px and matching what the screen actually has room for.

### Notes for reviewers

Focus areas:

- The diff is intentionally surgical: one deduction removed, one comment block rewritten. `userSpacing` is retained so the existing `Notch overflow budget:` log line continues to report the system spacing for diagnostics.
- No unit tests cover the notch overflow branch of `applyProfileLayout` today; verification was manual at `offset = -12`, `-6`, and `0` on the Built-in Retina display, with the `Notch overflow budget:` diagnostic line captured at each step (values above).
- Manual repro steps before and after the fix:
    1. Settings, Displays, set Built-in Retina spacing offset to `0`.
    2. Settings, Profiles, click Apply on a profile that has roughly 11 items in the visible section.
    3. Before the fix: several items overflow into hidden while the bar shows a visible empty gap between the last visible item and Control Center; `Notch overflow budget:` logs `availableWidth=232`.
    4. After the fix: items remain in visible filling the bar; `Notch overflow budget:` logs `availableWidth=424`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved menu bar item spacing calculation issue on notched displays affecting overflow decisions and proper menu layout

* **Chores**
  * Enhanced build process reliability by explicitly configuring Xcode version selection in DMG creation workflow

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/573)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->