### PR TITLE
fix(menubar): defer reveal and right-click paths to third-party widgets

### DIFF
--- a/Shared/Utilities/AXHelpers.swift
+++ b/Shared/Utilities/AXHelpers.swift
@@ -48,4 +48,12 @@ enum AXHelpers {
     static func role(for element: UIElement) -> Role? {
         queue.sync { try? element.role() }
     }
+
+    static func pid(for element: UIElement) -> pid_t? {
+        queue.sync {
+            var pid: pid_t = 0
+            let result = AXUIElementGetPid(element.element, &pid)
+            return result == .success ? pid : nil
+        }
+    }
 }

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -130,6 +130,11 @@ final class HIDEventManager: ObservableObject {
     /// The pending tooltip show task.
     private var tooltipTask: Task<Void, any Error>?
 
+    /// The pending secondary-context-menu reveal task. Holding a reference lets
+    /// a subsequent click (right or left) cancel the pre-100ms-delay reveal so
+    /// the menu doesn't pop up after the user has already dismissed or moved on.
+    private var pendingSecondaryContextMenuTask: Task<Void, any Error>?
+
     /// A Boolean value that indicates whether the manager is enabled.
     private var isEnabled = false {
         didSet {
@@ -180,6 +185,10 @@ final class HIDEventManager: ObservableObject {
         } else {
             return event
         }
+        // Cancel any pending secondary-context-menu task on every mouse-down so
+        // a dismiss click or a follow-up click can't be raced by a previously
+        // scheduled reveal that hasn't yet cleared its 100ms delay.
+        pendingSecondaryContextMenuTask?.cancel()
         switch event.type {
         case .leftMouseDown:
             // Check app menu first - if click is on app menu area, don't trigger
@@ -757,6 +766,16 @@ extension HIDEventManager {
             return
         }
 
+        // Defer to third-party menu bar widgets such as notch overlay
+        // applications whose windows aren't reported in the standard menu bar
+        // items query but visually occupy menu bar space. The AX hit-test
+        // resolves the actual UI element at the cursor, so clicks that land
+        // on a widget's icon don't also trigger Thaw's show-on-click reveal.
+        if isCursorOverForeignWidgetUIElement() {
+            Self.diagLog.debug("handleShowOnClick: suppressing, cursor over foreign UI element")
+            return
+        }
+
         if isDoubleClick {
             guard appState.settings.general.showOnDoubleClick else {
                 return
@@ -1024,7 +1043,17 @@ extension HIDEventManager {
         appState: AppState,
         screen: NSScreen
     ) {
-        Task {
+        pendingSecondaryContextMenuTask = Task { [weak self] in
+            guard let self else { return }
+            // Suppress when no menu bar items are rendered on-screen for the
+            // active space. Catches phantom right-clicks landing in the menu bar
+            // y-band while a fullscreen app has auto-hidden the menu bar; the
+            // event still passes through to the underlying app so its native
+            // context menu can appear normally.
+            if !screen.isSystemMenuBarVisible() {
+                Self.diagLog.debug("handleSecondaryContextMenu: suppressing, no menu bar items on-screen for active space")
+                return
+            }
             guard
                 appState.settings.advanced.enableSecondaryContextMenu,
                 isMouseInsideEmptyMenuBarSpace(
@@ -1035,10 +1064,85 @@ extension HIDEventManager {
             else {
                 return
             }
-            // Delay prevents the menu from immediately closing.
+            // Delay prevents the menu from immediately closing and gives any
+            // foreign widget's own right-click menu a chance to render. Notch
+            // overlay applications cover wide regions of the menu bar visually
+            // but only respond to clicks on their actual icon, so probing
+            // whether a foreign menu opened in response to this click is more
+            // accurate than testing window bounds.
             try await Task.sleep(for: .milliseconds(100))
+            try Task.checkCancellation()
+            if isForeignPopUpMenuOpen() {
+                Self.diagLog.debug("handleSecondaryContextMenu: suppressing, foreign pop-up menu is open")
+                return
+            }
+            if isCursorOverForeignWidgetUIElement() {
+                Self.diagLog.debug("handleSecondaryContextMenu: suppressing, cursor over foreign UI element")
+                return
+            }
             appState.menuBarManager.showSecondaryContextMenu(at: mouseLocation)
         }
+    }
+
+    /// Returns whether the cursor sits on a UI element owned by a foreign
+    /// third-party menu bar widget such as a notch overlay application,
+    /// using the system-wide accessibility hit-test. Excludes Thaw's own
+    /// elements, the Window Server (which owns the menu bar background), and
+    /// elements with a menu-bar / menu / menu-item role (the front app's
+    /// File/Edit/View region returns the app's PID but a menu-bar-class
+    /// role). When the helper returns true, Thaw defers to the widget under
+    /// the cursor even if the widget didn't open its own pop-up menu in
+    /// response to the click.
+    private func isCursorOverForeignWidgetUIElement() -> Bool {
+        guard let mouseLocation = MouseHelpers.locationCoreGraphics else {
+            return false
+        }
+        guard let element = AXHelpers.element(at: mouseLocation) else {
+            return false
+        }
+        guard let pid = AXHelpers.pid(for: element), pid > 0 else {
+            return false
+        }
+        if pid == getpid() {
+            return false
+        }
+        let ownerName = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier ?? "unknown"
+        // WindowServer / SystemUIServer own the system menu bar background; AX
+        // returning either of them indicates the cursor is over empty menu bar.
+        if ownerName == "com.apple.WindowManager" || ownerName == "com.apple.systemuiserver" {
+            return false
+        }
+        // The frontmost application owns its own menu bar background between
+        // File/Edit/View items. AX returns the app's menu bar element here
+        // even though the geometric isMouseInsideEmptyMenuBarSpace check
+        // already passed (no specific menu item is hit). Filter by role: a
+        // menu bar / menu / menu item role means the cursor is over the front
+        // app's menu bar, not over a third-party widget overlay.
+        switch AXHelpers.role(for: element) {
+        case .menuBar, .menu, .menuItem, .menuBarItem:
+            return false
+        default:
+            return true
+        }
+    }
+
+    /// Returns whether any non-Thaw window at the pop-up-menu window level is
+    /// currently on-screen. Right-click menus (NSMenu and equivalents) render
+    /// at kCGPopUpMenuWindowLevel, while persistent overlay windows from
+    /// notch overlay applications sit a level below. Filtering to the exact
+    /// pop-up level distinguishes an actually open menu from a widget's idle
+    /// overlay, which is needed to avoid showing Thaw's secondary context
+    /// menu after a click that landed on a foreign widget that opened its own
+    /// menu.
+    private func isForeignPopUpMenuOpen() -> Bool {
+        let ownPID = getpid()
+        let popUpLevel = Int(CGWindowLevelForKey(.popUpMenuWindow))
+        let windows = WindowInfo.createWindows(option: .onScreen)
+        for window in windows where window.ownerPID != ownPID {
+            guard window.layer == popUpLevel else { continue }
+            return true
+        }
+        return false
     }
 
     // MARK: Handle Application Menu Click-Through
@@ -1203,7 +1307,8 @@ extension HIDEventManager {
                 isMouseInsideEmptyMenuBarSpace(
                     appState: appState,
                     screen: screen
-                )
+                ),
+                !isCursorOverForeignWidgetUIElement()
             else {
                 if pendingHoverAction == .show {
                     hoverTask?.cancel()
@@ -1345,6 +1450,7 @@ extension HIDEventManager {
         guard
             appState.settings.general.showOnScroll,
             isMouseInsideEmptyMenuBarSpace(appState: appState, screen: screen),
+            !isCursorOverForeignWidgetUIElement(),
             let hiddenSection = appState.menuBarManager.section(
                 withName: .hidden
             )

--- a/Thaw/Events/HIDEventManager.swift
+++ b/Thaw/Events/HIDEventManager.swift
@@ -1106,10 +1106,15 @@ extension HIDEventManager {
         if pid == getpid() {
             return false
         }
-        let ownerName = NSRunningApplication(processIdentifier: pid)?.bundleIdentifier ?? "unknown"
-        // WindowServer / SystemUIServer own the system menu bar background; AX
-        // returning either of them indicates the cursor is over empty menu bar.
-        if ownerName == "com.apple.WindowManager" || ownerName == "com.apple.systemuiserver" {
+        // SystemUIServer owns part of the system menu bar; AX returning it
+        // indicates the cursor is over empty menu bar space. WindowServer also
+        // renders menu bar surfaces but is a system daemon with no bundle
+        // identifier, so NSRunningApplication can't resolve it; fall back to a
+        // process-name lookup via proc_name for that case.
+        if NSRunningApplication(processIdentifier: pid)?.bundleIdentifier == "com.apple.systemuiserver" {
+            return false
+        }
+        if isWindowServerPID(pid) {
             return false
         }
         // The frontmost application owns its own menu bar background between
@@ -1124,6 +1129,21 @@ extension HIDEventManager {
         default:
             return true
         }
+    }
+
+    /// Returns whether the given PID belongs to the macOS WindowServer
+    /// daemon. WindowServer has no bundle identifier and is not represented as
+    /// an NSRunningApplication, so the executable name has to be read via
+    /// proc_name. Used to exclude WindowServer-owned AX elements from the
+    /// foreign-widget hit-test.
+    private func isWindowServerPID(_ pid: pid_t) -> Bool {
+        var buffer = [CChar](repeating: 0, count: Int(MAXPATHLEN))
+        let length = buffer.withUnsafeMutableBufferPointer { ptr -> Int32 in
+            guard let base = ptr.baseAddress else { return -1 }
+            return proc_name(pid, base, UInt32(ptr.count))
+        }
+        guard length > 0 else { return false }
+        return String(cString: buffer) == "WindowServer"
     }
 
     /// Returns whether any non-Thaw window at the pop-up-menu window level is


### PR DESCRIPTION
## What does this PR do?

Extends Thaw's menu bar event handling so all four reveal paths (`handleShowOnClick`, `handleShowOnHover`, `handleShowOnScroll`, `handleSecondaryContextMenu`) defer to third-party menu bar widgets under the cursor, using a new system-wide accessibility hit-test. Also makes the right-click secondary context menu cancellable so a dismiss click inside its 100ms reveal delay can no longer race the reveal, and adds a foreign-pop-up probe so widgets that open their own context menu at `kCGPopUpMenuWindowLevel` no longer have it dismissed by Thaw's secondary menu.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

Clicks, hover, scroll, and right-click in the menu bar y-band that visually land on a third-party widget (notch overlay applications such as those that sit above the menu bar) trigger Thaw's section reveal or secondary context menu, because the existing geometric `isMouseInsideEmptyMenuBarSpace` check treats any non-status-item region as empty space. The widget's own pop-up menu, when one opens, is dismissed by Thaw's secondary context menu after the 100ms reveal delay. A rapid dismiss click within that 100ms window can also re-pop the secondary context menu after the user has already moved on.

Issue Number: Refs #481

## What is the new behavior?

A new system-wide AX hit-test `isCursorOverForeignWidgetUIElement` resolves the actual UI element under the cursor and defers when the element is owned by a non-Thaw, non-WindowServer, non-SystemUIServer process whose role is not `menuBar`, `menu`, `menuItem`, or `menuBarItem`. All four reveal paths consult it after the cheap geometric `isMouseInsideEmptyMenuBarSpace` check passes, so the AX cost only kicks in for clicks that would otherwise have been treated as empty menu bar space. `handleSecondaryContextMenu` additionally probes `isForeignPopUpMenuOpen` for any non-Thaw window at `kCGPopUpMenuWindowLevel`, and now runs as a cancellable `Task` stored in `pendingSecondaryContextMenuTask`. Every mouse-down (left or right) cancels the pending Task at the top of `mouseDownMonitor` and the Task checks `Task.checkCancellation()` after its 100ms sleep. `AXHelpers.pid(for:)` is added as a small wrapper around `AXUIElementGetPid` to support the hit-test.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Manually verified the following scenarios on an external display (which is where the regressions surface; the built-in display's reveal animation hides the y-band gap):

- Right-click on Thaw's chevron in fullscreen revealed mode: Thaw context menu fires.
- Right-click on phantom menu bar area in fullscreen (menu bar auto-hidden): event passes through to the underlying app's context menu, Thaw stays quiet.
- Right-click on truly empty Thaw bar space in fullscreen revealed mode: Thaw secondary context menu fires.
- Right-click on a notch overlay widget with its own pop-up menu: widget's menu opens and stays; Thaw's `isForeignPopUpMenuOpen` probe suppresses.
- Right-click on a notch overlay widget that does not open a pop-up menu: Thaw's AX hit-test suppresses, no Thaw menu fires.
- Rapid right-click followed by an immediate left-click to dismiss: cancellation prevents the queued reveal from re-popping.
- Left-click, hover, and scroll variants of the widget-deferral case all suppress via the shared `isCursorOverForeignWidgetUIElement` gate.

### Notes for reviewers

The widget-detection model is intentionally AX-based rather than window-bounds-based. Notch overlay applications create wide opaque-but-non-interactive window regions for animation purposes, so bounds-based heuristics either misclassify large empty stretches as the widget (when the threshold is loose) or miss the widget entirely (when it is tight). The AX hit-test asks the system what UI element is actually at the cursor, which gives the right answer without per-widget allowlists. AX queries run on the existing `AXHelpers.queue`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed context menu appearing over third‑party menu‑bar widgets.
  * Improved secondary (right‑click) context menu reveal timing with robust cancellation to avoid stale triggers.
  * Suppressed menu reveal when other pop‑up menus are open or when no menu‑bar items are visible.
  * Prevented show‑on‑hover and show‑on‑scroll from triggering when the cursor is over foreign widget UI elements, reducing unintended reveals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/584)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->