### PR TITLE
fix(profiles): prompt before applying display spacing

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -43989,6 +43989,30 @@
           }
         }
       }
+    },
+    "Apply spacing change?" : {
+      "comment" : "Title of the alert shown before applying a menu bar item spacing change.",
+      "localizations" : {}
+    },
+    "Applying this spacing change will briefly relaunch all apps with menu bar items." : {
+      "comment" : "Alert message variant shown when applying a spacing change for the active menu bar display and no profile is active.",
+      "localizations" : {}
+    },
+    "Applying this spacing change will briefly relaunch all apps with menu bar items. Save the new spacing to the active profile \"%@\", or save it to every profile." : {
+      "comment" : "Alert message variant shown when applying a spacing change for the active menu bar display while a profile is active. %@ is the active profile name.",
+      "localizations" : {}
+    },
+    "Save the new spacing to the active profile \"%@\", or save it to every profile." : {
+      "comment" : "Alert message variant shown when applying a spacing change for a non-active display while a profile is active. %@ is the active profile name.",
+      "localizations" : {}
+    },
+    "Update Active Profile" : {
+      "comment" : "Button in the spacing-change confirmation alert that writes the new spacing into the active profile.",
+      "localizations" : {}
+    },
+    "Update All Profiles" : {
+      "comment" : "Button in the spacing-change confirmation alert that writes the new spacing into every profile.",
+      "localizations" : {}
     }
   },
   "version" : "1.1"

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -46,6 +46,15 @@ final class DisplaySettingsManager: ObservableObject {
     /// Internal access so unit tests in ThawTests can seed and assert it.
     var lastAppliedActiveDisplayUUID: String?
 
+    /// UUID of the display that currently owns the menu bar, or nil if it
+    /// cannot be determined. Exposed for views that need to decide whether
+    /// a spacing change will trigger the relaunch wave (only writes against
+    /// the active display do, because applyActiveDisplaySpacing only reads
+    /// configurationForActiveDisplay()).
+    var activeMenuBarDisplayUUID: String? {
+        Bridging.getActiveMenuBarDisplayUUID()
+    }
+
     /// Performs the initial setup of the manager.
     func performSetup(with appState: AppState) {
         self.appState = appState
@@ -84,15 +93,32 @@ final class DisplaySettingsManager: ObservableObject {
 
     // MARK: - Loading
 
-    /// Loads saved configurations from Defaults.
+    /// Default baseline for NSStatusItemSpacing and NSStatusItemSelectionPadding,
+    /// kept in sync with MenuBarItemSpacingManager.Key.defaultValue. Used to
+    /// translate on-disk system spacing into Thaw's relative offset model.
+    private static let systemSpacingDefault = 16
+
+    /// Loads saved configurations from Defaults. On a truly first launch
+    /// (no persisted per-display configurations) with externally configured
+    /// system spacing, adopts the on-disk value as the seed offset for each
+    /// connected display so Thaw does not overwrite a user's manual
+    /// defaults write NSStatusItemSpacing and trigger a startup relaunch
+    /// wave. See issue #602.
     private func loadInitialState() {
-        if let data = Defaults.data(forKey: .displayIceBarConfigurations) {
+        let persistedData = Defaults.data(forKey: .displayIceBarConfigurations)
+        if let data = persistedData {
             do {
                 configurations = try decoder.decode([String: DisplayIceBarConfiguration].self, from: data)
                 diagLog.info("Loaded per-display configurations for \(configurations.count) display(s)")
             } catch {
                 diagLog.error("Failed to decode per-display configurations: \(error)")
             }
+        }
+        // Gate seeding on absence of the persisted key rather than an empty
+        // in-memory dictionary so a user-initiated reset (which persists an
+        // empty dict) is not silently re-seeded from on-disk system spacing.
+        if persistedData == nil {
+            seedConfigurationsFromSystemSpacing()
         }
         if let data = Defaults.data(forKey: .knownDisplays) {
             do {
@@ -112,6 +138,62 @@ final class DisplaySettingsManager: ObservableObject {
             } catch {
                 diagLog.error("Failed to decode known display cache: \(error)")
             }
+        }
+    }
+
+    /// Reads the current system value for NSStatusItemSpacing from the byHost
+    /// global domain. Returns nil when the key is unset, letting callers
+    /// distinguish "user has explicitly configured spacing" from "macOS
+    /// default applies".
+    private static func currentSystemSpacing() -> Int? {
+        CFPreferencesCopyValue(
+            "NSStatusItemSpacing" as CFString,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesCurrentHost
+        ) as? Int
+    }
+
+    /// When the user has manually set NSStatusItemSpacing outside of Thaw
+    /// (e.g. via a defaults write in Terminal), seed an entry for each
+    /// connected display whose itemSpacingOffset corresponds to that on-disk
+    /// value. Without this, applyActiveDisplaySpacing on first launch reads
+    /// the default offset of 0, computes target = 16, sees on-disk = N, and
+    /// fires a relaunch wave that rewrites the user's manual setting back to
+    /// 16. The seeded entries are written to Defaults inline because the
+    /// persistence sink is not yet wired at loadInitialState time; without
+    /// the explicit save, subsequent launches would re-seed on every start
+    /// instead of remembering the adopted value. The padding key is not
+    /// consulted because Thaw drives both keys from a single offset; users
+    /// whose padding diverges from spacing will see one normalising relaunch
+    /// on first launch but no recurring waves thereafter.
+    private func seedConfigurationsFromSystemSpacing() {
+        guard let onDisk = Self.currentSystemSpacing(),
+              onDisk != Self.systemSpacingDefault
+        else {
+            return
+        }
+        let offset = Double(onDisk - Self.systemSpacingDefault)
+        var seeded = configurations
+        for screen in NSScreen.screens {
+            guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
+                continue
+            }
+            if seeded[uuid] != nil { continue }
+            seeded[uuid] = DisplayIceBarConfiguration
+                .defaultConfiguration
+                .withItemSpacingOffset(offset)
+        }
+        guard seeded != configurations else { return }
+        configurations = seeded
+        do {
+            let data = try encoder.encode(seeded)
+            Defaults.set(data, forKey: .displayIceBarConfigurations)
+            diagLog.info(
+                "Seeded itemSpacingOffset=\(offset) from external NSStatusItemSpacing=\(onDisk) for \(seeded.count) display(s)"
+            )
+        } catch {
+            diagLog.error("Failed to persist seeded per-display configurations: \(error)")
         }
     }
 

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -667,6 +667,35 @@ final class ProfileManager: ObservableObject {
         try saveProfileAndUpdateManifest(profile)
     }
 
+    /// Writes the given itemSpacingOffset into every profile's stored
+    /// displayConfigurations entry for the specified display UUID. Creates
+    /// a default entry when a profile has no prior configuration for that
+    /// display. Used by the spacing-apply confirmation in DisplaySettingsPane
+    /// so a freshly applied spacing change is not reverted by the next
+    /// profile reapply.
+    func updateAllProfilesItemSpacingOffset(displayUUID: String, offset: Double) throws {
+        let now = Date()
+        var pending: [Profile] = []
+        pending.reserveCapacity(profiles.count)
+        for meta in profiles {
+            var profile = try loadProfile(id: meta.id)
+            let base = profile.displayConfigurations[displayUUID] ?? .defaultConfiguration
+            profile.displayConfigurations[displayUUID] = base.withItemSpacingOffset(offset)
+            profile.modifiedAt = now
+            pending.append(profile)
+        }
+        for profile in pending {
+            let data = try encoder.encode(profile)
+            try data.write(to: profileURL(for: profile.id), options: .atomic)
+        }
+        for profile in pending {
+            if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
+                profiles[index].modifiedAt = profile.modifiedAt
+            }
+        }
+        saveManifest()
+    }
+
     // MARK: - Profile Hooks
 
     /// Returns the automation config (pre/post hooks) attached to the

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -9,14 +9,31 @@
 import SwiftUI
 
 struct DisplaySettingsPane: View {
+    @EnvironmentObject var appState: AppState
     @ObservedObject var displaySettings: DisplaySettingsManager
 
     @State private var maxSliderLabelWidth: CGFloat = 0
     /// Per-display draft of the spacing slider, keyed by display UUID.
     /// Until the user clicks Apply, dragging the slider only updates this
-    /// dictionary — it does not touch the saved configuration or trigger
+    /// dictionary, it does not touch the saved configuration or trigger
     /// any relaunches.
     @State private var draftSpacing: [String: CGFloat] = [:]
+    /// Pending spacing apply held while the confirmation alert is shown.
+    /// Set by requestSpacingApply when a prompt is required; the alert binds
+    /// to its non-nil state. Nil when no alert is showing.
+    @State private var pendingSpacingApply: PendingSpacingApply?
+    @State private var errorMessage: String?
+    @State private var showingError = false
+
+    /// A spacing apply request awaiting user confirmation.
+    private struct PendingSpacingApply: Equatable {
+        let displayID: String
+        let displayName: String
+        let offset: Double
+        let isActiveDisplay: Bool
+        let activeProfileID: UUID?
+        let activeProfileName: String?
+    }
 
     var body: some View {
         IceForm {
@@ -25,6 +42,21 @@ struct DisplaySettingsPane: View {
                     displayRow(for: display)
                 }
             }
+        }
+        .alert(
+            String(localized: "Apply spacing change?"),
+            isPresented: Binding(
+                get: { pendingSpacingApply != nil },
+                set: { if !$0 { pendingSpacingApply = nil } }
+            ),
+            presenting: pendingSpacingApply,
+            actions: { pending in spacingConfirmationButtons(for: pending) },
+            message: { pending in Text(spacingConfirmationMessage(for: pending)) }
+        )
+        .alert("Error", isPresented: $showingError) {
+            Button("OK") { errorMessage = nil }
+        } message: {
+            if let errorMessage { Text(errorMessage) }
         }
     }
 
@@ -204,18 +236,13 @@ struct DisplaySettingsPane: View {
         } label: {
             LabeledContent {
                 Button("Apply") {
-                    displaySettings.updateConfiguration(forDisplayUUID: display.id) { config in
-                        config.withItemSpacingOffset(Double(draft))
-                    }
+                    requestSpacingApply(for: display, offset: Double(draft))
                 }
                 .help(Text("Apply the spacing for this display"))
                 .disabled(!canApply)
 
                 Button {
-                    draftSpacing[display.id] = 0
-                    displaySettings.updateConfiguration(forDisplayUUID: display.id) { config in
-                        config.withItemSpacingOffset(0)
-                    }
+                    requestSpacingApply(for: display, offset: 0)
                 } label: {
                     Image(systemName: "arrow.counterclockwise.circle.fill")
                 }
@@ -233,6 +260,134 @@ struct DisplaySettingsPane: View {
             // Sync draft when the saved value changes externally
             // (profile load, URI scheme, etc.).
             draftSpacing[display.id] = CGFloat(newValue)
+        }
+    }
+
+    // MARK: - Spacing Apply Confirmation
+
+    /// Routes both the Apply button and the inline reset button through a
+    /// single decision point. When no profile is active and the change is
+    /// for a non-active display, applies immediately (matches prior
+    /// behaviour). Otherwise stages a PendingSpacingApply so the .alert
+    /// can ask the user to choose between updating the active profile,
+    /// updating every profile, or cancelling.
+    private func requestSpacingApply(
+        for display: DisplaySettingsManager.DisplayInfo,
+        offset: Double
+    ) {
+        let activeID = appState.profileManager.activeProfileID
+        let isActiveDisplay = displaySettings.activeMenuBarDisplayUUID == display.id
+
+        if activeID == nil, !isActiveDisplay {
+            commitSpacing(displayID: display.id, offset: offset)
+            return
+        }
+
+        let activeName = activeID.flatMap { id in
+            appState.profileManager.profiles.first(where: { $0.id == id })?.name
+        }
+        pendingSpacingApply = PendingSpacingApply(
+            displayID: display.id,
+            displayName: display.name,
+            offset: offset,
+            isActiveDisplay: isActiveDisplay,
+            activeProfileID: activeID,
+            activeProfileName: activeName
+        )
+    }
+
+    /// Writes the new spacing to displaySettings.configurations. The
+    /// Combine sink in DisplaySettingsManager picks this up and drives the
+    /// relaunch wave on the next main-queue dispatch, so the caller is
+    /// expected to have already written the profile file when persisting
+    /// to a profile is desired.
+    private func commitSpacing(displayID: String, offset: Double) {
+        draftSpacing[displayID] = CGFloat(offset)
+        displaySettings.updateConfiguration(forDisplayUUID: displayID) { config in
+            config.withItemSpacingOffset(offset)
+        }
+    }
+
+    @ViewBuilder
+    private func spacingConfirmationButtons(for pending: PendingSpacingApply) -> some View {
+        if pending.activeProfileID != nil {
+            Button(String(localized: "Update Active Profile"), role: .destructive) {
+                if let id = pending.activeProfileID {
+                    // updateProfile(scope:.configurationOnly) captures live
+                    // state, so the in-memory configuration must hold the new
+                    // value before the save. Snapshot the previous offset so
+                    // a save failure can roll the live state back instead of
+                    // leaving the new spacing applied without a matching
+                    // profile entry, which the next reapply would revert.
+                    let previousOffset = displaySettings
+                        .configuration(forUUID: pending.displayID)
+                        .itemSpacingOffset
+                    commitSpacing(displayID: pending.displayID, offset: pending.offset)
+                    do {
+                        try appState.profileManager.updateProfile(
+                            id: id,
+                            scope: .configurationOnly,
+                            appState: appState
+                        )
+                    } catch {
+                        commitSpacing(displayID: pending.displayID, offset: previousOffset)
+                        errorMessage = error.localizedDescription
+                        showingError = true
+                    }
+                } else {
+                    commitSpacing(displayID: pending.displayID, offset: pending.offset)
+                }
+            }
+            Button(String(localized: "Update All Profiles"), role: .destructive) {
+                let previousOffset = displaySettings
+                    .configuration(forUUID: pending.displayID)
+                    .itemSpacingOffset
+                commitSpacing(displayID: pending.displayID, offset: pending.offset)
+                do {
+                    try appState.profileManager.updateAllProfilesItemSpacingOffset(
+                        displayUUID: pending.displayID,
+                        offset: pending.offset
+                    )
+                } catch {
+                    commitSpacing(displayID: pending.displayID, offset: previousOffset)
+                    errorMessage = error.localizedDescription
+                    showingError = true
+                }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                draftSpacing[pending.displayID] = CGFloat(
+                    displaySettings.configuration(forUUID: pending.displayID).itemSpacingOffset
+                )
+            }
+        } else {
+            Button(String(localized: "Apply"), role: .destructive) {
+                commitSpacing(displayID: pending.displayID, offset: pending.offset)
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {
+                draftSpacing[pending.displayID] = CGFloat(
+                    displaySettings.configuration(forUUID: pending.displayID).itemSpacingOffset
+                )
+            }
+        }
+    }
+
+    private func spacingConfirmationMessage(for pending: PendingSpacingApply) -> String {
+        let profileName = pending.activeProfileName ?? ""
+        switch (pending.isActiveDisplay, pending.activeProfileID != nil) {
+        case (true, true):
+            return String(
+                format: String(localized: "Applying this spacing change will briefly relaunch all apps with menu bar items. Save the new spacing to the active profile \"%@\", or save it to every profile."),
+                profileName
+            )
+        case (false, true):
+            return String(
+                format: String(localized: "Save the new spacing to the active profile \"%@\", or save it to every profile."),
+                profileName
+            )
+        case (true, false):
+            return String(localized: "Applying this spacing change will briefly relaunch all apps with menu bar items.")
+        case (false, false):
+            return ""
         }
     }
 }


### PR DESCRIPTION
## What does this PR do?

Two related fixes to the Displays > Menu Bar Item Spacing flow that together stop Thaw from breaking pre-existing user setups:

1. A confirmation alert in front of the Apply (and inline `↺` reset) buttons that doubles as a destructive-action warning for the relaunch wave and as the persistence channel that writes the new spacing into the active profile (or every profile) before the reapply pass fires.
2. A first-launch seed so that an externally configured `NSStatusItemSpacing` (set via `defaults write` in Terminal) is adopted as the implicit baseline instead of overwritten by Thaw's default of 0.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Issue Number: #598, #602, #619

With a profile active, dragging the Menu Bar Item Spacing slider for the active display and clicking Apply triggered a relaunch wave for all menu bar apps. Once the wave settled, `DisplaySettingsManager.applyActiveDisplaySpacing` called `ProfileManager.reapplyActiveProfile()`, which re-applied the active profile's stored `displayConfigurations`. Those still held the previous offset, so the just-applied value was silently overwritten, and a second relaunch wave fired to apply the reverted value. The Reset (`↺`) button next to Apply had the same problem because it also called `updateConfiguration` immediately. The user's documented workaround in #619 was to export the profile, delete it, change the setting, reimport, and re-save.

Separately, users who had set `NSStatusItemSpacing` (and/or `NSStatusItemSelectionPadding`) externally via `defaults write` saw Thaw fire a relaunch wave on every startup. `applyActiveDisplaySpacing` read the per-display default offset of 0, computed target = 16, found the on-disk value at e.g. 6, and rewrote it to 16, restarting every menu bar app in the process. The same wave fired again on screen-parameter changes (sleep/wake, monitor connect/disconnect, Sidecar handshake), giving the recurring app-restart symptom reported in #602 and #598.

## What is the new behavior?

**Confirmation gate in `DisplaySettingsPane`.** The Apply button and the inline `↺` reset button now route through a single `requestSpacingApply` helper. When the change targets the active menu bar display, an alert names the relaunch wave; when a profile is active, the alert offers `Update Active Profile` and `Update All Profiles` alongside Cancel.

- `Update Active Profile` calls `displaySettings.updateConfiguration` and then `profileManager.updateProfile(scope: .configurationOnly)` synchronously, so the profile file is on disk before the Combine sink dispatches `applyActiveDisplaySpacing`. The subsequent `reapplyActiveProfile` loads the new spacing instead of the old one.
- `Update All Profiles` calls a new `ProfileManager.updateAllProfilesItemSpacingOffset(displayUUID:offset:)` helper that walks every profile and writes the new offset into its `displayConfigurations[displayUUID]` via `withItemSpacingOffset`, inserting a `defaultConfiguration` entry where the profile has no prior entry for that display.
- With no active profile and a non-active display the change still applies immediately, preserving the prior fast path.
- Cancel snaps the slider draft back to the saved value.
- New `DisplaySettingsManager.activeMenuBarDisplayUUID` accessor wraps `Bridging.getActiveMenuBarDisplayUUID()` so the pane can decide whether a change targets the active display.

**First-launch seed in `DisplaySettingsManager.loadInitialState`.** When no per-display configurations have been persisted yet and `NSStatusItemSpacing` differs from the macOS default of 16, the manager reads the on-disk value, computes `offset = onDisk - 16`, and seeds every connected display's `itemSpacingOffset` with that offset. The seeded dictionary is written to `Defaults.displayIceBarConfigurations` inline (the Combine persistence sink is not wired yet at that point), so adoption is one-shot. The next time `applyActiveDisplaySpacing` runs, its target matches on-disk and the no-op guard skips the relaunch wave. `NSStatusItemSelectionPadding` is not consulted because Thaw drives both keys from a single offset; users whose padding diverges from spacing see one normalising relaunch on first launch and none thereafter.

New strings (`Apply spacing change?`, two profile-aware message variants, the relaunch-only message, `Update Active Profile`, `Update All Profiles`) are added to `Localizable.xcstrings` with empty localizations for Crowdin pickup.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

The confirmation-gate fix relies on a timing invariant: the Combine sink that drives `applyActiveDisplaySpacing` is `.receive(on: DispatchQueue.main).sink { ... }`, so it runs on the next main-runloop turn. The confirmation action calls `updateConfiguration` and then `updateProfile`/`updateAllProfilesItemSpacingOffset` synchronously on the main thread before yielding, which guarantees the profile file(s) are written before the sink fires and `reapplyActiveProfile` reads them back.

The seeding fix persists inline rather than relying on the standard Combine persistence sink, because the sink's `.dropFirst()` would discard the seeded emission since it is set up after `loadInitialState`. Without inline persistence the seed would re-run on every launch and never make it into `Defaults.displayIceBarConfigurations`.

Fixes #598, #602, #619

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a draft/confirm flow for menu bar item spacing changes with a confirmation dialog offering “Update Active Profile”, “Update All Profiles”, or apply to the current display.
  * Confirmation messages are dynamically localized and reflect active profile context.
  * App now detects and preserves existing system spacing on first launch.

* **Bug Fixes**
  * Improved error handling and rollback when profile updates fail, with user-facing error alerts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/621?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->