### PR TITLE
fix(layout-bar): cross-section drag landing and false move alerts

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -235,8 +235,27 @@ final class LayoutBarPaddingView: NSView {
                 await stabilizePlacement(of: item, to: destination, expectedSection: container.section, appState: appState)
             } catch {
                 Self.diagLog.error("Error moving menu bar item: \(error)")
-                let alert = NSAlert(error: error)
-                alert.runModal()
+                // The system event-driven move sometimes throws cannotComplete
+                // after macOS has already settled the item into the requested
+                // slot: the click sequence bounces the item past the target
+                // and back during verification, but a subsequent reconciliation
+                // lands it where the user asked. Resample the cache after a
+                // short settle window and only show the alert when the item
+                // is NOT in the position the user actually dragged it to;
+                // showing it for a move that visibly worked is a false alarm.
+                try? await Task.sleep(for: .milliseconds(250))
+                await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                if didItemReachIntendedPosition(
+                    item: item,
+                    destination: destination,
+                    expectedSection: container.section,
+                    cache: appState.itemManager.itemCache
+                ) {
+                    Self.diagLog.info("Move verification failed but \(item.logString) reached intended position in \(container.section.logString); suppressing alert")
+                } else {
+                    let alert = NSAlert(error: error)
+                    alert.runModal()
+                }
             }
             watchdogTask.cancel()
             if let appState = container.appState {
@@ -267,6 +286,34 @@ final class LayoutBarPaddingView: NSView {
                     sourceContainer?.canSetArrangedViews = true
                 }
             }
+        }
+    }
+
+    /// Returns true when the dragged item is sitting in the slot the user
+    /// asked for: in the destination section, immediately adjacent to the
+    /// target on the requested side. For control-item targets (section
+    /// dividers) there is no array entry to anchor against, so containment
+    /// in the destination section is the strongest claim we can make.
+    private func didItemReachIntendedPosition(
+        item: MenuBarItem,
+        destination: MenuBarItemManager.MoveDestination,
+        expectedSection: MenuBarSection.Name,
+        cache: MenuBarItemManager.ItemCache
+    ) -> Bool {
+        let sectionItems = cache[expectedSection]
+        guard let itemIndex = sectionItems.firstIndex(where: { $0.tag == item.tag }) else {
+            return false
+        }
+        let target = destination.targetItem
+        if target.isControlItem {
+            return true
+        }
+        guard let targetIndex = sectionItems.firstIndex(where: { $0.tag == target.tag }) else {
+            return false
+        }
+        return switch destination {
+        case .leftOfItem: itemIndex + 1 == targetIndex
+        case .rightOfItem: itemIndex == targetIndex + 1
         }
     }
 

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -76,6 +76,12 @@ final class LayoutBarPaddingView: NSView {
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
         guard !isStabilizing else { return [] }
+        // Freeze the destination's arrangedViews so that the cache refresh
+        // triggered while the system move is in flight cannot overwrite the
+        // mid-drag visual state. updateNewItemsPlacement at the end of move()
+        // depends on that state to capture the badge's new neighbors; without
+        // this guard the dropped item bounces to the wrong side of the badge.
+        container.canSetArrangedViews = false
         return container.updateArrangedViewsForDrag(with: sender, phase: .entered)
     }
 
@@ -143,6 +149,7 @@ final class LayoutBarPaddingView: NSView {
         }
 
         var willMove = false
