### PR TITLE
fix(ui): keep Choose Script button aligned when a hook script is selected

### DIFF
--- a/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
@@ -460,16 +460,17 @@ private struct HookRow: View {
                 Button("Choose Script...") { chooseScript() }
                     .buttonStyle(.bordered)
 
-                if hook != nil {
-                    Button(role: .destructive) {
-                        hook = nil
-                    } label: {
-                        Image(systemName: "minus.circle.fill")
-                            .foregroundStyle(.red)
-                    }
-                    .buttonStyle(.plain)
-                    .help("Clear hook")
+                Button(role: .destructive) {
+                    hook = nil
+                } label: {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundStyle(.red)
                 }
+                .buttonStyle(.plain)
+                .help("Clear hook")
+                .opacity(hook == nil ? 0 : 1)
+                .allowsHitTesting(hook != nil)
+                .accessibilityHidden(hook == nil)
             }
 
             if hook != nil {


### PR DESCRIPTION
## What does this PR do?

Aligns the `Choose Script...` button in the Automation settings Hooks UI so it no longer shifts horizontally depending on whether a script has been chosen.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path: N/A

## What is the current behavior?

In `AutomationSettingsPane`, each `HookRow` renders the clear-hook button (`minus.circle.fill`) only when a hook is selected (`if hook != nil { ... }`). Because the button is absent in the empty case, the trailing `Choose Script...` button slides to the right edge, while populated rows push it leftward to make room for the clear button. The result is misaligned `Choose Script...` buttons between rows that have a script and rows that do not, both in the Global Hooks group and the Per-Profile Hooks group.

Issue Number: N/A

## What is the new behavior?

The clear-hook button is now always present in the row layout. When `hook == nil` it is rendered with `.opacity(0)`, `.allowsHitTesting(false)`, and `.accessibilityHidden(true)` so the empty state reserves the same trailing width without exposing a clickable or VoiceOver-visible control. The `Choose Script...` button therefore stays in a fixed horizontal position whether or not a script has been chosen.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Touches a single file (`Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift`) inside the private `HookRow` view; no public API or behaviour change beyond the visual alignment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the clear button presentation in automation hook settings. The control is now consistently visible while remaining inactive when no hook is attached, enhancing UI consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/586)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->