### PR TITLE
fix(menubar): suppress clicks when fullscreen menu bar items rest above the screen

### DIFF
--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -750,7 +750,8 @@ extension NSScreen {
     }
 
     /// Returns true when at least one menu bar status item is currently
-    /// rendered on-screen for the active space.
+    /// rendered on-screen for the active space and positioned within this
+    /// screen's vertical bounds.
     ///
     /// Returns false when the menu bar is auto-hidden behind a fullscreen app
     /// and not yet visually revealed. The menu bar window itself flips to
@@ -758,8 +759,23 @@ extension NSScreen {
     /// the status items become visible to the user; gating on the items list
     /// more closely matches the perceived reveal state, which is what click
     /// suppression needs.
+    ///
+    /// The bounds check is required on top of the `.onScreen` filter because
+    /// NSStatusItem windows in a fullscreen space can remain flagged as
+    /// on-screen by the Window Server while positioned above the screen's
+    /// top edge (the auto-hide resting position). Requiring at least one
+    /// item's bounds to intersect this screen's frame catches that case,
+    /// so a click at the top of a fullscreen app does not get treated as a
+    /// menu bar click while the menu bar is visually hidden.
     func isSystemMenuBarVisible() -> Bool {
-        !Bridging.getMenuBarWindowList(option: [.onScreen, .activeSpace, .itemsOnly]).isEmpty
+        let windowIDs = Bridging.getMenuBarWindowList(option: [.onScreen, .activeSpace, .itemsOnly])
+        let screenFrame = frame
+        return windowIDs.contains { windowID in
+            guard let bounds = Bridging.getWindowBounds(for: windowID) else {
+                return false
+            }
+            return bounds.intersects(screenFrame)
+        }
     }
 
     /// Returns the raw frame of the application menu on this screen, as


### PR DESCRIPTION
## What does this PR do?

Tightens `NSScreen.isSystemMenuBarVisible()` so it returns `false` not just when the Window Server reports zero on-screen menu bar items, but also when those items are flagged on-screen yet positioned above the screen's top edge (the auto-hide resting position used inside a fullscreen space). All three call sites — `HIDEventManager.handleShowOnClick`, `HIDEventManager.handleSecondaryContextMenu`, and `ControlItem.performAction` — pick up the stricter check automatically.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

While another app is in fullscreen with the system menu bar auto-hidden, clicking near the top of that app's window (e.g. the top edge of a Chrome tab) makes Thaw treat the click as a menu bar click and reveal the hidden section. The existing guard added in #574 only filters by the Window Server's `kCGWindowIsOnscreen` flag, but macOS keeps `NSStatusItem` windows flagged as on-screen even while they sit at the auto-hide resting position above the visible screen — so the guard lets the phantom click through.

Issue Number: N/A

## What is the new behavior?

`isSystemMenuBarVisible()` now additionally requires at least one item's reported bounds (`Bridging.getWindowBounds`) to intersect this `NSScreen`'s frame. While the menu bar is auto-hidden in fullscreen all items sit above the screen and the function returns `false`, so show-on-click, show-on-double-click, the secondary context menu, and `ControlItem.performAction` all stay quiet. Once the user hovers to reveal the menu bar the items slide into the screen frame and every existing behaviour resumes unchanged. The same bounds-vs-screen filter already lives in `MenuBarItemImageCache` for the exact same macOS quirk, so this stays consistent with established patterns in the codebase.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Test plan (manual, since the affected paths depend on the live Window Server and aren't covered by `ThawTests`):

1. Enable **Show on click** in Settings → General and ensure a hidden section is populated.
2. Open Chrome (or any app), enter fullscreen via the green button or `Ctrl+Cmd+F`, and **do not** hover at the top edge.
3. Click a tab at the very top of the Chrome window — Thaw must not reveal the hidden section. The diagnostic log shows `handleShowOnClick: suppressing, no menu bar items on-screen for active space`.
4. Hover the top edge until the menu bar fully reveals, then click empty space in the revealed menu bar — show-on-click works as before.
5. Exit fullscreen and confirm show-on-click in the regular menu bar is unchanged.

### Notes for reviewers

- Single change in `Thaw/Utilities/Extensions.swift`. The function signature is unchanged; only the body is stricter, so existing callers don't need updates.
- The `frame.intersects(bounds)` check mirrors `MenuBarItemImageCache.swift` (the comment there explicitly calls out the macOS bug where hidden items are reported as on-screen), so the coordinate-space approximation is the established pattern in this codebase rather than a new one.
- This is layered on top of #574, not a replacement — the on-screen filter still does the cheap first pass; the bounds check only matters when the Window Server lies about visibility.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system menu bar visibility detection accuracy to better reflect the actual state of the menu bar on screen.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/626?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->