### PR TITLE
feat(search): reorder and filter sections in the search panel

### DIFF
--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -13,7 +13,7 @@ import SwiftUI
 @MainActor
 final class MenuBarSection {
     /// The name of a menu bar section.
-    enum Name: CaseIterable {
+    enum Name: String, CaseIterable, Codable {
         case visible
         case hidden
         case alwaysHidden

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -484,27 +484,19 @@ private struct MenuBarSearchContentView: View {
             }
             .onChange(of: appState.settings.advanced.searchSectionOrder) {
                 updateDisplayedItems()
-                if model.selection == nil {
-                    selectFirstDisplayedItem()
-                }
+                ensureValidSelection()
             }
             .onChange(of: appState.settings.advanced.searchIncludeVisible) {
                 updateDisplayedItems()
-                if model.selection == nil {
-                    selectFirstDisplayedItem()
-                }
+                ensureValidSelection()
             }
             .onChange(of: appState.settings.advanced.searchIncludeHidden) {
                 updateDisplayedItems()
-                if model.selection == nil {
-                    selectFirstDisplayedItem()
-                }
+                ensureValidSelection()
             }
             .onChange(of: appState.settings.advanced.searchIncludeAlwaysHidden) {
                 updateDisplayedItems()
-                if model.selection == nil {
-                    selectFirstDisplayedItem()
-                }
+                ensureValidSelection()
             }
     }
 
@@ -626,6 +618,18 @@ private struct MenuBarSearchContentView: View {
             return
         }
         model.selection = model.displayedItems.first { $0.isSelectable }?.id
+    }
+
+    /// Re-selects the first item when the current selection has been
+    /// filtered out of `displayedItems` (or was never set).
+    private func ensureValidSelection() {
+        guard let selection = model.selection else {
+            selectFirstDisplayedItem()
+            return
+        }
+        if !model.displayedItems.contains(where: { $0.id == selection }) {
+            selectFirstDisplayedItem()
+        }
     }
 
     private func updateDisplayedItems() {

--- a/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
+++ b/Thaw/MenuBar/Search/MenuBarSearchPanel.swift
@@ -430,6 +430,7 @@ private final class MenuBarSearchHostingView: NSHostingView<AnyView> {
 private struct MenuBarSearchContentView: View {
     private typealias ListItem = SectionedListItem<MenuBarSearchModel.ItemID>
 
+    @EnvironmentObject var appState: AppState
     @EnvironmentObject var itemManager: MenuBarItemManager
     @EnvironmentObject var imageCache: MenuBarItemImageCache
     @EnvironmentObject var model: MenuBarSearchModel
@@ -476,6 +477,30 @@ private struct MenuBarSearchContentView: View {
                 selectFirstDisplayedItem()
             }
             .onChange(of: itemManager.itemCache, initial: true) {
+                updateDisplayedItems()
+                if model.selection == nil {
+                    selectFirstDisplayedItem()
+                }
+            }
+            .onChange(of: appState.settings.advanced.searchSectionOrder) {
+                updateDisplayedItems()
+                if model.selection == nil {
+                    selectFirstDisplayedItem()
+                }
+            }
+            .onChange(of: appState.settings.advanced.searchIncludeVisible) {
+                updateDisplayedItems()
+                if model.selection == nil {
+                    selectFirstDisplayedItem()
+                }
+            }
+            .onChange(of: appState.settings.advanced.searchIncludeHidden) {
+                updateDisplayedItems()
+                if model.selection == nil {
+                    selectFirstDisplayedItem()
+                }
+            }
+            .onChange(of: appState.settings.advanced.searchIncludeAlwaysHidden) {
                 updateDisplayedItems()
                 if model.selection == nil {
                     selectFirstDisplayedItem()
@@ -596,6 +621,10 @@ private struct MenuBarSearchContentView: View {
     }
 
     private func selectFirstDisplayedItem() {
+        guard !model.displayedItems.isEmpty else {
+            model.selection = nil
+            return
+        }
         model.selection = model.displayedItems.first { $0.isSelectable }?.id
     }
 
@@ -610,8 +639,21 @@ private struct MenuBarSearchContentView: View {
         }
         typealias ScoredItem = (listItem: ListItem, score: Double)
 
-        let searchItems: [SearchItem] = MenuBarSection.Name.allCases
+        let advanced = itemManager.appState?.settings.advanced
+        let orderedNames: [MenuBarSection.Name] = advanced?.searchSectionOrder ?? Array(MenuBarSection.Name.allCases)
+
+        let searchItems: [SearchItem] = orderedNames
             .reduce(into: []) { items, name in
+                let included: Bool = {
+                    guard let advanced else { return true }
+                    switch name {
+                    case .visible: return advanced.searchIncludeVisible
+                    case .hidden: return advanced.searchIncludeHidden
+                    case .alwaysHidden: return advanced.searchIncludeAlwaysHidden
+                    }
+                }()
+                guard included else { return }
+
                 if
                     let appState = itemManager.appState,
                     let section = appState.menuBarManager.section(

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -9694,6 +9694,9 @@
         }
       }
     },
+    "Choose which menu bar sections appear in the search panel, and in what order. Use the up and down buttons to reorder, and turn off a section to exclude its items from search results." : {
+      "comment" : "Description for the Search section in the Advanced settings pane that controls which menu bar sections appear in the menu bar search panel and in what order."
+    },
     "Clear" : {
       "comment" : "A glass style that is clear.",
       "localizations" : {
@@ -25170,6 +25173,9 @@
         }
       }
     },
+    "Move down" : {
+      "comment" : "Accessibility label for the down-chevron button that reorders a row to a lower position in a list."
+    },
     "Move menu bar items from the visible section into the hidden section when they don't fit beside the notch on a notched display. Disable to keep the saved profile layout exactly as authored even when items would otherwise be pushed under the notch." : {
       "comment" : "A tooltip that describes the effect of enabling or disabling the overflow.",
       "localizations" : {
@@ -25407,6 +25413,9 @@
           }
         }
       }
+    },
+    "Move up" : {
+      "comment" : "Accessibility label for the up-chevron button that reorders a row to a higher position in a list."
     },
     "Never" : {
       "comment" : "Text displayed in the \"Last update check\" section of the about settings pane, indicating that the last update check date is unknown.",
@@ -33380,6 +33389,9 @@
           }
         }
       }
