### PR TITLE
refactor(settings): add Notch and Disconnected badges to Auto-Switch displays

### DIFF
--- a/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
@@ -429,11 +429,30 @@ struct ProfileSettingsPane: View {
     private struct DisplayInfo: Identifiable {
         let id: String
         let name: String
+        let hasNotch: Bool
         let isConnected: Bool
 
-        var localizedLabel: Text {
-            if isConnected { Text(name) } else {
-                Text("\(name) (\(String(localized: "disconnected")))")
+        @ViewBuilder
+        var localizedLabel: some View {
+            HStack(spacing: 6) {
+                Text(name)
+                if hasNotch {
+                    Text("Notch")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary)
+                        .clipShape(Capsule())
+                }
+                if !isConnected {
+                    Text("Disconnected")
+                        .font(.caption)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.quaternary)
+                        .clipShape(Capsule())
+                        .foregroundStyle(.secondary)
+                }
             }
         }
     }
@@ -441,11 +460,17 @@ struct ProfileSettingsPane: View {
     /// Returns all displays relevant to auto-switch: connected displays plus
     /// any disconnected displays that still have a profile association.
     private func allDisplays() -> [DisplayInfo] {
+        let knownDisplays = appState.settings.displaySettings.knownDisplays
         var displays = NSScreen.screens.compactMap { screen -> DisplayInfo? in
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 return nil
             }
-            return DisplayInfo(id: uuid, name: screen.localizedName, isConnected: true)
+            return DisplayInfo(
+                id: uuid,
+                name: screen.localizedName,
+                hasNotch: screen.hasNotch,
+                isConnected: true
+            )
         }
 
         let connectedIDs = Set(displays.map(\.id))
@@ -457,6 +482,7 @@ struct ProfileSettingsPane: View {
             displays.append(DisplayInfo(
                 id: uuid,
                 name: cachedName,
+                hasNotch: knownDisplays[uuid]?.hasNotch ?? false,
                 isConnected: false
             ))
         }


### PR DESCRIPTION
## What does this PR do?

Replaces the parenthetical "(disconnected)" suffix on Auto-Switch display rows in the Profiles pane with capsule badges, and adds a matching "Notch" badge for notched screens. The badges reuse the visual treatment already used in the Displays pane.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

In the Profiles settings pane, the Auto-Switch section labels each display row with just the display name, suffixing disconnected entries with " (disconnected)" in parentheses. There is no visual indication of which displays have a notch, so notched and non-notched screens are indistinguishable in this list. The styling diverges from the Displays pane, which already uses capsule badges for both states.

Issue Number: N/A

## What is the new behavior?

Each Auto-Switch display row now renders the display name followed by inline capsule badges: a "Notch" badge for notched screens and a "Disconnected" badge for displays that still have a profile association but are no longer attached. Connected rows read `hasNotch` directly from `NSScreen.hasNotch`; disconnected rows look the notch state up from `DisplaySettingsManager.knownDisplays`, which already persists name and notch metadata across launches, so the badge is correct without needing the display to be reconnected. The badge styling matches `DisplaySettingsPane` (caption font, quaternary background, capsule clip, secondary foreground on the disconnected variant).

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Touches a single file (`Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift`): `DisplayInfo` gains a `hasNotch` field, `localizedLabel` becomes a `@ViewBuilder some View` returning an `HStack` of name plus badges, and `allDisplays()` populates `hasNotch` from `NSScreen` or `knownDisplays` as appropriate.

### Notes for reviewers

Worth a quick visual check that the badge spacing/alignment inside the `IcePicker` label looks right when both badges are present on a disconnected notched display, and that the `knownDisplays` lookup returns the expected notch state for disconnected entries on your setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Display auto-switch picker now shows notch status indicators for compatible displays
  * Added visual connection status badges to distinguish between connected and disconnected displays
  * Enhanced display information visibility with hardware-specific details for improved device management

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/587)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->