### PR TITLE
Avoid persisting transitional always-hidden layout state

### DIFF
--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -48,7 +48,7 @@ final class ControlItem {
     }
 
     /// A hiding state for a control item.
-    enum HidingState {
+    enum HidingState: Equatable {
         case showSection
         case hideSection
     }
@@ -117,7 +117,14 @@ final class ControlItem {
     }
 
     /// The control item's hiding state (`@Published`).
-    @Published var state = HidingState.hideSection
+    @Published var state = HidingState.hideSection {
+        didSet {
+            guard oldValue != state, isSectionDivider else {
+                return
+            }
+            appState?.itemManager.recordSectionDividerTransition()
+        }
+    }
 
     /// The control item's window (`@Published`).
     @Published private(set) var window: NSWindow?
@@ -506,6 +513,9 @@ final class ControlItem {
             return
         }
         statusItem.isVisible = true
+        if isSectionDivider {
+            appState?.itemManager.recordSectionDividerTransition()
+        }
     }
 
     /// Removes the control item from the menu bar.
@@ -522,6 +532,9 @@ final class ControlItem {
         statusItem.isVisible = false
         if !isSectionDivider {
             ControlItemDefaults[.preferredPosition, autosaveName] = cached
+        }
+        if isSectionDivider {
+            appState?.itemManager.recordSectionDividerTransition()
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -868,13 +868,15 @@ enum LayoutSolver {
         isResettingLayout: Bool,
         isInStartupSettling: Bool,
         isApplyingProfileLayout: Bool,
-        temporarilyShownItemContextsIsEmpty: Bool
+        temporarilyShownItemContextsIsEmpty: Bool,
+        hasRecentSectionDividerTransition: Bool
     ) -> Bool {
         !isRestoringItemOrder &&
             !isResettingLayout &&
             !isInStartupSettling &&
             !isApplyingProfileLayout &&
-            temporarilyShownItemContextsIsEmpty
+            temporarilyShownItemContextsIsEmpty &&
+            !hasRecentSectionDividerTransition
     }
 
     // MARK: - Pending rehide identifiers

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -117,6 +117,11 @@ final class MenuBarItemManager: ObservableObject {
     /// giving macOS time to settle menu bar item positions.
     static let uiSettleDelay: Duration = .milliseconds(300)
 
+    /// Grace period after a hidden/always-hidden divider geometry change
+    /// during which cache snapshots are transitional and must not be
+    /// promoted into persisted layout state.
+    static let sectionDividerTransitionSettleDelay: Duration = .milliseconds(750)
+
     /// The current cache of menu bar items.
     @Published private(set) var itemCache = ItemCache(displayID: nil)
 
@@ -142,6 +147,9 @@ final class MenuBarItemManager: ObservableObject {
 
     /// Timestamp of the most recent menu bar item move operation.
     private var lastMoveOperationTimestamp: ContinuousClock.Instant?
+    /// Timestamp of the most recent hidden/always-hidden divider state or
+    /// visibility change.
+    private var lastSectionDividerTransitionTimestamp: ContinuousClock.Instant?
 
     /// Cached timeouts for move operations.
     private var moveOperationTimeouts = [MenuBarItemTag: Duration]()
@@ -197,6 +205,7 @@ final class MenuBarItemManager: ObservableObject {
     //      - isRestoringItemOrder (+ isRestoringItemOrderTimestamp)
     //      - isApplyingProfileLayout
     //      - suppressNextNewLeftmostItemRelocation
+    //      - lastSectionDividerTransitionTimestamp
     //
     // 2. Startup settling. Gates restore and saves during the cold-boot
     //    or post-permission-grant window when many apps appear at once:
@@ -1329,10 +1338,27 @@ final class MenuBarItemManager: ObservableObject {
         return timestamp.duration(to: .now) <= duration
     }
 
+    /// Returns a Boolean value that indicates whether a hidden/always-hidden
+    /// divider changed state recently enough that section classification may
+    /// still reflect a transitional layout.
+    func sectionDividerTransitionOccurred(within duration: Duration) -> Bool {
+        guard let timestamp = lastSectionDividerTransitionTimestamp else {
+            return false
+        }
+        return timestamp.duration(to: .now) <= duration
+    }
+
     /// Records that a move operation occurred outside of Thaw's own `move()` function
     /// (e.g. the user cmd+dragged an item directly on the menu bar).
     func recordExternalMoveOperation() {
         lastMoveOperationTimestamp = .now
+    }
+
+    /// Records that the hidden/always-hidden divider geometry changed
+    /// (show/hide, style/width change, or add/remove), so the next cache
+    /// snapshot should not be treated as stable saved layout state.
+    func recordSectionDividerTransition() {
+        lastSectionDividerTransitionTimestamp = .now
     }
 }
 
@@ -1755,12 +1781,16 @@ extension MenuBarItemManager {
             isRestoringItemOrderTimestamp = nil
         }
 
+        let hasRecentSectionDividerTransition = sectionDividerTransitionOccurred(
+            within: Self.sectionDividerTransitionSettleDelay
+        )
         if LayoutSolver.shouldPersistSavedOrder(
             isRestoringItemOrder: isRestoringItemOrder,
             isResettingLayout: isResettingLayout,
             isInStartupSettling: isInStartupSettling,
             isApplyingProfileLayout: isApplyingProfileLayout,
-            temporarilyShownItemContextsIsEmpty: temporarilyShownItemContexts.isEmpty
+            temporarilyShownItemContextsIsEmpty: temporarilyShownItemContexts.isEmpty,
+            hasRecentSectionDividerTransition: hasRecentSectionDividerTransition
         ) {
             // Don't persist if any items are in a transient blocked state (x=-1).
             // Wait for the next cache cycle when bounds are reliable.
@@ -1777,6 +1807,10 @@ extension MenuBarItemManager {
                     "Skipping saveSectionOrder; blocked items detected (x=-1), will retry on next cache tick"
                 )
             }
+        } else if hasRecentSectionDividerTransition {
+            MenuBarItemManager.diagLog.debug(
+                "Skipping saveSectionOrder; section divider transition grace period active"
+            )
         }
         MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
     }
@@ -6356,6 +6390,10 @@ extension MenuBarItemManager {
         // running; a concurrent savedOrder apply would fight it.
         guard !isApplyingProfileLayout else {
             MenuBarItemManager.diagLog.debug("applySavedLayout: skipping, profile apply in flight")
+            return false
+        }
+        guard !sectionDividerTransitionOccurred(within: Self.sectionDividerTransitionSettleDelay) else {
+            MenuBarItemManager.diagLog.debug("applySavedLayout: skipping, section divider transition grace period active")
             return false
         }
         // 5 s cooldown after a recent move (same value the legacy

--- a/ThawTests/ShouldPersistSavedOrderTests.swift
+++ b/ThawTests/ShouldPersistSavedOrderTests.swift
@@ -26,7 +26,8 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: false,
             isInStartupSettling: false,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
     }
 
@@ -39,7 +40,8 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: false,
             isInStartupSettling: false,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
     }
 
@@ -51,7 +53,8 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: true,
             isInStartupSettling: false,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
     }
 
