### PR TITLE
Add PR command trigger workflow and update stale issue configuration

### DIFF
--- a/.github/workflows/pr-trigger.yml
+++ b/.github/workflows/pr-trigger.yml
@@ -1,0 +1,49 @@
+name: PR Command Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-build:
+    if: github.event.issue.pull_request
+    runs-on: ubuntu-slim
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: read
+
+    steps:
+      - name: Parse command
+        id: command
+        uses: github/command@v2.0.3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          command: ".build"
+          permissions: write
+
+      - name: Get PR Branch
+        if: steps.command.outputs.continue == 'true'
+        id: get-branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL="${{ github.event.issue.pull_request.url }}"
+          PR_BRANCH=$(gh api $PR_URL --jq '.head.ref')
+          echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+          echo "Detected branch: $PR_BRANCH"
+
+      - name: Trigger Build DMG Workflow
+        if: steps.command.outputs.continue == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run build-dmg.yml --ref ${{ steps.get-branch.outputs.branch }} -R ${{ github.repository }}
+
+      - name: Comment on PR
+        if: steps.command.outputs.continue == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          gh pr comment $PR_NUMBER --body "Build triggered for branch `${{ steps.get-branch.outputs.branch }}`. Check the Actions tab for progress." -R ${{ github.repository }}

--- a/.github/workflows/pr-trigger.yml
+++ b/.github/workflows/pr-trigger.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Parse command
         id: command
-        uses: github/command@v2.0.3
+        uses: github/command@76d69a2a6b747d621fba374d707409f89114c620
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           command: ".build"

--- a/.github/workflows/pr-trigger.yml
+++ b/.github/workflows/pr-trigger.yml
@@ -22,28 +22,43 @@ jobs:
           command: ".build"
           permissions: write
 
-      - name: Get PR Branch
+      - name: Get PR Details
         if: steps.command.outputs.continue == 'true'
         id: get-branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_URL="${{ github.event.issue.pull_request.url }}"
-          PR_BRANCH=$(gh api $PR_URL --jq '.head.ref')
+          PR_BRANCH=$(gh api "$PR_URL" --jq '.head.ref')
+          PR_HEAD_REPO=$(gh api "$PR_URL" --jq '.head.repo.full_name')
+          SAME_REPO=false
+          if [ "$PR_HEAD_REPO" = "${{ github.repository }}" ]; then
+            SAME_REPO=true
+          fi
           echo "branch=$PR_BRANCH" >> $GITHUB_OUTPUT
+          echo "same_repo=$SAME_REPO" >> $GITHUB_OUTPUT
           echo "Detected branch: $PR_BRANCH"
+          echo "PR head repository: $PR_HEAD_REPO"
 
       - name: Trigger Build DMG Workflow
-        if: steps.command.outputs.continue == 'true'
+        if: steps.command.outputs.continue == 'true' && steps.get-branch.outputs.same_repo == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh workflow run build-dmg.yml --ref ${{ steps.get-branch.outputs.branch }} -R ${{ github.repository }}
 
       - name: Comment on PR
-        if: steps.command.outputs.continue == 'true'
+        if: steps.command.outputs.continue == 'true' && steps.get-branch.outputs.same_repo == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PR_NUMBER="${{ github.event.issue.number }}"
           gh pr comment $PR_NUMBER --body "Build triggered for branch `${{ steps.get-branch.outputs.branch }}`. Check the Actions tab for progress." -R ${{ github.repository }}
+
+      - name: Comment on PR for fork
+        if: steps.command.outputs.continue == 'true' && steps.get-branch.outputs.same_repo != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.issue.number }}"
+          gh pr comment $PR_NUMBER --body "Build was not triggered automatically because this pull request comes from a fork, and branch `${{ steps.get-branch.outputs.branch }}` does not exist in `${{ github.repository }}`." -R ${{ github.repository }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/stale@v10
         with:
           operations-per-run: 100
-          days-before-stale: 21
+          days-before-stale: 30
           days-before-close: 7
           days-before-pr-stale: -1
           days-before-pr-close: -1


### PR DESCRIPTION
## What does this PR do?

Introduce a new workflow to trigger automated builds via a comment on pull requests and extend the inactivity period before issues are marked as stale.

## PR Type

- [x] CI/CD related changes

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

Currently, there is no automated build trigger via pull request comments, and the stale issue configuration marks issues as stale after 21 days of inactivity.

## What is the new behavior?

This change allows users to trigger builds by commenting on pull requests and increases the inactivity period for marking issues as stale to 30 days.

## PR Checklist

N/A

## Other information

N/A

### Notes for reviewers

N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added workflow automation to allow triggering repository builds via pull request comment commands, with contextual responses when automatic dispatch isn't possible.
  * Increased issue staleness threshold from 21 to 30 days before marking issues as inactive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/585)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/585)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->