### PR TITLE
fix(logging): unify XPC service diagnostic log into the main apps file

### DIFF
--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import Foundation
 import XPC
 
 /// A wrapper around an XPC listener object.
@@ -37,6 +38,10 @@ final class Listener: @unchecked Sendable {
             case .start:
                 diagLog.debug("Listener received start request")
                 return .start
+            case let .configureLogging(filePath):
+                DiagnosticLogger.shared.attachToFile(at: URL(fileURLWithPath: filePath))
+                diagLog.debug("Listener attached diagnostic logging to \(filePath)")
+                return .configureLogging
             case let .sourcePID(window):
                 diagLog.debug("Listener: sourcePID request for windowID=\(window.windowID) title=\(window.title ?? "nil")")
                 let pid = SourcePIDCache.shared.pid(for: window)

--- a/MenuBarItemService/main.swift
+++ b/MenuBarItemService/main.swift
@@ -8,9 +8,12 @@
 
 import Foundation
 
-#if DEBUG
-DiagnosticLogger.shared.isEnabled = true
-#endif
+// Diagnostic file logging is enabled by the main app via the
+// configureLogging XPC request once it has opened its own log file.
+// That way both processes append to a single shared file instead of
+// each minting its own timestamped filename at startup. Anything
+// logged before the configureLogging request arrives still reaches
+// OSLog; only the on-disk diagnostic file is gated.
 
 SourcePIDCache.shared.start()
 Listener.shared.activate()

--- a/Shared/Services/MenuBarItemService.swift
+++ b/Shared/Services/MenuBarItemService.swift
@@ -15,12 +15,14 @@ enum MenuBarItemService {
 extension MenuBarItemService {
     enum Request: Codable {
         case start
+        case configureLogging(filePath: String)
         case sourcePID(WindowInfo)
         case sourcePIDs([WindowInfo])
     }
 
     enum Response: Codable {
         case start
+        case configureLogging
         case sourcePID(pid_t?)
         case sourcePIDs([pid_t?])
     }

--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -145,6 +145,7 @@ final class DiagnosticLogger: @unchecked Sendable {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
             osLog.error("Failed to create log directory at \(dir.path): \(error)")
+            isEnabledLock.withLock { $0 = false }
             return
         }
 
@@ -162,6 +163,7 @@ final class DiagnosticLogger: @unchecked Sendable {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
             osLog.error("Failed to create log directory at \(dir.path): \(error)")
+            isEnabledLock.withLock { $0 = false }
             return
         }
 
@@ -179,6 +181,7 @@ final class DiagnosticLogger: @unchecked Sendable {
         let fd = open(fileURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
         guard fd >= 0 else {
             osLog.error("Failed to open log file at \(fileURL.path): errno \(errno)")
+            isEnabledLock.withLock { $0 = false }
             return
         }
         let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)

--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -115,7 +115,30 @@ final class DiagnosticLogger: @unchecked Sendable {
 
     // MARK: - File Management
 
-    /// Creates the log directory if needed and opens a new log file.
+    /// Enables diagnostic logging using an explicit log file URL chosen
+    /// by another process. The MenuBarItemService XPC service calls this
+    /// after the main app sends its log file path over the XPC channel,
+    /// so both processes append to the same file instead of each
+    /// minting its own filename from its own wall clock (which can
+    /// straddle a one-second boundary at startup and produce two
+    /// separate files). Safe to call repeatedly; the existing handle
+    /// is closed before the new one is opened.
+    func attachToFile(at fileURL: URL) {
+        let wasEnabled = isEnabledLock.withLock { current -> Bool in
+            let was = current
+            current = true
+            return was
+        }
+        if wasEnabled {
+            closeLogFile()
+        }
+        openLogFile(at: fileURL)
+    }
+
+    /// Creates the log directory if needed and opens a freshly minted
+    /// log file. Called by the main app when diagnostic logging is
+    /// turned on; the chosen URL is then shared with the XPC service
+    /// via attachToFile(at:).
     private func openLogFile() {
         let dir = logDirectory
         do {
@@ -126,21 +149,33 @@ final class DiagnosticLogger: @unchecked Sendable {
         }
 
         let fileName = "thaw_\(fileNameFormatter.string(from: Date())).log"
-        let fileURL = dir.appendingPathComponent(fileName)
+        openLogFile(at: dir.appendingPathComponent(fileName))
+    }
 
-        // Open with O_APPEND so the main app and the XPC service
-        // can safely write to the same file. Both processes call
-        // openLogFile during startup, often within the same second,
-        // so they land on the same filename. FileManager.createFile
-        // and FileHandle(forWritingTo:) would truncate an existing
-        // file and the two processes' per-fd offsets would race
-        // against each other on the same byte range. POSIX open(2)
-        // with O_APPEND tells the kernel to atomically position
-        // each write at end-of-file, which is atomic between
-        // processes for writes smaller than PIPE_BUF on local
-        // filesystems; O_CREAT creates the file if absent without
-        // touching an existing one. Swift's FileHandle initializers
-        // do not expose these flags, hence the POSIX call.
+    /// Opens the given file with O_APPEND and writes the per-process
+    /// header. Shared by the main app's fresh-mint path and the XPC
+    /// service's attach path so both processes use identical open and
+    /// header logic.
+    private func openLogFile(at fileURL: URL) {
+        let dir = fileURL.deletingLastPathComponent()
+        do {
+            try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        } catch {
+            osLog.error("Failed to create log directory at \(dir.path): \(error)")
+            return
+        }
+
+        // Open with O_APPEND so the main app and the XPC service can
+        // safely write to the same file. FileManager.createFile and
+        // FileHandle(forWritingTo:) would truncate an existing file
+        // and the two processes' per-fd offsets would race against
+        // each other on the same byte range. POSIX open(2) with
+        // O_APPEND tells the kernel to atomically position each write
+        // at end-of-file, which is atomic between processes for writes
+        // smaller than PIPE_BUF on local filesystems; O_CREAT creates
+        // the file if absent without touching an existing one. Swift's
+        // FileHandle initializers do not expose these flags, hence the
+        // POSIX call.
         let fd = open(fileURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
         guard fd >= 0 else {
             osLog.error("Failed to open log file at \(fileURL.path): errno \(errno)")

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -44,6 +44,24 @@ extension MenuBarItemService {
         func start() async {
             diagLog.debug("Starting MenuBarItemService connection")
 
+            // If the main app already has a diagnostic log file open,
+            // hand its path to the XPC service so both processes append
+            // to the same file. Sent before the start request so the
+            // XPC service is logging to disk by the time it handles any
+            // subsequent traffic. When file logging is off in the main
+            // app currentLogFile is nil and the XPC service simply logs
+            // to OSLog only, matching the prior release-build behaviour.
+            if let logFile = DiagnosticLogger.shared.currentLogFile {
+                let response = await session.sendAsync(request: .configureLogging(filePath: logFile.path))
+                if response == nil {
+                    diagLog.error("configureLogging request returned nil")
+                } else if case .configureLogging = response {
+                    // success
+                } else {
+                    diagLog.error("configureLogging request returned invalid response \(String(describing: response))")
+                }
+            }
+
             let response = await session.sendAsync(request: .start)
             guard let response else {
                 diagLog.error("Start request returned nil")


### PR DESCRIPTION
## What does this PR do?

Removes the timestamp-race in `DiagnosticLogger` that produced two parallel `thaw_*.log` files (one for the main app, one for the `MenuBarItemService` XPC service) whenever XPC bring-up straddled a one-second boundary at startup, replacing it with explicit XPC-channel coordination so both processes always append to a single shared file.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

`DiagnosticLogger.openLogFile` minted a filename from `Date()` in each process (`thaw_<yyyy-MM-dd_HH-mm-ss>.log`) and relied on the main app and the XPC service starting within the same wall-clock second so both ended up on the same path and interleaved writes via `O_APPEND`. XPC bring-up routinely takes a few hundred milliseconds, so ~760 ms of jitter was enough to land the two processes on either side of a `:59` → `:00` boundary. The result was two separate log files per session (e.g. `thaw_..._17-58-59.log` from the main app and `thaw_..._17-59-00.log` from the XPC service), which forced log analysis to grep across both halves.

Issue Number: N/A

## What is the new behavior?

The main app drives the XPC service's log file selection over the existing XPC channel instead of relying on coincident timestamps. `DiagnosticLogger` gains an `attachToFile(at:)` entry point that opens a specific URL with `O_APPEND` and writes the per-process header; the original parameterless `openLogFile()` now mints the timestamped filename and delegates to it. `MenuBarItemService.Request` and `Response` gain a `configureLogging(filePath:)` pair, the XPC `Listener` handles it by calling service's `main.swift` no longer self-enables file logging on `#if DEBUG`; it waits for the main app's path. Two informational setup lines from the XPC service (`Starting observers for source PID cache` and `Activating listener`) run before the `configureLogging` handler fires and now reach `OSLog` only, not the on-disk file; the first `Performing PID cache cleanup` still lands in the file because the `NSWorkspace.runningApplications` KVO publisher emits asynchronously on subscribe. When file logging is off in the main app (release builds with the toggle off), `currentLogFile` is nil and no `configureLogging` request is sent, preserving the prior behaviour where the XPC service logs to `OSLog` only.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Verified against a fresh debug launch (`~/Library/Logs/Thaw/thaw_2026-05-25_13-14-41.log`): a single log file is produced with one `Process: Thaw` header at the top and the second `Process: MenuBarItemService` header inline at the moment `configureLogging` is handled, followed by the XPC service's `Listener attached diagnostic logging to ...` debug line and all subsequent XPC traffic interleaved with the main app's lines on per-line wall-clock order.

### Notes for reviewers

The two missed XPC-side setup lines are a deliberate trade for keeping the change small (no in-memory ring buffer in `DiagnosticLogger`); the runtime fact of subsequent XPC traffic in the same file already proves the listener activated and the cache started its observers, so no diagnostic content is lost in practice. Release-build behaviour with the diagnostic-logging toggle off is unchanged: no `configureLogging` request is sent, and the XPC service continues to log to `OSLog` only as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Menu bar service and main app can append to a shared diagnostic log file so diagnostics are consolidated.

* **Bug Fixes**
  * Logging configuration is coordinated so on-disk diagnostic logging is enabled reliably after the main app configures it; early logs still reach system logging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/615?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->