### PR TITLE
fix(capture): tolerate menu-bar item bounds that overshoot NSScreen.frame

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -630,16 +630,22 @@ extension Bridging {
             return unionBounds
         }()
 
-        // Require a single display that fully contains BOTH the effective
-        // capture bounds and the union of all selected windows. Using
-        // intersects here would let a display that only partially overlaps
-        // through, producing a silently clipped capture; SCContentFilter
-        // (display:including:) clips at display.frame, so anything outside is
-        // lost without an error. A clean nil lets callers fall back or skip.
-        guard let display = content.displays.first(where: {
-            $0.frame.contains(effectiveBounds) && $0.frame.contains(unionBounds)
-        }) else {
-            diagLog.warning("captureWindowsImageSCK: no display fully contains effectiveBounds=\(effectiveBounds) and unionBounds=\(unionBounds)")
+        // Pick the display that holds the largest share of unionBounds. A
+        // strict frame.contains check rejected status-item windows whose
+        // bounds overshoot NSScreen.frame.maxX by a handful of pixels
+        // (observed on the Clock and Thaw items: bounds = (1029, 0, 443, 33)
+        // on a 1470-wide display), so the SCK capture never happened and the
+        // icons disappeared from Settings / Search. Largest-intersection wins
+        // the common edge-overshoot case, picks the majority display for a
+        // cross-display span, and still returns nil when no display overlaps
+        // at all so truly orphan windows fall back / skip cleanly.
+        let displayCandidates = content.displays.compactMap { display -> (SCDisplay, CGFloat)? in
+            let intersection = display.frame.intersection(unionBounds)
+            guard !intersection.isNull else { return nil }
+            return (display, intersection.width * intersection.height)
+        }
+        guard let display = displayCandidates.max(by: { $0.1 < $1.1 })?.0 else {
+            diagLog.warning("captureWindowsImageSCK: no display intersects unionBounds=\(unionBounds) (effectiveBounds=\(effectiveBounds))")
             return nil
         }
 


### PR DESCRIPTION
## What does this PR do?

Fixes a regression introduced by #613 where the strict `display.frame.contains(...)` precondition in `Bridging.captureWindowsImageSCK` rejected status-item windows whose bounds report a few pixels past `NSScreen.frame.maxX` (observed on the Clock and Thaw's own status item). The SCK capture silently returned `nil`, so the affected icons disappeared from Settings → Menu Bar Layout and the Search bar. Replaces the contains guard with a largest-intersection-area display selection that tolerates small edge overshoots while still rejecting truly orphan windows.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A. Function signature and external behaviour for healthy captures are unchanged. The fix only relaxes a precondition that was rejecting valid captures.

## What is the current behavior?

After #613, `Bridging.captureWindowsImageSCK` selects the host display via `content.displays.first(where: { $0.frame.contains(effectiveBounds) && $0.frame.contains(unionBounds) })`. macOS 26's WindowServer routinely reports status-item bounds that overshoot `NSScreen.frame.maxX` by a couple of pixels (observed example: Clock at `(1029, 0, 443, 33)` on a 1470-wide display: the bounds end at x=1472, two pixels past the display's right edge). The strict `contains` rejects every such case as "no display fully contains effectiveBounds", returns `nil`, and the downstream consumer (Layout settings preview, Search panel icon strip) renders nothing for that item. The Clock and Thaw's own status item are the most consistently affected because they sit at the trailing end of the menu bar.

Issue Number: N/A

## What is the new behavior?

`captureWindowsImageSCK` now picks the display whose intersection with `unionBounds` has the largest area. The display holding the bulk of the window wins for edge-overshoot cases (SCK still clips the trailing few pixels at `display.frame.maxX`, which matches the legacy `SLWindowListCreateImageFromArray` behaviour that also clipped at the display edge, so the captured image is visually identical). Cross-display spans pick the majority side instead of accepting whichever display arbitrarily intersected first. Truly orphan windows whose `unionBounds` doesn't intersect any display still return `nil` with a warning, so the defensive intent of #613's change is preserved for the case that warranted it. Diagnostic warning is updated to report both `effectiveBounds` and `unionBounds` so future rejections are debuggable.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Reproduction was driven from the user-facing report: open Settings → Menu Bar Layout and check that the Clock and Thaw status items render in the layout preview; open the menu-bar Search panel and check that those icons appear in the row. Before this fix, both surfaces displayed empty slots for those items. Diagnostic confirmation in `~/Library/Logs/Thaw/thaw_*.log` showed the rejection lines `captureWindowsImageSCK: no display fully contains effectiveBounds=(1029.0, 0.0, 443.0, 33.0) and unionBounds=(1029.0, 0.0, 443.0, 33.0)` firing once per affected item per refresh tick. After the fix, those warnings disappear and `captureWindowsImageSCK: captured N windows -> WxHpx` lines replace them.

### Notes for reviewers

Largest-intersection was preferred over reverting to the original `intersects`-with-fallback chain because the fallback chain ended in `content.displays.first` (any display), which was looser than necessary and could have picked an unrelated display. Largest-intersection is genuinely better than both: it tolerates the macOS-26 overshoot we observed empirically, picks the right display for cross-monitor spans, and rejects truly orphan windows so callers still fall back / skip cleanly. The diagnostic warning now includes both `effectiveBounds` and `unionBounds` so future regressions report enough state to investigate without instrumentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved window capture reliability on multi-monitor setups. Enhanced display selection logic now identifies the most appropriate display based on visual intersection area, providing more robust handling of complex display configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->