### PR TITLE
fix(profile): land cross-section items in always-hidden on profile apply

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -5454,6 +5454,25 @@ extension MenuBarItemManager {
         let hiddenCtrlUID = controlItems.hidden.uniqueIdentifier
         let ahCtrlUID = controlItems.alwaysHidden?.uniqueIdentifier
 
+        // Snapshot each item's current section ONCE so the cache-log loop
+        // and Phase 1 below see identical classifications. context.findSection
+        // re-queries the Window Server via Bridging.getWindowBounds on every
+        // call. Between the cache-log iteration (a few lines below) and the
+        // Phase 1 iteration further down, the transient bounds reported
+        // during a section.show()-driven control-item move can flip an
+        // item's classification, producing empty currentHiddenSet and
+        // currentAHSet that let Phase 1 skip the AH_ctrl move when items
+        // legitimately need to cross the hidden↔always-hidden boundary.
+        // Indexed by windowID because items duplicated across displays
+        // share a uniqueIdentifier but have distinct windows; storing per
+        // window preserves each instance's own classification.
+        var sectionByWindowID: [CGWindowID: MenuBarSection.Name] = [:]
+        for item in items where isProfileItem(item) {
+            if let section = context.findSection(for: item) {
+                sectionByWindowID[item.windowID] = section
+            }
+        }
+
         // Rebuild desiredFlat with control items at section boundaries.
         var sectionMap = itemSectionMap
         var desiredFlatWithControls = [String]()
@@ -5479,7 +5498,7 @@ extension MenuBarItemManager {
         for sectionName in [MenuBarSection.Name.visible, .hidden, .alwaysHidden] {
             let sectionItems = items.filter { item in
                 guard isProfileItem(item) else { return false }
-                return context.findSection(for: item) == sectionName
+                return sectionByWindowID[item.windowID] == sectionName
             }
             MenuBarItemManager.diagLog.debug(
                 "applyProfileLayout: current \(sectionName.logString) has \(sectionItems.count) items: \(sectionItems.map(\.uniqueIdentifier))"
@@ -5880,13 +5899,16 @@ extension MenuBarItemManager {
             var movedCount = 0
 
             // Classify items into the two sets Phase 1 actually consults.
-            // A single pass with direct insertion avoids the UID-keyed dict
-            // collapse that previously dropped entries when the same UID
-            // resolved across multiple sections (e.g. multi-display).
+            // Read from the sectionByWindowID snapshot built earlier so the
+            // classification here matches what the cache-log loop reported
+            // above. Calling context.findSection again can return different
+            // values for the same windowID if section.show()'s control-item
+            // moves landed in between, which surfaces as an empty Phase 1
+            // view of currently-occupied hidden / always-hidden sections.
             var currentHiddenSet = Set<String>()
             var currentAHSet = Set<String>()
             for item in items where isProfileItem(item) {
-                switch context.findSection(for: item) {
+                switch sectionByWindowID[item.windowID] {
                 case .hidden:
                     currentHiddenSet.insert(item.uniqueIdentifier)
                 case .alwaysHidden:
@@ -5978,6 +6000,113 @@ extension MenuBarItemManager {
                             try? await Task.sleep(for: .milliseconds(200))
                         } catch {
                             MenuBarItemManager.diagLog.error("Profile layout: failed to move AH_ctrl: \(error)")
+                        }
+                    }
+                }
+
+                // Per-item cross-section fallback. The AH_ctrl move only
+                // re-classifies items implicitly via its X position. When
+                // the items destined for AH are currently RIGHT of items
+                // destined for hidden (and vice versa) — most commonly
+                // after a fresh start where every managed item sits in
+                // the hidden section — no single AH_ctrl placement can
+                // split the two groups correctly. The move() no-op guard
+                // can also cancel the AH_ctrl move outright when AH_ctrl
+                // already sits adjacent to the chosen anchor. Either way,
+                // a re-classification pass after the AH_ctrl attempt
+                // tells us which items still need to cross the boundary,
+                // and dragging them explicitly to .leftOfItem(AH_ctrl)
+                // or .rightOfItem(AH_ctrl) puts them on the correct
+                // side. Phase 2's LCS handles within-section ordering.
+                let freshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+                var freshItemsCopy = freshItems
+                if let freshControl = ControlItemPair(
+                    items: &freshItemsCopy,
+                    hiddenControlItemWindowID: hiddenWID,
+                    alwaysHiddenControlItemWindowID: alwaysHiddenWID
+                ),
+                    let ahItem = freshItems.first(where: { $0.uniqueIdentifier == ahCtrlUID })
+                {
+                    var verifyContext = CacheContext(
+                        controlItems: freshControl,
+                        displayID: Bridging.getActiveMenuBarDisplayID()
+                    )
+                    // Single classification pass, indexed by windowID so
+                    // multi-display duplicates of the same uniqueIdentifier
+                    // each keep their own section.
+                    var postSectionByWindowID: [CGWindowID: MenuBarSection.Name] = [:]
+                    for item in freshItems where isProfileItem(item) {
+                        if let s = verifyContext.findSection(for: item) {
+                            postSectionByWindowID[item.windowID] = s
+                        }
+                    }
+                    var stillInHidden = Set<String>()
+                    var stillInAH = Set<String>()
+                    for item in freshItems where isProfileItem(item) {
+                        switch postSectionByWindowID[item.windowID] {
+                        case .hidden:
+                            stillInHidden.insert(item.uniqueIdentifier)
+                        case .alwaysHidden:
+                            stillInAH.insert(item.uniqueIdentifier)
+                        case .visible, .none:
+                            break
+                        }
+                    }
+                    let crossToAH = stillInHidden.intersection(desiredAHSet)
+                    let crossToHidden = stillInAH.intersection(desiredHiddenSet)
+
+                    if !crossToAH.isEmpty || !crossToHidden.isEmpty {
+                        MenuBarItemManager.diagLog.debug(
+                            "Profile layout: AH_ctrl placement left \(crossToAH.count) item(s) needing AH and \(crossToHidden.count) item(s) needing hidden, running per-item fallback"
+                        )
+
+                        // Move items destined for AH (currently in hidden)
+                        // to the LEFT of AH_ctrl. Iterate in reverse
+                        // profile order so the first item in
+                        // itemOrder["alwaysHidden"] (rightmost in AH per
+                        // profile convention, index 0) is moved last and
+                        // therefore lands closest to AH_ctrl, matching
+                        // the order LCS will leave it in.
+                        let ahProfileOrder = itemOrder["alwaysHidden"] ?? []
+                        let orderedCrossToAH = ahProfileOrder.reversed().filter { crossToAH.contains($0) }
+                            + crossToAH.subtracting(ahProfileOrder).sorted()
+                        for uid in orderedCrossToAH {
+                            guard
+                                let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
+                            else { continue }
+                            do {
+                                try await move(item: item, to: .leftOfItem(ahItem), skipInputPause: true)
+                                movedCount += 1
+                                try? await Task.sleep(for: .milliseconds(100))
+                            } catch {
+                                MenuBarItemManager.diagLog.error(
+                                    "Profile layout: per-item move to AH failed for \(uid): \(error)"
+                                )
+                            }
+                        }
+
+                        // Move items destined for hidden (currently in AH)
+                        // to the RIGHT of AH_ctrl. Iterate in profile
+                        // order so itemOrder["hidden"] index 0 (rightmost
+                        // in hidden = furthest from AH_ctrl) is moved
+                        // first and gets pushed furthest right by
+                        // subsequent moves.
+                        let hiddenProfileOrder = itemOrder["hidden"] ?? []
+                        let orderedCrossToHidden = hiddenProfileOrder.filter { crossToHidden.contains($0) }
+                            + crossToHidden.subtracting(hiddenProfileOrder).sorted()
+                        for uid in orderedCrossToHidden {
+                            guard
+                                let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
+                            else { continue }
+                            do {
+                                try await move(item: item, to: .rightOfItem(ahItem), skipInputPause: true)
+                                movedCount += 1
+                                try? await Task.sleep(for: .milliseconds(100))
+                            } catch {
+                                MenuBarItemManager.diagLog.error(
+                                    "Profile layout: per-item move to hidden failed for \(uid): \(error)"
+                                )
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced in #529 (`1ed2ce67`) where applying a profile that asks for items in always-hidden left those items stranded in the hidden section. Two independent bugs in `applyProfileLayout` are addressed: a `context.findSection` timing race that made Phase 1 see empty section sets, and a structural limitation of the `AH_ctrl`-move optimization that can't split an inverted item layout with a single boundary move.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

When applying a profile with non-empty `desiredAlwaysHidden` from a starting state where every managed item sits in the hidden section, the items meant for always-hidden stay in hidden instead. The diagnostic log shows `Profile layout Phase 1: currentHidden=[]`, `currentAH=[]` followed by `totalSectionMismatch=0` even though the cache log immediately above lists items in those sections, so the `AH_ctrl` move is skipped.
Even when the `AH_ctrl` move does fire, `itemHasCorrectPosition` cancels it because `AH_ctrl` already sits adjacent to the chosen anchor, or the single boundary move can't reach all the items that need to cross. The user-visible workaround is to apply a profile first (which physically relocates every item to the leftmost slots) and then re-apply the intended profile.

Issue Number: N/A

## What is the new behavior?

`applyProfileLayout` snapshots each item's section exactly once into a `sectionByWindowID` map right after `items` is fetched, and both the cache-log loop and Phase 1's `currentHiddenSet`/`currentAHSet` construction read from the snapshot. The cache-log output and Phase 1's view can no longer disagree because they consult the same precomputed map instead of calling `findSection` again. After the existing `AH_ctrl` move attempt, the algorithm re-classifies items via the same snapshot pattern, computes the remaining cross-section mismatch, and explicitly drags any stranded items to `.leftOfItem(AH_ctrl)` or `.rightOfItem(AH_ctrl)`. The Phase 2 LCS pass handles within-section ordering as before. The fast path is preserved: when the `AH_ctrl` move alone produces the correct split, the fallback finds nothing to do and emits no moves. A new debug line `Profile layout: AH_ctrl placement left X item(s) needing AH and Y item(s) needing hidden, running per-item fallback` records when the fallback engages.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

### Reproduction recipe

1. Apply a profile that pushes every managed item into the hidden section (or use Cmd-drag to manually move every always-hidden item into hidden), so `Saved section order` reports `hidden=N, alwaysHidden=0`.
2. Apply a profile whose `desiredAlwaysHidden` is non-empty.
3. Before this fix: items stay in hidden, `Saved section order` ends without an `alwaysHidden` key. After this fix: items land in always-hidden on the first apply.

### Verification trace from a successful repro

applyProfileLayout: current hidden section has 1 items: [AlwaysHiddenCtrl]
applyProfileLayout: current always-hidden section has 11 items: [cisco, wdav, ...]
Profile layout Phase 1: crossSectionMoves=5, totalSectionMismatch=5
Profile layout Phase 1: currentHidden=[AlwaysHiddenCtrl]
Profile layout Phase 1: currentAH=[cisco, displaylink, ..., wdav]
Profile layout: moving AH_ctrl → left of numi
Profile layout: AH_ctrl placement left 2 item(s) needing AH and 0 item(s) needing hidden, running per-item fallback
Profile layout: completed with 8 move(s)
Saved section order: [alwaysHidden: 2, visible: 20, hidden: 6]

### Notes for reviewers

- The Phase 1 snapshot is indexed by `windowID` rather than `uniqueIdentifier`, because items duplicated across displays share a `uniqueIdentifier` but have distinct windows. Indexing by window preserves each instance's own section assignment, matching the behaviour of the original `findSection` calls.
- The per-item fallback runs inside the same `if crossSectionMoves > 0 || totalSectionMismatch > 0, let ahCtrlUID { ... }` block as the existing `AH_ctrl` move, so it only engages on applies that already detected a cross-section need. Applies with no cross-section mismatch skip it entirely.
- Cross-section move order: `crossToAH` iterates `itemOrder["alwaysHidden"]` reversed (the profile's index 0 is the rightmost-in-AH item, so it's moved last and ends up closest to `AH_ctrl`); `crossToHidden` iterates `itemOrder["hidden"]` in profile order. Order is for LCS-friendliness, not correctness; LCS reorders within each section afterwards.
- Manual smoke-tested on a multi-display setup with the auto-switch path and the manual Apply button. Both produce the expected `Saved section order` on the first apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent menu bar item classification during layout reorganization.
  * Improved handling of hidden and always-hidden menu bar items when repositioning occurs.
  * Enhanced menu bar item movement with more reliable section boundary detection and cross-section reorganization.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/576)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->