@@ -64,7 +67,8 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: false,
             isInStartupSettling: true,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
     }
 
@@ -78,7 +82,8 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: false,
             isInStartupSettling: false,
             isApplyingProfileLayout: true,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
     }
 
@@ -94,7 +99,22 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: false,
             isInStartupSettling: false,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: false
+            temporarilyShownItemContextsIsEmpty: false,
+            hasRecentSectionDividerTransition: false
+        ))
+    }
+
+    /// Divider show/hide transitions briefly move the hidden and
+    /// always-hidden boundaries through item space. A cache snapshot in
+    /// that window is transitional UI state, not user intent.
+    func testRecentSectionDividerTransitionBlocks() {
+        XCTAssertFalse(LayoutSolver.shouldPersistSavedOrder(
+            isRestoringItemOrder: false,
+            isResettingLayout: false,
+            isInStartupSettling: false,
+            isApplyingProfileLayout: false,
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: true
         ))
     }
 
@@ -107,14 +127,24 @@ final class ShouldPersistSavedOrderTests: XCTestCase {
             isResettingLayout: true,
             isInStartupSettling: false,
             isApplyingProfileLayout: false,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
         ))
         XCTAssertFalse(LayoutSolver.shouldPersistSavedOrder(
             isRestoringItemOrder: false,
             isResettingLayout: false,
             isInStartupSettling: true,
             isApplyingProfileLayout: true,
-            temporarilyShownItemContextsIsEmpty: true
+            temporarilyShownItemContextsIsEmpty: true,
+            hasRecentSectionDividerTransition: false
+        ))
+        XCTAssertFalse(LayoutSolver.shouldPersistSavedOrder(
+            isRestoringItemOrder: false,
+            isResettingLayout: false,
+            isInStartupSettling: false,
+            isApplyingProfileLayout: false,
+            temporarilyShownItemContextsIsEmpty: false,
+            hasRecentSectionDividerTransition: true
         ))
     }
 }


### PR DESCRIPTION
## Summary
- avoid persisting saved layout snapshots while the hidden / always-hidden dividers are still transitioning
- block saved-layout reapply during the same divider-transition grace window
- add coverage for the new persistence gate behavior

## Bug
This bug is very subtle and still needs more real-world testing before we can know whether it is fully fixed.

Observed symptom:
- sometimes an icon gets moved into `always-hidden` for no obvious reason
- users experience it as icons being mysteriously or randomly pushed into the always-hidden section

Current hypothesis:
- a cache pass can observe the menu bar while the hidden / always-hidden control items are expanding or collapsing
- that transitional geometry can temporarily classify an item as `alwaysHidden`
- the transient classification then gets persisted into `savedSectionOrder`, and later layout restore applies it as if it were intentional

## Validation
- added a targeted unit test for the new section-divider transition persistence gate
- ran:
  - `xcodebuild test -quiet -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/thaw-codex-tests.577xm6 -only-testing:ThawTests/ShouldPersistSavedOrderTests CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''`

## Risk
- this is a defensive fix around persistence and restore timing, not a proof that the underlying race can never happen in another path
- because the symptom is intermittent and timing-sensitive, more manual / long-running testing is still needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar layout stability by preventing temporary state changes during menu section adjustments from being saved as persistent preferences.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->