### PR TITLE
fix(menubar): ignore clicks while the system menu bar is auto-hidden offscreen

### DIFF
--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -741,6 +741,18 @@ extension HIDEventManager {
             return
         }
 
+        // Suppress show-on-click when no menu bar status items are currently
+        // rendered on-screen for the active space. This catches the case where
+        // a fullscreen app has auto-hidden the menu bar and the click lands in
+        // the top-of-screen trigger zone before the menu bar visually reveals.
+        // NSApp.currentSystemPresentationOptions is per-app and does not
+        // reflect another app's fullscreen state, so the items-list signal is
+        // used directly without a precondition.
+        if !screen.isSystemMenuBarVisible() {
+            Self.diagLog.debug("handleShowOnClick: suppressing, no menu bar items on-screen for active space")
+            return
+        }
+
         guard isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen) else {
             return
         }

--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -557,6 +557,18 @@ final class ControlItem {
         }
         let menuBarManager = appState.menuBarManager
 
+        // Suppress phantom clicks delivered to the status item button while
+        // no menu bar items are rendered on-screen for the active space. This
+        // catches fast top-of-screen clicks during the menu bar reveal
+        // sequence under a fullscreen app, which would otherwise expand the
+        // hidden section offscreen. NSApp.currentSystemPresentationOptions is
+        // per-app and does not reflect another app's fullscreen state, so the
+        // items-list signal is used directly.
+        let screenForCheck = window?.screen ?? NSScreen.main
+        if let screen = screenForCheck, !screen.isSystemMenuBarVisible() {
+            return
+        }
+
         switch event.type {
         case .leftMouseDown:
             // Capture modifier flags from the event to ensure we have the state

--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -749,6 +749,19 @@ extension NSScreen {
         return fallback
     }
 
+    /// Returns true when at least one menu bar status item is currently
+    /// rendered on-screen for the active space.
+    ///
+    /// Returns false when the menu bar is auto-hidden behind a fullscreen app
+    /// and not yet visually revealed. The menu bar window itself flips to
+    /// kCGWindowIsOnscreen at the start of the reveal sequence, well before
+    /// the status items become visible to the user; gating on the items list
+    /// more closely matches the perceived reveal state, which is what click
+    /// suppression needs.
+    func isSystemMenuBarVisible() -> Bool {
+        !Bridging.getMenuBarWindowList(option: [.onScreen, .activeSpace, .itemsOnly]).isEmpty
+    }
+
     /// Returns the raw frame of the application menu on this screen, as
     /// reported by the Accessibility API, without any notch-capping applied.
     ///


### PR DESCRIPTION
## What does this PR do?

Suppresses Thaw's two menu-bar click handlers (`HIDEventManager.handleShowOnClick` and `ControlItem.performAction`) whenever no menu bar status items are currently rendered on-screen for the active space, fixing the case where fast clicks at the top of the screen during a fullscreen app's menu bar reveal were popping the Thaw Bar or silently expanding the always-hidden section offscreen.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

When an app is in macOS fullscreen mode and the system menu bar is auto-hidden offscreen, clicking near the very top of the screen before the menu bar visually reveals triggers Thaw click handlers: with `Show on click` enabled the Thaw Bar pops up, and even with it disabled the always-hidden section can be expanded offscreen and only becomes visible after the user scrolls/hovers far enough to bring the menu bar in. Root cause: the existing geometry guard `isMouseInsideMenuBar` calls `NSScreen.getMenuBarHeight()`, which caches per-display and keeps returning the previously measured height even after the menu bar window has been auto-hidden, so the geometry check still passes for top-of-screen clicks. The `NSStatusItem` button action wired to `ControlItem.performAction` has no visibility guard at all and is invoked by AppKit during the reveal sequence.

Issue Number: #481

## What is the new behavior?

A new `NSScreen.isSystemMenuBarVisible()` helper queries the Window Server live (no cache) via `Bridging.getMenuBarWindowList(option: [.onScreen, .activeSpace, .itemsOnly])` and returns true only when at least one status item is currently on-screen for the active space. Both `handleShowOnClick` and `ControlItem.performAction` short-circuit and return when the helper reports false, so phantom clicks during the menu bar reveal sequence are dropped. Once the user hovers and the menu bar fully repopulates with items the check returns true and clicks fall through to the existing geometry/section logic, preserving normal Thaw behaviour inside fullscreen spaces. A `[DEBUG]`-level `diagLog` entry is emitted in `handleShowOnClick` when suppression fires, available for future regression hunts via the existing forced-debug toggle.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Empirical verification was driven by the existing diagnostic logging at `~/Library/Logs/Thaw/thaw_*.log`. A pre-fix run showed `IceBarPanel show:` lines firing 1ms after each fast top-of-screen click in fullscreen; a post-fix run shows clusters of `handleShowOnClick: suppressing, no menu bar items on-screen for active space` entries during the click storm with no `IceBarPanel show:` until after the user pauses and the menu bar fully reveals, then normal clicks resume working.

The earlier `MenuBarManager.isMenuBarHiddenBySystem` signal (sourced from `NSApp.currentSystemPresentationOptions`) was investigated but proved unusable because that property is per-app and reports `0` even when a third-party app is fullscreen; the items-list signal is sufficient on its own.

Fixes #481

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added detection for whether the system menu bar is visibly rendering status items for the active space.

* **Bug Fixes**
  * Suppressed phantom clicks and prevented unintended show-on-click behavior during menu bar reveal when no status items are visible.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/574)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->