### PR TITLE
perf(capture): route window capture through ScreenCaptureKit to cut SkyLight leaks

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -630,11 +630,16 @@ extension Bridging {
             return unionBounds
         }()
 
-        guard let display = content.displays.first(where: { $0.frame.intersects(effectiveBounds) })
-            ?? content.displays.first(where: { $0.frame.intersects(unionBounds) })
-            ?? content.displays.first
-        else {
-            diagLog.warning("captureWindowsImageSCK: no display matched bounds \(effectiveBounds)")
+        // Require a single display that fully contains BOTH the effective
+        // capture bounds and the union of all selected windows. Using
+        // intersects here would let a display that only partially overlaps
+        // through, producing a silently clipped capture; SCContentFilter
+        // (display:including:) clips at display.frame, so anything outside is
+        // lost without an error. A clean nil lets callers fall back or skip.
+        guard let display = content.displays.first(where: {
+            $0.frame.contains(effectiveBounds) && $0.frame.contains(unionBounds)
+        }) else {
+            diagLog.warning("captureWindowsImageSCK: no display fully contains effectiveBounds=\(effectiveBounds) and unionBounds=\(unionBounds)")
             return nil
         }
 
@@ -644,8 +649,10 @@ extension Bridging {
         configuration.showsCursor = false
         // boundsIgnoreFraming on the legacy API means "skip the window frame".
         // For a display+including filter the equivalent is ignoreShadowsDisplay;
-        // no per-window shadow toggle exists on this filter shape.
-        configuration.ignoreShadowsDisplay = options.contains(.boundsIgnoreFraming) || options.isEmpty
+        // no per-window shadow toggle exists on this filter shape. Empty
+        // options matches the legacy SkyLight default of keeping framing, so
+        // honor only the explicit flag here.
+        configuration.ignoreShadowsDisplay = options.contains(.boundsIgnoreFraming)
 
         let scale: CGFloat = options.contains(.nominalResolution)
             ? 1.0

--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import Cocoa
+@preconcurrency import ScreenCaptureKit
 
 // MARK: - Bridging
 
@@ -558,5 +559,111 @@ extension Bridging {
 
         diagLog.debug("captureWindowsImage: captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
         return image
+    }
+}
+
+// MARK: - ScreenCaptureKit Window Capture
+
+extension Bridging {
+    /// Captures a composite image of an array of windows using ScreenCaptureKit.
+    ///
+    /// Async, leak-free replacement for captureWindowsImage. Use this for any
+    /// window set whose union bounds fit within a display. For menu-bar items
+    /// in hidden / always-hidden sections (positioned at large negative x),
+    /// stay on captureWindowsImage: SCK's display+including filter returns
+    /// error -3812 for sourceRects outside display bounds, and the
+    /// desktopIndependentWindow filter returns -3811 for those windows too.
+    ///
+    /// - Parameters:
+    ///   - windowIDs: The identifiers of the windows to capture.
+    ///   - screenBounds: The bounds to capture, specified in screen coordinates.
+    ///     Pass nil (or CGRect.null) to capture the minimum rectangle that
+    ///     encloses the selected windows.
+    ///   - options: Capture options. boundsIgnoreFraming maps to
+    ///     ignoreShadowsDisplay; nominalResolution forces 1x scale.
+    /// - Returns: The captured image, or nil if capture failed.
+    static func captureWindowsImageSCK(
+        windowIDs: [CGWindowID],
+        screenBounds: CGRect? = nil,
+        options: CGWindowImageOption = []
+    ) async -> CGImage? {
+        guard !windowIDs.isEmpty else {
+            diagLog.warning("captureWindowsImageSCK: empty windowIDs")
+            return nil
+        }
+
+        let content: SCShareableContent
+        do {
+            content = try await SCShareableContent.excludingDesktopWindows(
+                false,
+                onScreenWindowsOnly: false
+            )
+        } catch {
+            diagLog.error("captureWindowsImageSCK: SCShareableContent failed: \(error)")
+            return nil
+        }
+
+        let requested = Set(windowIDs)
+        // Preserve caller's z-order so the composite renders correctly.
+        let scWindows = windowIDs.compactMap { id in
+            content.windows.first { $0.windowID == id }
+        }
+
+        guard !scWindows.isEmpty else {
+            diagLog.warning("captureWindowsImageSCK: no SCWindows matched \(requested.count) requested IDs")
+            return nil
+        }
+
+        // Union of selected window frames; used both as default bounds and
+        // to find the host display.
+        let unionBounds = scWindows.reduce(CGRect.null) { $0.union($1.frame) }
+        let effectiveBounds: CGRect = {
+            if let screenBounds, !screenBounds.isNull {
+                return screenBounds
+            }
+            return unionBounds
+        }()
+
+        guard let display = content.displays.first(where: { $0.frame.intersects(effectiveBounds) })
+            ?? content.displays.first(where: { $0.frame.intersects(unionBounds) })
+            ?? content.displays.first
+        else {
+            diagLog.warning("captureWindowsImageSCK: no display matched bounds \(effectiveBounds)")
+            return nil
+        }
+
+        let filter = SCContentFilter(display: display, including: scWindows)
+
+        let configuration = SCStreamConfiguration()
+        configuration.showsCursor = false
+        // boundsIgnoreFraming on the legacy API means "skip the window frame".
+        // For a display+including filter the equivalent is ignoreShadowsDisplay;
+        // no per-window shadow toggle exists on this filter shape.
+        configuration.ignoreShadowsDisplay = options.contains(.boundsIgnoreFraming) || options.isEmpty
+
+        let scale: CGFloat = options.contains(.nominalResolution)
+            ? 1.0
+            : CGFloat(filter.pointPixelScale)
+
+        configuration.sourceRect = CGRect(
+            x: effectiveBounds.origin.x - display.frame.origin.x,
+            y: effectiveBounds.origin.y - display.frame.origin.y,
+            width: effectiveBounds.width,
+            height: effectiveBounds.height
+        )
+        configuration.width = Int((effectiveBounds.width * scale).rounded())
+        configuration.height = Int((effectiveBounds.height * scale).rounded())
+
+        do {
+            let image = try await SCScreenshotManager.captureImage(
+                contentFilter: filter,
+                configuration: configuration
+            )
+            diagLog.debug("captureWindowsImageSCK: captured \(scWindows.count)/\(windowIDs.count) matched windows → \(image.width)×\(image.height)px")
+            return image
+        } catch {
+            diagLog.error("captureWindowsImageSCK: SCScreenshotManager.captureImage failed: \(error)")
+            return nil
+        }
     }
 }

--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -603,14 +603,20 @@ extension Bridging {
             return nil
         }
 
-        let requested = Set(windowIDs)
         // Preserve caller's z-order so the composite renders correctly.
         let scWindows = windowIDs.compactMap { id in
             content.windows.first { $0.windowID == id }
         }
 
-        guard !scWindows.isEmpty else {
-            diagLog.warning("captureWindowsImageSCK: no SCWindows matched \(requested.count) requested IDs")
+        // Require an exact match. Partial captures are unsafe: cache composites
+        // rely on the result covering every requested window's bounds for the
+        // post-capture crop math, and color samplers rely on every requested
+        // window being included for the averaged color to mean anything.
+        // Fail fast so callers fall back cleanly to SkyLight or skip the tick.
+        guard scWindows.count == windowIDs.count else {
+            let matched = Set(scWindows.map(\.windowID))
+            let missing = windowIDs.filter { !matched.contains($0) }
+            diagLog.warning("captureWindowsImageSCK: SCK resolved \(scWindows.count)/\(windowIDs.count) requested windows; missing IDs: \(missing)")
             return nil
         }
 
@@ -659,7 +665,7 @@ extension Bridging {
                 contentFilter: filter,
                 configuration: configuration
             )
-            diagLog.debug("captureWindowsImageSCK: captured \(scWindows.count)/\(windowIDs.count) matched windows → \(image.width)×\(image.height)px")
+            diagLog.debug("captureWindowsImageSCK: captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
             return image
         } catch {
             diagLog.error("captureWindowsImageSCK: SCScreenshotManager.captureImage failed: \(error)")

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -163,15 +163,22 @@ final class IceBarColorManager: ObservableObject {
             return
         }
 
-        guard let image = ScreenCapture.captureWindows(
-            with: [menuBarWindow.windowID, wallpaperWindow.windowID],
-            screenBounds: withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 },
-            option: .nominalResolution
-        ) else {
-            return
-        }
+        let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
+        let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
 
-        windowImage = image
+        // SCK runs off MainActor; the Task body resumes back on @MainActor
+        // (class isolation) so the state mutation is safe.
+        Task { [weak self] in
+            guard let image = await ScreenCapture.captureWindowsAsync(
+                with: windowIDs,
+                screenBounds: bounds,
+                option: .nominalResolution
+            ) else {
+                return
+            }
+            guard let self else { return }
+            self.windowImage = image
+        }
     }
 
     private func updateColorInfo(with frame: CGRect, screen: NSScreen) {

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -17,6 +17,12 @@ final class IceBarColorManager: ObservableObject {
 
     private var windowImage: CGImage?
 
+    /// Monotonically incremented by updateWindowImage and clearWindowImage.
+    /// A capture in flight stamps the value it observed; on completion it only
+    /// writes windowImage if the value still matches, so a late completion
+    /// can't undo a freshly cleared image or overwrite a newer capture.
+    private var windowImageGeneration: Int = 0
+
     private var cancellables = Set<AnyCancellable>()
 
     /// Cancellable for the periodic refresh timer, active only while the Thaw Bar is visible.
@@ -42,7 +48,10 @@ final class IceBarColorManager: ObservableObject {
                     else {
                         return
                     }
-                    updateWindowImage(for: screen)
+                    Task { [weak self] in
+                        guard let self else { return }
+                        await self.updateWindowImage(for: screen)
+                    }
                 }
                 .store(in: &c)
 
@@ -82,7 +91,8 @@ final class IceBarColorManager: ObservableObject {
                     return
                 }
                 // Clear window image on display changes to prevent memory growth
-                self.windowImage = nil
+                // and invalidate any in-flight capture from before the change.
+                self.clearWindowImage()
                 guard
                     let iceBarPanel,
                     iceBarPanel.isVisible,
@@ -91,9 +101,13 @@ final class IceBarColorManager: ObservableObject {
                 else {
                     return
                 }
-                updateWindowImage(for: screen)
-                withAnimation {
-                    self.updateColorInfo(with: iceBarPanel.frame, screen: screen)
+                let frame = iceBarPanel.frame
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.updateWindowImage(for: screen)
+                    withAnimation {
+                        self.updateColorInfo(with: frame, screen: screen)
+                    }
                 }
             }
             .store(in: &c)
@@ -106,10 +120,17 @@ final class IceBarColorManager: ObservableObject {
                 .sink { [weak self, weak iceBarPanel] isVisible in
                     guard let self else { return }
                     if isVisible {
-                        // Refresh windowImage immediately so the first color update isn't stale.
+                        // Refresh windowImage immediately so the first color
+                        // update isn't stale. Awaiting inside a Task so
+                        // updateColorInfo reads the fresh capture, not the
+                        // previous cycle's leftover.
                         if let iceBarPanel, let screen = iceBarPanel.screen, screen == .main {
-                            self.updateWindowImage(for: screen)
-                            self.updateColorInfo(with: iceBarPanel.frame, screen: screen)
+                            let frame = iceBarPanel.frame
+                            Task { [weak self] in
+                                guard let self else { return }
+                                await self.updateWindowImage(for: screen)
+                                self.updateColorInfo(with: frame, screen: screen)
+                            }
                         }
                         self.startPeriodicRefresh(for: iceBarPanel)
                     } else {
@@ -137,9 +158,13 @@ final class IceBarColorManager: ObservableObject {
                 else {
                     return
                 }
-                updateWindowImage(for: screen)
-                withAnimation {
-                    self.updateColorInfo(with: iceBarPanel.frame, screen: screen)
+                let frame = iceBarPanel.frame
+                Task { [weak self] in
+                    guard let self else { return }
+                    await self.updateWindowImage(for: screen)
+                    withAnimation {
+                        self.updateColorInfo(with: frame, screen: screen)
+                    }
                 }
             }
     }
@@ -148,11 +173,19 @@ final class IceBarColorManager: ObservableObject {
     private func stopPeriodicRefresh() {
         periodicRefreshCancellable?.cancel()
         periodicRefreshCancellable = nil
-        // Clear the window image to free memory when IceBar is hidden
+        // Clear the window image to free memory when IceBar is hidden.
+        clearWindowImage()
+    }
+
+    /// Clears windowImage and invalidates any in-flight capture. Use whenever
+    /// callers want a synchronous nil state that an outstanding async capture
+    /// must not be allowed to overwrite.
+    private func clearWindowImage() {
+        windowImageGeneration += 1
         windowImage = nil
     }
 
-    private func updateWindowImage(for screen: NSScreen) {
+    private func updateWindowImage(for screen: NSScreen) async {
         let windows = WindowInfo.createWindows(option: .onScreen)
         let displayID = screen.displayID
 
@@ -166,19 +199,20 @@ final class IceBarColorManager: ObservableObject {
         let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
         let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
 
-        // SCK runs off MainActor; the Task body resumes back on @MainActor
-        // (class isolation) so the state mutation is safe.
-        Task { [weak self] in
-            guard let image = await ScreenCapture.captureWindowsAsync(
-                with: windowIDs,
-                screenBounds: bounds,
-                option: .nominalResolution
-            ) else {
-                return
-            }
-            guard let self else { return }
-            self.windowImage = image
-        }
+        // Stamp our generation before suspending. If the counter advances while
+        // we await (a clearWindowImage, a stopPeriodicRefresh, or a newer
+        // updateWindowImage call), our completion is stale and must skip the
+        // write so we don't undo intentional clears or clobber a fresher image.
+        windowImageGeneration += 1
+        let generation = windowImageGeneration
+
+        let image = await ScreenCapture.captureWindowsAsync(
+            with: windowIDs,
+            screenBounds: bounds,
+            option: .nominalResolution
+        )
+        guard generation == windowImageGeneration, let image else { return }
+        windowImage = image
     }
 
     private func updateColorInfo(with frame: CGRect, screen: NSScreen) {
@@ -208,7 +242,14 @@ final class IceBarColorManager: ObservableObject {
     }
 
     func updateAllProperties(with frame: CGRect, screen: NSScreen) {
-        updateWindowImage(for: screen)
-        updateColorInfo(with: frame, screen: screen)
+        // Keep the public signature synchronous so IceBar.show doesn't ripple
+        // async upstream. Wraps the async refresh+color combo in a Task so
+        // updateColorInfo reads the fresh capture instead of the previous
+        // cycle's leftover.
+        Task { [weak self] in
+            guard let self else { return }
+            await self.updateWindowImage(for: screen)
+            self.updateColorInfo(with: frame, screen: screen)
+        }
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -549,18 +549,39 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 continue
             }
 
+            // Hoisted: these are tick-global, not per-section.
+            if appState.itemManager.lastMoveOperationOccurred(within: .seconds(2)) {
+                continue
+            }
+            if appState.itemManager.isResettingLayout {
+                continue
+            }
+
+            let scale = screen.backingScaleFactor
+
+            // Partition by capture path: visible items refresh via SCK
+            // (leak-free); hidden + always-hidden items refresh via SkyLight,
+            // batched into a single call per tick to amortize the irreducible
+            // per-call dictionary leak.
+            var offscreenBatch = [MenuBarItem]()
+            var offscreenSectionLabels = [String]()
+
             for section in sections {
-                if appState.itemManager.lastMoveOperationOccurred(within: .seconds(2)) {
-                    continue
-                }
-                if appState.itemManager.isResettingLayout {
-                    continue
-                }
                 let items = appState.itemManager.itemCache.managedItems(for: section)
                 guard !items.isEmpty else { continue }
-                let scale = screen.backingScaleFactor
-                MenuBarItemImageCache.diagLog.debug("liveRefresh: section=\(section.logString) displayID=\(screen.displayID) backingScaleFactor=\(Double(scale)) hasNotch=\(screen.hasNotch) items=\(items.count) menuBarHeight=\(Double(screen.getMenuBarHeightEstimate()))")
-                await refreshImages(of: items, scale: scale)
+
+                if section == .visible {
+                    MenuBarItemImageCache.diagLog.debug("liveRefresh (SCK): section=\(section.logString) displayID=\(screen.displayID) backingScaleFactor=\(Double(scale)) hasNotch=\(screen.hasNotch) items=\(items.count) menuBarHeight=\(Double(screen.getMenuBarHeightEstimate()))")
+                    await refreshImages(of: items, scale: scale, viaSCK: true)
+                } else {
+                    offscreenBatch.append(contentsOf: items)
+                    offscreenSectionLabels.append("\(section.logString)=\(items.count)")
+                }
+            }
+
+            if !offscreenBatch.isEmpty {
+                MenuBarItemImageCache.diagLog.debug("liveRefresh (SkyLight): batched \(offscreenBatch.count) offscreen items [\(offscreenSectionLabels.joined(separator: ", "))]")
+                await refreshImages(of: offscreenBatch, scale: scale)
             }
         }
 
@@ -580,7 +601,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
     private nonisolated func compositeCapture(
         _ itemsWithBounds: [(item: MenuBarItem, bounds: CGRect)],
         scale: CGFloat
-    ) -> CaptureResult {
+    ) async -> CaptureResult {
         var result = CaptureResult()
 
         var windowIDs = [CGWindowID]()
@@ -599,7 +620,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return result
         }
 
-        let compositeImage = ScreenCapture.captureWindows(
+        let compositeImage = await ScreenCapture.captureWindowsAsync(
             with: windowIDs,
             option: captureOption
         )
@@ -688,7 +709,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
     private nonisolated func individualCapture(
         _ items: [MenuBarItem],
         scale: CGFloat
-    ) -> CaptureResult {
+    ) async -> CaptureResult {
         var result = CaptureResult()
         var capturedCount = 0
         var nilImageCount = 0
@@ -706,7 +727,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
                 continue
             }
 
-            let image = ScreenCapture.captureWindow(
+            let image = await ScreenCapture.captureWindowAsync(
                 with: item.windowID,
                 option: captureOption
             )
@@ -757,15 +778,15 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             within: .seconds(2)
         ) {
             MenuBarItemImageCache.diagLog.debug("Capturing individually due to recent item movement")
-            return individualCapture(capturable, scale: scale)
+            return await individualCapture(capturable, scale: scale)
         }
 
         // Pre-filter off-screen items: hidden section items are positioned past
-        // the right edge of the screen. Including them in compositeCapture
+        // the left edge of the screen. Including them in compositeCapture
         // inflates boundsUnion → CGWindowListCreateImageFromArray returns an
         // image narrower than expected → width mismatch → the whole composite
-        // fails for ALL items. Off-screen items are captured by the live refresh
-        // loop (refreshImages) instead, so we can safely skip them here.
+        // fails for ALL items. Off-screen items are captured by the live
+        // refresh loop (refreshImages) instead, so we can safely skip them here.
         //
         // Note: isWindowOnScreen() cannot be used for this — macOS incorrectly
         // reports hidden menu bar items as on-screen (known macOS behaviour).
@@ -814,7 +835,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return CaptureResult()
         }
 
-        let compositeResult = compositeCapture(onScreenItemsWithBounds, scale: scale)
+        let compositeResult = await compositeCapture(onScreenItemsWithBounds, scale: scale)
 
         if compositeResult.excluded.isEmpty {
             return compositeResult // All items captured successfully.
@@ -824,7 +845,7 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             "\(compositeResult.excluded.count)/\(onScreenItemsWithBounds.count) items excluded from composite, retrying individually"
         )
 
-        var individualResult = individualCapture(
+        var individualResult = await individualCapture(
             compositeResult.excluded,
             scale: scale
         )
@@ -846,7 +867,8 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
     /// Skips `@Published` updates when images haven't changed visually.
     nonisolated func refreshImages(
         of items: [MenuBarItem],
-        scale: CGFloat
+        scale: CGFloat,
+        viaSCK: Bool = false
     ) async {
         var windowIDs = [CGWindowID]()
         var storage = [CGWindowID: (MenuBarItem, CGRect)]()
@@ -866,10 +888,27 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return
         }
 
-        guard let compositeImage = ScreenCapture.captureWindows(
-            with: windowIDs,
-            option: captureOption
-        ) else {
+        // Capture path: SCK is leak-free but display-bounded, so only use it
+        // when the caller knows all items are on-screen (visible section).
+        // SkyLight is required for items positioned past the display's left
+        // edge (hidden / always-hidden); both SCK filter shapes fail there
+        // (display+including → -3812, desktopIndependentWindow → -3811). Each
+        // SkyLight call leaks one CFMutableDictionary inside
+        // SLSWindowListCreateImageFromArrayProxying; that floor stays until
+        // Apple fixes SCK or the framework leak.
+        let compositeImage: CGImage?
+        if viaSCK {
+            compositeImage = await ScreenCapture.captureWindowsAsync(
+                with: windowIDs,
+                option: captureOption
+            )
+        } else {
+            compositeImage = ScreenCapture.captureWindows(
+                with: windowIDs,
+                option: captureOption
+            )
+        }
+        guard let compositeImage else {
             MenuBarItemImageCache.diagLog.debug("refreshImages: capture failed, skipping")
             return
         }

--- a/Thaw/MenuBar/MenuBarManager.swift
+++ b/Thaw/MenuBar/MenuBarManager.swift
@@ -299,35 +299,43 @@ final class MenuBarManager: ObservableObject {
                     .autoconnect()
                     .sink { [weak self] _ in
                         guard let self else { return }
-                        let elapsed = wakePollStartTime.map { Date().timeIntervalSince($0) } ?? 0
+                        // Wraps the stabilization logic in a Task that awaits
+                        // updateAverageColorInfoAsync so the post-capture read
+                        // of averageColors sees the fresh values; the original
+                        // sync call returned before the fire-and-forget Tasks
+                        // populated state, defeating stabilization detection.
+                        Task { [weak self] in
+                            guard let self else { return }
+                            let elapsed = wakePollStartTime.map { Date().timeIntervalSince($0) } ?? 0
 
-                        if elapsed >= 10 {
-                            sleepColorCache = nil
-                            wakePollTimer = nil
-                            return
-                        }
-
-                        updateAverageColorInfo()
-                        let after = averageColors
-
-                        if !wakePollDidChange, let cache = sleepColorCache, after != cache {
-                            wakePollDidChange = true
-                        }
-
-                        if wakePollDidChange {
-                            if let prev = wakePollPrevColors, prev == after {
-                                wakePollStableCount += 1
-                                if wakePollStableCount >= 1 {
-                                    sleepColorCache = nil
-                                    wakePollTimer = nil
-                                    return
-                                }
-                            } else {
-                                wakePollStableCount = 0
+                            if elapsed >= 10 {
+                                sleepColorCache = nil
+                                wakePollTimer = nil
+                                return
                             }
-                        }
 
-                        wakePollPrevColors = after
+                            await updateAverageColorInfoAsync()
+                            let after = averageColors
+
+                            if !wakePollDidChange, let cache = sleepColorCache, after != cache {
+                                wakePollDidChange = true
+                            }
+
+                            if wakePollDidChange {
+                                if let prev = wakePollPrevColors, prev == after {
+                                    wakePollStableCount += 1
+                                    if wakePollStableCount >= 1 {
+                                        sleepColorCache = nil
+                                        wakePollTimer = nil
+                                        return
+                                    }
+                                } else {
+                                    wakePollStableCount = 0
+                                }
+                            }
+
+                            wakePollPrevColors = after
+                        }
                     }
             }
             .store(in: &c)
@@ -473,7 +481,22 @@ final class MenuBarManager: ObservableObject {
 
     /// Updates the ``averageColorInfo`` and ``averageColors`` properties with
     /// the current average color of the menu bar background per screen.
+    ///
+    /// Fire-and-forget shape preserved for the call sites that don't need to
+    /// read averageColors immediately after. Callers that DO need read-after
+    /// semantics (captureAdaptiveColorWithRetry, the wake-poll loop) must use
+    /// updateAverageColorInfoAsync directly so their read sees fresh state.
     func updateAverageColorInfo() {
+        Task { [weak self] in
+            await self?.updateAverageColorInfoAsync()
+        }
+    }
+
+    /// Awaitable variant of updateAverageColorInfo. Per-screen captures run
+    /// concurrently in a TaskGroup; the for-await loop collects results on the
+    /// @MainActor context, so all averageColors / averageColorInfo writes are
+    /// complete before the await returns.
+    func updateAverageColorInfoAsync() async {
         guard let appState else { return }
 
         // Only update if we really need the color info
@@ -503,40 +526,49 @@ final class MenuBarManager: ObservableObject {
         let windows = WindowInfo.createWindows(option: .onScreen)
         let activeDisplayID = NSScreen.screenWithActiveMenuBar?.displayID
 
+        // Resolve per-screen capture inputs synchronously on MainActor before
+        // fanning out; the SCK calls themselves are the only async work.
+        var inputs = [(displayID: CGDirectDisplayID, windowIDs: [CGWindowID], bounds: CGRect)]()
         for screen in targetScreens {
             let displayID = screen.displayID
-
             guard
                 let menuBarWindow = WindowInfo.menuBarWindow(from: windows, for: displayID),
                 let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: displayID)
             else {
                 continue
             }
-
             let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
             let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
+            inputs.append((displayID, windowIDs, bounds))
+        }
 
-            // SCK runs off MainActor; the Task body resumes on @MainActor for
-            // the per-display state mutations. Per-screen captures are
-            // independent so they can run concurrently.
-            Task { [weak self] in
-                guard
-                    let image = await ScreenCapture.captureWindowsAsync(
-                        with: windowIDs,
-                        screenBounds: bounds,
-                        option: .nominalResolution
-                    ),
-                    let color = image.averageColor(option: .ignoreAlpha)
-                else {
-                    return
+        await withTaskGroup(of: (CGDirectDisplayID, MenuBarAverageColorInfo)?.self) { group in
+            for input in inputs {
+                group.addTask {
+                    guard
+                        let image = await ScreenCapture.captureWindowsAsync(
+                            with: input.windowIDs,
+                            screenBounds: input.bounds,
+                            option: .nominalResolution
+                        ),
+                        let color = image.averageColor(option: .ignoreAlpha)
+                    else {
+                        return nil
+                    }
+                    return (input.displayID, MenuBarAverageColorInfo(color: color, source: .menuBarWindow))
                 }
-                guard let self else { return }
-                let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
-                if self.averageColors[displayID] != info {
-                    self.averageColors[displayID] = info
+            }
+
+            // Collected on @MainActor (enclosing class isolation), so the
+            // averageColors / averageColorInfo writes below are safe and
+            // observable to read-after callers as soon as this await returns.
+            for await result in group {
+                guard let (displayID, info) = result else { continue }
+                if averageColors[displayID] != info {
+                    averageColors[displayID] = info
                 }
-                if displayID == activeDisplayID, self.averageColorInfo != info {
-                    self.averageColorInfo = info
+                if displayID == activeDisplayID, averageColorInfo != info {
+                    averageColorInfo = info
                 }
             }
         }
@@ -546,23 +578,21 @@ final class MenuBarManager: ObservableObject {
     /// capture fails (e.g. during early app launch before the Window Server
     /// is fully settled). Retries until all screens have a color entry.
     private func captureAdaptiveColorWithRetry() {
-        updateAverageColorInfo()
-        let allCaptured = NSScreen.screens.allSatisfy { averageColors.keys.contains($0.displayID) }
-        guard !allCaptured else { return }
-        var retries = 0
-        func scheduleRetry() {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 1) { [weak self] in
-                guard let self else { return }
-                retries += 1
-                guard retries < 10 else { return }
-                updateAverageColorInfo()
-                let allCaptured = NSScreen.screens.allSatisfy { averageColors.keys.contains($0.displayID) }
-                if !allCaptured {
-                    scheduleRetry()
+        // Awaits each capture before checking averageColors so we don't burn
+        // retries on stale reads of fire-and-forget Task results.
+        Task { [weak self] in
+            guard let self else { return }
+            for attempt in 0..<10 {
+                if attempt > 0 {
+                    try? await Task.sleep(for: .seconds(1))
                 }
+                await self.updateAverageColorInfoAsync()
+                let allCaptured = NSScreen.screens.allSatisfy {
+                    self.averageColors.keys.contains($0.displayID)
+                }
+                if allCaptured { return }
             }
         }
-        scheduleRetry()
     }
 
     /// Returns a Boolean value that indicates whether the given display

--- a/Thaw/MenuBar/MenuBarManager.swift
+++ b/Thaw/MenuBar/MenuBarManager.swift
@@ -508,25 +508,36 @@ final class MenuBarManager: ObservableObject {
 
             guard
                 let menuBarWindow = WindowInfo.menuBarWindow(from: windows, for: displayID),
-                let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: displayID),
-                let image = ScreenCapture.captureWindows(
-                    with: [menuBarWindow.windowID, wallpaperWindow.windowID],
-                    screenBounds: withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 },
-                    option: .nominalResolution
-                ),
-                let color = image.averageColor(option: .ignoreAlpha)
+                let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: displayID)
             else {
                 continue
             }
 
-            let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
+            let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
+            let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
 
-            if averageColors[displayID] != info {
-                averageColors[displayID] = info
-            }
-
-            if displayID == activeDisplayID, averageColorInfo != info {
-                averageColorInfo = info
+            // SCK runs off MainActor; the Task body resumes on @MainActor for
+            // the per-display state mutations. Per-screen captures are
+            // independent so they can run concurrently.
+            Task { [weak self] in
+                guard
+                    let image = await ScreenCapture.captureWindowsAsync(
+                        with: windowIDs,
+                        screenBounds: bounds,
+                        option: .nominalResolution
+                    ),
+                    let color = image.averageColor(option: .ignoreAlpha)
+                else {
+                    return
+                }
+                guard let self else { return }
+                let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
+                if self.averageColors[displayID] != info {
+                    self.averageColors[displayID] = info
+                }
+                if displayID == activeDisplayID, self.averageColorInfo != info {
+                    self.averageColorInfo = info
+                }
             }
         }
     }

--- a/Thaw/MenuBar/Search/MenuBarSearchModel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchModel.swift
@@ -27,6 +27,13 @@ final class MenuBarSearchModel: ObservableObject {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// Monotonically incremented by updateAverageColorInfo and
+    /// clearAverageColorInfo. A capture in flight stamps the value it observed
+    /// and only writes averageColorInfo on completion if the value still
+    /// matches, so a late completion can't overwrite a freshly cleared value
+    /// or a newer capture's result.
+    private var captureGeneration: Int = 0
+
     let fuse = Fuse(threshold: 0.5)
 
     func performSetup(with panel: MenuBarSearchPanel) {
@@ -50,22 +57,31 @@ final class MenuBarSearchModel: ObservableObject {
         .store(in: &c)
 
         // Clear average color when search panel closes to free memory
+        // and invalidate any in-flight capture from the open lifetime.
         panel.publisher(for: \.isVisible)
             .filter { !$0 }
             .sink { [weak self] _ in
-                self?.averageColorInfo = nil
+                self?.clearAverageColorInfo()
             }
             .store(in: &c)
 
-        // Clear on display changes to prevent stale color info
+        // Clear on display changes to prevent stale color info and invalidate
+        // any in-flight capture targeting the previous screen geometry.
         NotificationCenter.default
             .publisher(for: NSApplication.didChangeScreenParametersNotification)
             .sink { [weak self] _ in
-                self?.averageColorInfo = nil
+                self?.clearAverageColorInfo()
             }
             .store(in: &c)
 
         cancellables = c
+    }
+
+    /// Clears averageColorInfo and invalidates any in-flight capture so a late
+    /// completion can't overwrite the cleared state with a stale value.
+    private func clearAverageColorInfo() {
+        captureGeneration += 1
+        averageColorInfo = nil
     }
 
     private func updateAverageColorInfo(for screen: NSScreen) {
@@ -82,8 +98,13 @@ final class MenuBarSearchModel: ObservableObject {
         let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
         let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
 
-        // SCK runs off MainActor; the Task body resumes on @MainActor for the
-        // averageColorInfo mutation.
+        // Stamp our generation before suspending. If clearAverageColorInfo or
+        // a newer updateAverageColorInfo bumps the counter while we await, our
+        // completion is stale and must skip the write so we don't undo an
+        // intentional clear or clobber a fresher capture.
+        captureGeneration += 1
+        let generation = captureGeneration
+
         Task { [weak self] in
             guard
                 let image = await ScreenCapture.captureWindowsAsync(
@@ -95,7 +116,7 @@ final class MenuBarSearchModel: ObservableObject {
             else {
                 return
             }
-            guard let self else { return }
+            guard let self, generation == self.captureGeneration else { return }
             let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
             if self.averageColorInfo != info {
                 self.averageColorInfo = info

--- a/Thaw/MenuBar/Search/MenuBarSearchModel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchModel.swift
@@ -79,21 +79,27 @@ final class MenuBarSearchModel: ObservableObject {
             return
         }
 
-        guard
-            let image = ScreenCapture.captureWindows(
-                with: [menuBarWindow.windowID, wallpaperWindow.windowID],
-                screenBounds: withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 },
-                option: .nominalResolution
-            ),
-            let color = image.averageColor(option: .ignoreAlpha)
-        else {
-            return
-        }
+        let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
+        let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
 
-        let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
-
-        if averageColorInfo != info {
-            averageColorInfo = info
+        // SCK runs off MainActor; the Task body resumes on @MainActor for the
+        // averageColorInfo mutation.
+        Task { [weak self] in
+            guard
+                let image = await ScreenCapture.captureWindowsAsync(
+                    with: windowIDs,
+                    screenBounds: bounds,
+                    option: .nominalResolution
+                ),
+                let color = image.averageColor(option: .ignoreAlpha)
+            else {
+                return
+            }
+            guard let self else { return }
+            let info = MenuBarAverageColorInfo(color: color, source: .menuBarWindow)
+            if self.averageColorInfo != info {
+                self.averageColorInfo = info
+            }
         }
     }
 }

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -74,20 +74,23 @@ enum ScreenCapture {
 
     // MARK: Capture Window(s)
 
-    // NOTE: We intentionally use the deprecated CGWindowList API here instead of
-    // ScreenCaptureKit. SCShareableContent only returns on-screen windows in the
-    // current Space, but we need to capture:
-    //   - Offscreen menu bar items (overflow area)
-    //   - Windows in other Spaces
-    //   - Windows partially clipped by screen edges
+    // NOTE: The synchronous captureWindows / captureWindow below intentionally
+    // route through the deprecated SkyLight private API
+    // (SLWindowListCreateImageFromArray) for the menu-bar refresh path. On
+    // macOS 26 SCShareableContent.excludingDesktopWindows(_: onScreenWindowsOnly:
+    // false) *does* enumerate offscreen menu-bar overflow items, but SCK
+    // capture rejects them: SCContentFilter(display: including:) returns error
+    // -3812 (sourceRect outside display bounds) and SCContentFilter(
+    // desktopIndependentWindow:) returns -3811 (stream start failure). SkyLight
+    // is the only public API on macOS 26 that can capture status-item windows
+    // positioned at large negative x. It leaks one CFMutableDictionary per
+    // call inside SLSWindowListCreateImageFromArrayProxying; that's a system
+    // bug awaiting an Apple fix.
     //
-    // This is an architectural limitation of ScreenCaptureKit (designed for
-    // screen recording/streaming, not arbitrary window capture), not a bug.
-    // Even macOS 15+ does not provide public APIs to enumerate offscreen windows.
-    //
-    // CGWindowList remains the only public API capable of accessing offscreen
-    // and cross-Space window content. We use the hybrid approach:
-    // ScreenCaptureKit for display capture, CGWindowList for window capture.
+    // The async captureWindowsAsync / captureWindowAsync below route through
+    // ScreenCaptureKit and are leak-free. Use those for any capture whose
+    // windows fit within display bounds (the menu-bar item cache paths
+    // pre-filter offscreen items and use the async path).
 
     /// Captures a composite image of an array of windows.
     ///
@@ -116,6 +119,20 @@ enum ScreenCapture {
     ///   - option: Options that specify which parts of the window are captured.
     static func captureWindow(with windowID: CGWindowID, screenBounds: CGRect? = nil, option: CGWindowImageOption = []) -> CGImage? {
         captureWindows(with: [windowID], screenBounds: screenBounds, option: option)
+    }
+
+    // MARK: Capture Window(s) via ScreenCaptureKit
+
+    /// Async, ScreenCaptureKit-backed equivalent of captureWindows. Leak-free,
+    /// but the underlying SCK filter is display-bounded; use captureWindows
+    /// (SkyLight) for windows positioned off-display.
+    static func captureWindowsAsync(with windowIDs: [CGWindowID], screenBounds: CGRect? = nil, option: CGWindowImageOption = []) async -> CGImage? {
+        await Bridging.captureWindowsImageSCK(windowIDs: windowIDs, screenBounds: screenBounds, options: option)
+    }
+
+    /// Async, ScreenCaptureKit-backed equivalent of captureWindow.
+    static func captureWindowAsync(with windowID: CGWindowID, screenBounds: CGRect? = nil, option: CGWindowImageOption = []) async -> CGImage? {
+        await captureWindowsAsync(with: [windowID], screenBounds: screenBounds, option: option)
     }
 
     // MARK: - ScreenCaptureKit Implementation


### PR DESCRIPTION
## What does this PR do?

Migrates Thaw's window capture path from the leaking SkyLight private API (`SLWindowListCreateImageFromArray`) to ScreenCaptureKit (`SCScreenshotManager.captureImage(contentFilter:configuration:)`) for every call site whose target windows fit within display bounds, and batches the residual SkyLight calls that genuinely cannot move to SCK. Eliminates ~79% of the `NSMutableDictionary` leaks reported by `leaks` on macOS 26.4.1 and reduces total leaked bytes by ~76%.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A. The public surfaces of all migrated functions are preserved. `refreshImages` only gains a new `viaSCK: Bool = false` parameter with a default that matches prior behaviour. `compositeCapture` and `individualCapture` become `async`, but they are `private` to `MenuBarItemImageCache`. The three color-sampler functions (`MenuBarManager.updateAverageColorInfo`, `IceBarColorManager.updateWindowImage`, `MenuBarSearchModel.updateAverageColorInfo`) keep their synchronous signatures and externally observable behaviour.

## What is the current behavior?

Every call to `Bridging.captureWindowsImage` (the wrapper around the private `SLWindowListCreateImageFromArray`) leaks one `CFMutableDictionary` inside `SLSWindowListCreateImageFromArrayProxying` via `CGRectCreateDictionaryRepresentation`. `leaks` on a fresh `MallocStackLogging=1` Thaw process attributed ~250 `NSMutableDictionary` instances (~42 KB of ~44 KB total leaked bytes) to that one allocation site, exercised by six distinct Thaw call sites: `MenuBarItemImageCache.individualCapture`, `compositeCapture`, and `refreshImages`, plus `MenuBarManager.updateAverageColorInfo`, `IceBarColorManager.updateWindowImage`, and `MenuBarSearchModel.updateAverageColorInfo`. The leak is inside Apple's SkyLight framework, so the dictionary cannot be released from Swift; the only levers are to stop calling SkyLight or to call it less.

Issue Number: N/A

## What is the new behavior?

Adds `Bridging.captureWindowsImageSCK` as an async, leak-free SCK replacement (using `SCContentFilter(display:including:)` + `SCScreenshotManager.captureImage(contentFilter:configuration:)`) and exposes it via `ScreenCapture.captureWindowsAsync` / `captureWindowAsync`. Migrates `MenuBarItemImageCache.compositeCapture` and `individualCapture` to the SCK path (both become `async`). Migrates the three color-sampler functions while preserving their sync signatures by wrapping the capture in a `Task`; the SCK call runs off the main actor and state mutation resumes on the owning `@MainActor` class. For `refreshImages`, where items live past the display's left edge and both SCK filter shapes fail (`-3812` for display-bounded, `-3811` for desktopIndependentWindow), `refreshImages` gains an opt-in `viaSCK: Bool = false` parameter and `runLiveRefreshLoop` is restructured: tick-global guards (`lastMoveOperationOccurred`, `isResettingLayout`) hoist out of the per-section loop, the `.visible` section refreshes individually via the leak-free SCK path, and `.hidden` plus `.alwaysHidden` items batch into a single SkyLight call per tick instead of two separate ones. Net result on testing across normal exercise: 122 leaks / 10.8 KB total versus the 507 leaks / 44 KB baseline; the remaining 53 `NSMutableDictionary` instances are the irreducible Apple-framework floor.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Verified empirically rather than via unit tests, since the bug surfaces in `leaks` output not in functional assertions. Workflow: build with `xcodebuild -scheme Thaw-configuration Debug build`, launch with `MallocStackLogging=1`, exercise all four scenarios (menu bar idle, ThawBar visible-section, ThawBar hidden + always-hidden expanded, `Settings → Menu Bar Layout` open), then `leaks <pid> --fullStacks --groupByType` and inspect attribution. The diagnostic delta is the most useful artefact: before the change, dictionary leaks scale with total capture-call count across all six call sites; after, they scale only with the batched `refreshImages` SkyLight call frequency. Comments at `Thaw/Utilities/ScreenCapture.swift` and `Shared/Bridging/Bridging.swift` document the SCK display-bounds limitation and the specific error codes (`-3812` / `-3811`) so future maintainers don't re-investigate.

### Notes for reviewers

The `refreshImages` `viaSCK` parameter defaults to `false` deliberately so any future external caller keeps the SkyLight semantics (offscreen-capable). Only the in-loop call site in `runLiveRefreshLoop` opts in to `true`, and only for `.visible`. Per-section routing is by section enum rather than runtime bounds-check because the section identity is already known at the call site and items in `.hidden` / `.alwaysHidden` are off-screen by definition (control items observed at x = -3985 and x = -9245 respectively). Color-sampler `Task` wraps trade a small change in update timing for leak elimination: paths that previously ran `updateWindowImage(); updateColorInfo();` back-to-back will now read the *previous* cycle's `windowImage` until the next async capture lands. On the 5 s periodic refresh this is imperceptible, but it's worth a quick visual smoke when exercising IceBar adaptive backgrounds. Apple Feedback drafts for the SkyLight `CGRectCreateDictionaryRepresentation` leak, the AppKit `_regionForOpaqueDescendants` `CGRegion` leak, and a separate `AppIntents` `NSProgress` retain cycle (observed when System Settings materializes `SetFocusFilterIntent` metadata) are prepared and will be filed via Feedback Assistant; FB numbers will be added as in-code comments once issued.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an async ScreenCaptureKit-backed capture path for display-bounded window screenshots and per-display captures.

* **Bug Fixes**
  * Prevented stale async captures from overwriting current color state via generation-based invalidation.
  * Improved capture failure handling and reduced missed updates during display/config changes.

* **Refactor**
  * Migrated menu-bar and image-cache refresh flows to async/await, batching visible-item captures and stabilizing wake-time polling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/613?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->