+        let sourceContainer = draggingSource.oldContainerInfo?.container
 
         if let index = arrangedViews.firstIndex(of: draggingSource) {
             if arrangedViews.count == 1 {
@@ -150,30 +157,33 @@ final class LayoutBarPaddingView: NSView {
                 Task {
                     guard case let .item(item) = draggingSource.kind else {
                         self.container.canSetArrangedViews = true
+                        sourceContainer?.canSetArrangedViews = true
                         return
                     }
                     if let destination = await self.liveFallbackDestinationForDraggedItem() {
-                        self.move(item: item, to: destination)
+                        self.move(item: item, to: destination, sourceContainer: sourceContainer)
                     } else {
                         Self.diagLog.error("No target item for layout bar drag")
                         self.container.canSetArrangedViews = true
+                        sourceContainer?.canSetArrangedViews = true
                     }
                 }
             } else if case let .item(item) = draggingSource.kind {
                 if let targetItem = nearestItem(toRightOf: index) {
                     willMove = true
-                    move(item: item, to: .leftOfItem(targetItem))
+                    move(item: item, to: .leftOfItem(targetItem), sourceContainer: sourceContainer)
                 } else if let targetItem = nearestItem(toLeftOf: index) {
                     willMove = true
-                    move(item: item, to: .rightOfItem(targetItem))
+                    move(item: item, to: .rightOfItem(targetItem), sourceContainer: sourceContainer)
                 } else if !arrangedViews.isEmpty {
                     willMove = true
                     Task {
                         if let destination = await self.liveFallbackDestinationForDraggedItem() {
-                            self.move(item: item, to: destination)
+                            self.move(item: item, to: destination, sourceContainer: sourceContainer)
                         } else {
                             Self.diagLog.error("No target item for layout bar drag")
                             self.container.canSetArrangedViews = true
+                            sourceContainer?.canSetArrangedViews = true
                         }
                     }
                 }
@@ -189,7 +199,11 @@ final class LayoutBarPaddingView: NSView {
         return true
     }
 
-    private func move(item: MenuBarItem, to destination: MenuBarItemManager.MoveDestination) {
+    private func move(
+        item: MenuBarItem,
+        to destination: MenuBarItemManager.MoveDestination,
+        sourceContainer: LayoutBarContainer? = nil
+    ) {
         guard let appState = container.appState else {
             return
         }
@@ -243,9 +257,15 @@ final class LayoutBarPaddingView: NSView {
                         arrangedViews: self.container.arrangedViews
                     )
                 }
-                // Re-enable view updates. The didSet will automatically refresh
-                // from the current cache with the updated badge anchor.
+                // Re-enable view updates on both the destination (frozen by
+                // draggingEntered) and the source (frozen by willBeginAt on
+                // the dragging session). Without resetting the source, its
+                // arrangedViews would stay frozen at the mid-drag snapshot
+                // until the next drag originated from that container.
                 self.container.canSetArrangedViews = true
+                if sourceContainer !== self.container {
+                    sourceContainer?.canSetArrangedViews = true
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Two related fixes for menu-bar item drags in the Layout settings pane: items no longer bounce to the wrong side of the New Items badge on a cross-section drop, and the "Operation could not be completed" alert no longer fires when the dragged item actually lands in the slot the user dropped it on.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the current behavior?

Two separate user-reported issues, both surfacing in the Layout settings pane.

1. Dragging an item from one section into another (for example hidden to visible) sometimes left the item on the opposite side of the New Items badge from where the user released it. The destination container's `canSetArrangedViews` stayed `true` for the duration of the system move, so the `CombineLatest3` sink in `LayoutBarContainer.configureCancellables` fired on the in-flight `itemCache` update and overwrote the mid-drag `arrangedViews` with a layout recomputed from the still-persisted badge anchor. `updateNewItemsPlacement` then read that stale post-refresh state, found the old anchor still as the badge's right neighbour, and never re-anchored, so the next refresh slotted the badge back onto the original side of the dropped item. Separately, source-container freezes were never reset after item drags (only after badge drags), so the section the user dragged FROM stayed pinned at the mid-drag snapshot until they originated another drag from it.

2. The system event-driven move occasionally threw `EventError.cannotComplete` even though macOS had settled the dragged item where the user asked. The click sequence bounced the item past the target and back during verification, `itemHasCorrectPosition` (which compares `itemBounds.maxX == targetBounds.minX` exactly, with no spacing tolerance) failed all 8 retries, and `LayoutBarPaddingView.move()` surfaced an `NSAlert` titled "Operation could not be completed" for a move the user could plainly see had worked.

Issue Number: N/A

## What is the new behavior?

1. `LayoutBarPaddingView.draggingEntered` now sets `container.canSetArrangedViews = false` so the destination's `arrangedViews` survives the mid-move cache refresh and `updateNewItemsPlacement` reads the user's intended layout. A `sourceContainer` argument is plumbed through `move()` so the source container's `canSetArrangedViews` (set to `false` by `LayoutBarArrangedView.draggingSession(_:willBeginAt:)`) gets reset alongside the destination's flag when the move task finishes.

2. The `catch` block in `LayoutBarPaddingView.move()` sleeps 250 ms to let macOS finish settling, refreshes the cache, then consults a new `didItemReachIntendedPosition` helper before showing the alert. The helper looks up the dragged item in the destination section's cache array and confirms it sits at exactly `targetIndex - 1` for `.leftOfItem` or `targetIndex + 1` for `.rightOfItem`; any other landing (item still in the source section, or in the destination section but not adjacent to the target) still raises the alert. Control-item targets (section dividers, only hit by the `arrangedViews.count == 1` fallback) are special-cased: dividers aren't stored as cache array entries so adjacency cannot be computed, and section containment is treated as proof the move took effect.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved drag-and-drop stability by preventing visual conflicts during item movement.
  * Enhanced error recovery when items land in ambiguous positions; suppresses unnecessary alerts if reconciliation succeeds.
  * Fixed placement verification so items are confirmed to reach their intended positions after dragging.

* **Improvements**
  * Better tracking of drag origin to ensure more reliable moves between containers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/644?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->