+    },
+    "Search" : {
+      "comment" : "The header of the Search section in the Advanced settings pane."
     },
     "Search menu bar items" : {
       "comment" : "A description of an action that searches menu bar items.",

--- a/Thaw/Settings/Models/AdvancedSettings.swift
+++ b/Thaw/Settings/Models/AdvancedSettings.swift
@@ -64,6 +64,22 @@ final class AdvancedSettings: ObservableObject {
     /// Only affects notched displays; non-notched displays never use this path.
     @Published var enableMenuBarItemOverflow = Defaults.DefaultValue.enableMenuBarItemOverflow
 
+    /// The order in which menu bar sections appear in the search panel.
+    @Published var searchSectionOrder: [MenuBarSection.Name] = Defaults.DefaultValue.searchSectionOrder
+        .compactMap(MenuBarSection.Name.init(rawValue:))
+
+    /// A Boolean value that indicates whether items from the visible section
+    /// are included in the menu bar search panel.
+    @Published var searchIncludeVisible = Defaults.DefaultValue.searchIncludeVisible
+
+    /// A Boolean value that indicates whether items from the hidden section
+    /// are included in the menu bar search panel.
+    @Published var searchIncludeHidden = Defaults.DefaultValue.searchIncludeHidden
+
+    /// A Boolean value that indicates whether items from the always-hidden section
+    /// are included in the menu bar search panel.
+    @Published var searchIncludeAlwaysHidden = Defaults.DefaultValue.searchIncludeAlwaysHidden
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -93,12 +109,39 @@ final class AdvancedSettings: ObservableObject {
         Defaults.ifPresent(key: .enableDiagnosticLogging, assign: &enableDiagnosticLogging)
         Defaults.ifPresent(key: .useLCSSortingOnNotchedDisplays, assign: &useLCSSortingOnNotchedDisplays)
         Defaults.ifPresent(key: .enableMenuBarItemOverflow, assign: &enableMenuBarItemOverflow)
+        Defaults.ifPresent(key: .searchIncludeVisible, assign: &searchIncludeVisible)
+        Defaults.ifPresent(key: .searchIncludeHidden, assign: &searchIncludeHidden)
+        Defaults.ifPresent(key: .searchIncludeAlwaysHidden, assign: &searchIncludeAlwaysHidden)
 
         Defaults.ifPresent(key: .sectionDividerStyle) { rawValue in
             if let style = SectionDividerStyle(rawValue: rawValue) {
                 sectionDividerStyle = style
             }
         }
+
+        Defaults.ifPresent(key: .searchSectionOrder) { (rawValues: [String]) in
+            searchSectionOrder = Self.sanitizedSearchSectionOrder(from: rawValues)
+        }
+    }
+
+    /// Returns a search-section order that contains each `MenuBarSection.Name`
+    /// case exactly once, using the supplied raw values as the preferred order
+    /// and filling any missing cases at the end. Returns the default order if
+    /// the input is unusable.
+    static func sanitizedSearchSectionOrder(from rawValues: [String]) -> [MenuBarSection.Name] {
+        var seen = Set<MenuBarSection.Name>()
+        var ordered: [MenuBarSection.Name] = []
+        for raw in rawValues {
+            guard let name = MenuBarSection.Name(rawValue: raw), !seen.contains(name) else {
+                continue
+            }
+            ordered.append(name)
+            seen.insert(name)
+        }
+        for name in MenuBarSection.Name.allCases where !seen.contains(name) {
+            ordered.append(name)
+        }
+        return ordered
     }
 
     /// Configures the internal observers for the model.
@@ -132,6 +175,14 @@ final class AdvancedSettings: ObservableObject {
         )
         $useLCSSortingOnNotchedDisplays.persistToDefaults(key: .useLCSSortingOnNotchedDisplays, in: &c)
         $enableMenuBarItemOverflow.persistToDefaults(key: .enableMenuBarItemOverflow, in: &c)
+        $searchSectionOrder.persistToDefaults(
+            key: .searchSectionOrder,
+            transform: { $0.map(\.rawValue) },
+            in: &c
+        )
+        $searchIncludeVisible.persistToDefaults(key: .searchIncludeVisible, in: &c)
+        $searchIncludeHidden.persistToDefaults(key: .searchIncludeHidden, in: &c)
+        $searchIncludeAlwaysHidden.persistToDefaults(key: .searchIncludeAlwaysHidden, in: &c)
 
         // Observe external settings changes via Settings URI
         NotificationCenter.default
@@ -176,6 +227,12 @@ final class AdvancedSettings: ObservableObject {
                 useLCSSortingOnNotchedDisplays = boolValue
             case "enableMenuBarItemOverflow":
                 enableMenuBarItemOverflow = boolValue
+            case "searchIncludeVisible":
+                searchIncludeVisible = boolValue
+            case "searchIncludeHidden":
+                searchIncludeHidden = boolValue
+            case "searchIncludeAlwaysHidden":
+                searchIncludeAlwaysHidden = boolValue
             default:
                 // Key not handled by AdvancedSettings
                 break

--- a/Thaw/Settings/Models/Profile.swift
+++ b/Thaw/Settings/Models/Profile.swift
@@ -104,6 +104,10 @@ struct AdvancedSettingsSnapshot: Codable {
     var useOptionClickToShowAlwaysHiddenSection: Bool
     var useLCSSortingOnNotchedDisplays: Bool
     var enableMenuBarItemOverflow: Bool
+    var searchSectionOrder: [String]
+    var searchIncludeVisible: Bool
+    var searchIncludeHidden: Bool
+    var searchIncludeAlwaysHidden: Bool
 
     @MainActor
     static func capture(from settings: AdvancedSettings) -> AdvancedSettingsSnapshot {
@@ -122,7 +126,11 @@ struct AdvancedSettingsSnapshot: Codable {
             useDoubleClickToShowAlwaysHiddenSection: settings.useDoubleClickToShowAlwaysHiddenSection,
             useOptionClickToShowAlwaysHiddenSection: settings.useOptionClickToShowAlwaysHiddenSection,
             useLCSSortingOnNotchedDisplays: settings.useLCSSortingOnNotchedDisplays,
-            enableMenuBarItemOverflow: settings.enableMenuBarItemOverflow
+            enableMenuBarItemOverflow: settings.enableMenuBarItemOverflow,
+            searchSectionOrder: settings.searchSectionOrder.map(\.rawValue),
+            searchIncludeVisible: settings.searchIncludeVisible,
+            searchIncludeHidden: settings.searchIncludeHidden,
+            searchIncludeAlwaysHidden: settings.searchIncludeAlwaysHidden
         )
     }
 
@@ -145,6 +153,10 @@ struct AdvancedSettingsSnapshot: Codable {
         settings.useOptionClickToShowAlwaysHiddenSection = useOptionClickToShowAlwaysHiddenSection
         settings.useLCSSortingOnNotchedDisplays = useLCSSortingOnNotchedDisplays
         settings.enableMenuBarItemOverflow = enableMenuBarItemOverflow
+        settings.searchSectionOrder = AdvancedSettings.sanitizedSearchSectionOrder(from: searchSectionOrder)
+        settings.searchIncludeVisible = searchIncludeVisible
+        settings.searchIncludeHidden = searchIncludeHidden
+        settings.searchIncludeAlwaysHidden = searchIncludeAlwaysHidden
     }
 
     enum CodingKeys: String, CodingKey {
@@ -163,6 +175,10 @@ struct AdvancedSettingsSnapshot: Codable {
         case useOptionClickToShowAlwaysHiddenSection
         case useLCSSortingOnNotchedDisplays
         case enableMenuBarItemOverflow
+        case searchSectionOrder
+        case searchIncludeVisible
+        case searchIncludeHidden
+        case searchIncludeAlwaysHidden
     }
 
     init(
@@ -180,7 +196,11 @@ struct AdvancedSettingsSnapshot: Codable {
         useDoubleClickToShowAlwaysHiddenSection: Bool,
         useOptionClickToShowAlwaysHiddenSection: Bool,
         useLCSSortingOnNotchedDisplays: Bool,
-        enableMenuBarItemOverflow: Bool
+        enableMenuBarItemOverflow: Bool,
+        searchSectionOrder: [String],
+        searchIncludeVisible: Bool,
+        searchIncludeHidden: Bool,
+        searchIncludeAlwaysHidden: Bool
     ) {
         self.enableAlwaysHiddenSection = enableAlwaysHiddenSection
         self.showAllSectionsOnUserDrag = showAllSectionsOnUserDrag
@@ -197,6 +217,10 @@ struct AdvancedSettingsSnapshot: Codable {
         self.useOptionClickToShowAlwaysHiddenSection = useOptionClickToShowAlwaysHiddenSection
         self.useLCSSortingOnNotchedDisplays = useLCSSortingOnNotchedDisplays
         self.enableMenuBarItemOverflow = enableMenuBarItemOverflow
+        self.searchSectionOrder = searchSectionOrder
+        self.searchIncludeVisible = searchIncludeVisible
+        self.searchIncludeHidden = searchIncludeHidden
+        self.searchIncludeAlwaysHidden = searchIncludeAlwaysHidden
     }
 
     init(from decoder: Decoder) throws {
@@ -246,6 +270,18 @@ struct AdvancedSettingsSnapshot: Codable {
         enableMenuBarItemOverflow = try container.decodeIfPresent(
             Bool.self, forKey: .enableMenuBarItemOverflow
         ) ?? Defaults.DefaultValue.enableMenuBarItemOverflow
+        searchSectionOrder = try container.decodeIfPresent(
+            [String].self, forKey: .searchSectionOrder
+        ) ?? Defaults.DefaultValue.searchSectionOrder
+        searchIncludeVisible = try container.decodeIfPresent(
+            Bool.self, forKey: .searchIncludeVisible
+        ) ?? Defaults.DefaultValue.searchIncludeVisible
+        searchIncludeHidden = try container.decodeIfPresent(
+            Bool.self, forKey: .searchIncludeHidden
+        ) ?? Defaults.DefaultValue.searchIncludeHidden
+        searchIncludeAlwaysHidden = try container.decodeIfPresent(
+            Bool.self, forKey: .searchIncludeAlwaysHidden
+        ) ?? Defaults.DefaultValue.searchIncludeAlwaysHidden
     }
 }
 
@@ -426,7 +462,11 @@ struct Profile: Codable, Identifiable {
             useDoubleClickToShowAlwaysHiddenSection: Defaults.DefaultValue.useDoubleClickToShowAlwaysHiddenSection,
             useOptionClickToShowAlwaysHiddenSection: Defaults.DefaultValue.useOptionClickToShowAlwaysHiddenSection,
             useLCSSortingOnNotchedDisplays: Defaults.DefaultValue.useLCSSortingOnNotchedDisplays,
-            enableMenuBarItemOverflow: Defaults.DefaultValue.enableMenuBarItemOverflow
+            enableMenuBarItemOverflow: Defaults.DefaultValue.enableMenuBarItemOverflow,
+            searchSectionOrder: Defaults.DefaultValue.searchSectionOrder,
+            searchIncludeVisible: Defaults.DefaultValue.searchIncludeVisible,
+            searchIncludeHidden: Defaults.DefaultValue.searchIncludeHidden,
+            searchIncludeAlwaysHidden: Defaults.DefaultValue.searchIncludeAlwaysHidden
         )
 
         hotkeys = try container.decodeIfPresent(

--- a/Thaw/Settings/Models/SettingsResetter.swift
+++ b/Thaw/Settings/Models/SettingsResetter.swift
@@ -58,6 +58,12 @@ extension AppSettings {
         advanced.showMenuBarTooltips = Defaults.DefaultValue.showMenuBarTooltips
         advanced.iconRefreshInterval = Defaults.DefaultValue.iconRefreshInterval
         advanced.enableDiagnosticLogging = Defaults.DefaultValue.enableDiagnosticLogging
+        advanced.searchSectionOrder = AdvancedSettings.sanitizedSearchSectionOrder(
+            from: Defaults.DefaultValue.searchSectionOrder
+        )
+        advanced.searchIncludeVisible = Defaults.DefaultValue.searchIncludeVisible
+        advanced.searchIncludeHidden = Defaults.DefaultValue.searchIncludeHidden
+        advanced.searchIncludeAlwaysHidden = Defaults.DefaultValue.searchIncludeAlwaysHidden
     }
 
     /// Resets Hotkeys settings to their default values.

--- a/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -48,6 +48,9 @@ struct AdvancedSettingsPane: View {
                 showAllSectionsOnUserDrag
                 sectionDividerStyle
             }
+            IceSection("Search") {
+                searchSectionOrdering
+            }
             IceSection("Tooltips") {
                 if ScreenCapture.cachedCheckPermissions() {
                     showMenuBarTooltips
@@ -147,6 +150,87 @@ struct AdvancedSettingsPane: View {
                 Text(style.localized).tag(style)
             }
         }
+    }
+
+    private var displayedSearchSectionNames: [MenuBarSection.Name] {
+        settings.searchSectionOrder.filter { name in
+            name != .alwaysHidden || settings.enableAlwaysHiddenSection
+        }
+    }
+
+    private var searchSectionOrdering: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(displayedSearchSectionNames, id: \.self) { name in
+                searchSectionRow(for: name)
+            }
+        }
+        .animation(.default, value: settings.searchSectionOrder)
+        .animation(.default, value: settings.enableAlwaysHiddenSection)
+        .annotation("Choose which menu bar sections appear in the search panel, and in what order. Use the up and down buttons to reorder, and turn off a section to exclude its items from search results.")
+    }
+
+    @ViewBuilder
+    private func searchSectionRow(for name: MenuBarSection.Name) -> some View {
+        let displayed = displayedSearchSectionNames
+        let position = displayed.firstIndex(of: name) ?? 0
+        let isFirst = position == 0
+        let isLast = position == displayed.count - 1
+        HStack(spacing: 8) {
+            Text(name.localized)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            Button {
+                moveSearchSection(name, by: -1)
+            } label: {
+                Image(systemName: "chevron.up")
+            }
+            .buttonStyle(.borderless)
+            .disabled(isFirst)
+            .accessibilityLabel(String(localized: "Move up"))
+            Button {
+                moveSearchSection(name, by: 1)
+            } label: {
+                Image(systemName: "chevron.down")
+            }
+            .buttonStyle(.borderless)
+            .disabled(isLast)
+            .accessibilityLabel(String(localized: "Move down"))
+            Toggle("", isOn: searchInclusionBinding(for: name))
+                .labelsHidden()
+        }
+    }
+
+    private func searchInclusionBinding(for name: MenuBarSection.Name) -> Binding<Bool> {
+        switch name {
+        case .visible:
+            return $settings.searchIncludeVisible
+        case .hidden:
+            return $settings.searchIncludeHidden
+        case .alwaysHidden:
+            return $settings.searchIncludeAlwaysHidden
+        }
+    }
+
+    private func moveSearchSection(_ name: MenuBarSection.Name, by offset: Int) {
+        // Swap by the user-visible neighbour so the move is predictable when
+        // the always-hidden row is conditionally hidden from this list.
+        let displayed = displayedSearchSectionNames
+        guard let displayIndex = displayed.firstIndex(of: name) else {
+            return
+        }
+        let displayTarget = displayIndex + offset
+        guard displayed.indices.contains(displayTarget) else {
+            return
+        }
+        let other = displayed[displayTarget]
+        guard
+            let index = settings.searchSectionOrder.firstIndex(of: name),
+            let otherIndex = settings.searchSectionOrder.firstIndex(of: other)
+        else {
+            return
+        }
+        var order = settings.searchSectionOrder
+        order.swapAt(index, otherIndex)
+        settings.searchSectionOrder = order
     }
 
     private var enableMenuBarItemOverflow: some View {

--- a/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -194,7 +194,7 @@ struct AdvancedSettingsPane: View {
             .buttonStyle(.borderless)
             .disabled(isLast)
             .accessibilityLabel(String(localized: "Move down"))
-            Toggle("", isOn: searchInclusionBinding(for: name))
+            Toggle(name.localized, isOn: searchInclusionBinding(for: name))
                 .labelsHidden()
         }
     }

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -185,6 +185,10 @@ extension Defaults {
         // MARK: Search
 
         static let rememberSearchQuery = false
+        static let searchSectionOrder: [String] = ["visible", "hidden", "alwaysHidden"]
+        static let searchIncludeVisible = true
+        static let searchIncludeHidden = true
+        static let searchIncludeAlwaysHidden = true
 
         // MARK: Hotkeys Settings
 
@@ -249,6 +253,10 @@ extension Defaults {
         // MARK: Search
 
         case rememberSearchQuery = "RememberSearchQuery"
+        case searchSectionOrder = "SearchSectionOrder"
+        case searchIncludeVisible = "SearchIncludeVisible"
+        case searchIncludeHidden = "SearchIncludeHidden"
+        case searchIncludeAlwaysHidden = "SearchIncludeAlwaysHidden"
 
         // MARK: Internal
 

--- a/Thaw/Utilities/SettingsURIHandler.swift
+++ b/Thaw/Utilities/SettingsURIHandler.swift
@@ -37,6 +37,9 @@ enum SettingsURIHandler {
         "iceBarLocationOnHotkey",
         "useLCSSortingOnNotchedDisplays",
         "enableMenuBarItemOverflow",
+        "searchIncludeVisible",
+        "searchIncludeHidden",
+        "searchIncludeAlwaysHidden",
     ]
 
     /// Double/numeric settings with ranges
@@ -82,6 +85,9 @@ enum SettingsURIHandler {
         "iceBarLocationOnHotkey": .iceBarLocationOnHotkey,
         "useLCSSortingOnNotchedDisplays": .useLCSSortingOnNotchedDisplays,
         "enableMenuBarItemOverflow": .enableMenuBarItemOverflow,
+        "searchIncludeVisible": .searchIncludeVisible,
+        "searchIncludeHidden": .searchIncludeHidden,
+        "searchIncludeAlwaysHidden": .searchIncludeAlwaysHidden,
         "rehideInterval": .rehideInterval,
         "showOnHoverDelay": .showOnHoverDelay,
         "tooltipDelay": .tooltipDelay,

--- a/ThawTests/AdvancedSettingsSnapshotTests.swift
+++ b/ThawTests/AdvancedSettingsSnapshotTests.swift
@@ -43,7 +43,11 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
             useDoubleClickToShowAlwaysHiddenSection: false,
             useOptionClickToShowAlwaysHiddenSection: false,
             useLCSSortingOnNotchedDisplays: false,
-            enableMenuBarItemOverflow: false
+            enableMenuBarItemOverflow: false,
+            searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+            searchIncludeVisible: true,
+            searchIncludeHidden: true,
+            searchIncludeAlwaysHidden: true
         )
     }
 
@@ -63,7 +67,11 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
             useDoubleClickToShowAlwaysHiddenSection: true,
             useOptionClickToShowAlwaysHiddenSection: true,
             useLCSSortingOnNotchedDisplays: true,
-            enableMenuBarItemOverflow: true
+            enableMenuBarItemOverflow: true,
+            searchSectionOrder: ["alwaysHidden", "hidden", "visible"],
+            searchIncludeVisible: false,
+            searchIncludeHidden: true,
+            searchIncludeAlwaysHidden: false
         )
     }
 
@@ -303,7 +311,11 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
             useDoubleClickToShowAlwaysHiddenSection: false,
             useOptionClickToShowAlwaysHiddenSection: false,
             useLCSSortingOnNotchedDisplays: false,
-            enableMenuBarItemOverflow: false
+            enableMenuBarItemOverflow: false,
+            searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+            searchIncludeVisible: false,
+            searchIncludeHidden: false,
+            searchIncludeAlwaysHidden: false
         )
 
         let data = try encoder.encode(snapshot)
@@ -317,6 +329,9 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
         XCTAssertFalse(decoded.showMenuBarTooltips)
         XCTAssertFalse(decoded.enableDiagnosticLogging)
         XCTAssertFalse(decoded.useDoubleClickToShowAlwaysHiddenSection)
+        XCTAssertFalse(decoded.searchIncludeVisible)
+        XCTAssertFalse(decoded.searchIncludeHidden)
+        XCTAssertFalse(decoded.searchIncludeAlwaysHidden)
     }
 
     func testAllBooleansTrue() throws {
@@ -335,7 +350,11 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
             useDoubleClickToShowAlwaysHiddenSection: true,
             useOptionClickToShowAlwaysHiddenSection: true,
             useLCSSortingOnNotchedDisplays: true,
-            enableMenuBarItemOverflow: true
+            enableMenuBarItemOverflow: true,
+            searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+            searchIncludeVisible: true,
+            searchIncludeHidden: true,
+            searchIncludeAlwaysHidden: true
         )
 
         let data = try encoder.encode(snapshot)
@@ -349,5 +368,49 @@ final class AdvancedSettingsSnapshotTests: XCTestCase {
         XCTAssertTrue(decoded.showMenuBarTooltips)
         XCTAssertTrue(decoded.enableDiagnosticLogging)
         XCTAssertTrue(decoded.useDoubleClickToShowAlwaysHiddenSection)
+        XCTAssertTrue(decoded.searchIncludeVisible)
+        XCTAssertTrue(decoded.searchIncludeHidden)
+        XCTAssertTrue(decoded.searchIncludeAlwaysHidden)
+    }
+
+    // MARK: - Search Section Ordering
+
+    func testSearchSectionOrderRoundTrip() throws {
+        var snapshot = makeDefaultSnapshot()
+        snapshot.searchSectionOrder = ["alwaysHidden", "hidden", "visible"]
+        snapshot.searchIncludeVisible = false
+
+        let data = try encoder.encode(snapshot)
+        let decoded = try decoder.decode(AdvancedSettingsSnapshot.self, from: data)
+
+        XCTAssertEqual(decoded.searchSectionOrder, ["alwaysHidden", "hidden", "visible"])
+        XCTAssertFalse(decoded.searchIncludeVisible)
+        XCTAssertTrue(decoded.searchIncludeHidden)
+        XCTAssertTrue(decoded.searchIncludeAlwaysHidden)
+    }
+
+    func testDecodeProfileMissingSearchKeysFallsBackToDefaults() throws {
+        // Simulates a profile saved before the search-ordering fields were added.
+        let json = """
+        {
+            "enableAlwaysHiddenSection": true,
+            "showAllSectionsOnUserDrag": false,
+            "sectionDividerStyle": 0,
+            "hideApplicationMenus": true,
+            "enableSecondaryContextMenu": true,
+            "showOnHoverDelay": 0.2,
+            "tooltipDelay": 1.0,
+            "showMenuBarTooltips": false,
+            "iconRefreshInterval": 3.0,
+            "enableDiagnosticLogging": false
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try decoder.decode(AdvancedSettingsSnapshot.self, from: json)
+
+        XCTAssertEqual(decoded.searchSectionOrder, Defaults.DefaultValue.searchSectionOrder)
+        XCTAssertEqual(decoded.searchIncludeVisible, Defaults.DefaultValue.searchIncludeVisible)
+        XCTAssertEqual(decoded.searchIncludeHidden, Defaults.DefaultValue.searchIncludeHidden)
+        XCTAssertEqual(decoded.searchIncludeAlwaysHidden, Defaults.DefaultValue.searchIncludeAlwaysHidden)
     }
 }

--- a/ThawTests/ProfileExportBundleTests.swift
+++ b/ThawTests/ProfileExportBundleTests.swift
@@ -63,7 +63,11 @@ final class ProfileExportBundleTests: XCTestCase {
                 useDoubleClickToShowAlwaysHiddenSection: false,
                 useOptionClickToShowAlwaysHiddenSection: false,
                 useLCSSortingOnNotchedDisplays: false,
-                enableMenuBarItemOverflow: false
+                enableMenuBarItemOverflow: false,
+                searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+                searchIncludeVisible: true,
+                searchIncludeHidden: true,
+                searchIncludeAlwaysHidden: true
             ),
             hotkeys: [:],
             displayConfigurations: [:],

--- a/ThawTests/ProfileTests.swift
+++ b/ThawTests/ProfileTests.swift
@@ -269,7 +269,11 @@ final class ProfileFullTests: XCTestCase {
                 useDoubleClickToShowAlwaysHiddenSection: false,
                 useOptionClickToShowAlwaysHiddenSection: false,
                 useLCSSortingOnNotchedDisplays: false,
-                enableMenuBarItemOverflow: false
+                enableMenuBarItemOverflow: false,
+                searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+                searchIncludeVisible: true,
+                searchIncludeHidden: true,
+                searchIncludeAlwaysHidden: true
             ),
             hotkeys: [:],
             displayConfigurations: [:],
@@ -482,7 +486,11 @@ final class ProfileContentTests: XCTestCase {
             useDoubleClickToShowAlwaysHiddenSection: false,
             useOptionClickToShowAlwaysHiddenSection: false,
             useLCSSortingOnNotchedDisplays: false,
-            enableMenuBarItemOverflow: false
+            enableMenuBarItemOverflow: false,
+            searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+            searchIncludeVisible: true,
+            searchIncludeHidden: true,
+            searchIncludeAlwaysHidden: true
         )
 
         let content = ProfileContent(
@@ -539,7 +547,11 @@ final class ProfileContentTests: XCTestCase {
                 useDoubleClickToShowAlwaysHiddenSection: false,
                 useOptionClickToShowAlwaysHiddenSection: false,
                 useLCSSortingOnNotchedDisplays: false,
-                enableMenuBarItemOverflow: false
+                enableMenuBarItemOverflow: false,
+                searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+                searchIncludeVisible: true,
+                searchIncludeHidden: true,
+                searchIncludeAlwaysHidden: true
             ),
             hotkeys: [:],
             displayConfigurations: [:],


### PR DESCRIPTION
## What does this PR do?

Adds a `Search` group to the Advanced settings pane that lets users control which menu bar sections (`Visible`, `Hidden`, `Always-Hidden`) appear in the menu bar search panel and in what order. Settings are per-profile, default to today's behaviour, and decode forward-compatibly so existing profiles upgrade cleanly.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A. `AdvancedSettingsSnapshot.init(from:)` uses `decodeIfPresent` for every new field and falls back to `Defaults.DefaultValue.searchSectionOrder` etc., so profiles authored before this change continue to decode and pick up the default behaviour. `SettingsURIHandler` only gains additive keys.

## What is the current behavior?

The menu bar search panel always lists items from every section in the fixed order `Visible` -> `Hidden` -> `Always-Hidden`, with no way to hide a section or change the order. Visible items are already reachable from the menu bar itself, so the top of the search panel is consumed by items the user can already click directly. Issue Number: #618

## What is the new behavior?

A new `IceSection("Search")` appears in the Advanced settings pane between `Menu Bar Sections` and `Tooltips`. It has one row per section: each row shows the localized section name, up and down chevron buttons that reorder the row, and a toggle that includes or excludes that section's items from the search panel. The `Always-Hidden` row is hidden when `enableAlwaysHiddenSection` is off, matching the existing conditional pattern in `Menu Bar Sections`. The configured order is honoured for the initial section listing and empty-query results in `MenuBarSearchPanel.updateDisplayedItems()`, the inclusion toggles short-circuit a section before its header is emitted, and `MenuBarSearchContentView` observes the four new properties via `.onChange` so the panel refreshes immediately when the user toggles a setting in the open Settings window. Defaults preserve today's behaviour: `searchSectionOrder = ["visible", "hidden", "alwaysHidden"]`, all three `searchInclude*` toggles `true`. State persists through `UserDefaults` (`MenuBarSection.Name` gained `String` raw values for the round-trip), through `AdvancedSettingsSnapshot` so each profile carries its own search ordering, and the three inclusion booleans are URI-addressable via `SettingsURIHandler`. `SettingsResetter.resetAdvanced()` restores the new defaults.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

New strings (`Search`, `Move up`, `Move down`, and the annotation description) were added to `Localizable.xcstrings` with translator comments and will be picked up by the existing translation pipeline. The order array is intentionally not exposed via the Settings URI scheme because `SettingsURIHandler` only supports `Bool` and `Double` values today; the three inclusion toggles are addressable. `MenuBarSection.Name` is now `String, CaseIterable, Codable`, which is a purely additive change to the enum's API.

Closes #618

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Advanced Search: customize which menu-bar sections appear, reorder sections, and toggle inclusion of visible/hidden/always-hidden items in search.
* **User Experience**
  * Search panel selection now initializes and recovers selection more reliably when results change.
* **Localization**
  * Added help text, accessibility labels, and section header text for the new Search settings.
* **Tests**
  * Updated snapshot and profile tests to cover the new search settings.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->