### PR TITLE
feat(display): add global template for per-display configuration

### DIFF
--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -44703,6 +44703,50 @@
           }
         }
       }
+    },
+    "Always show hidden menu bar items in the menu bar." : {
+      "comment" : "Annotation for the Always-show-hidden-items toggle in the Global section of the Displays pane.",
+      "localizations" : {}
+    },
+    "Apply global settings to all displays?" : {
+      "comment" : "Title of the alert shown before applying the global display template to every known display.",
+      "localizations" : {}
+    },
+    "Apply the global template above to every connected and previously-seen display. Newly connected displays are also seeded from this template." : {
+      "comment" : "Annotation under the Apply-to-All-Displays button in the Global section of the Displays pane.",
+      "localizations" : {}
+    },
+    "Apply to All Displays" : {
+      "comment" : "Button in the Global section of the Displays pane that broadcasts the global template to every known display.",
+      "localizations" : {}
+    },
+    "Applying briefly relaunches apps with menu bar items so they pick up the new spacing." : {
+      "comment" : "Annotation under the spacing slider in the Global section of the Displays pane.",
+      "localizations" : {}
+    },
+    "Broadcast" : {
+      "comment" : "Label for the row that contains the Apply-to-All-Displays button in the Global section of the Displays pane.",
+      "localizations" : {}
+    },
+    "Global" : {
+      "comment" : "Header of the Global section at the top of the Displays pane.",
+      "localizations" : {}
+    },
+    "Not available because the %@ Bar is enabled in the global template." : {
+      "comment" : "Annotation shown when the Always-show-hidden-items toggle in the Global section is disabled because Use Thaw Bar is enabled in the global template. %@ is the Thaw display name.",
+      "localizations" : {}
+    },
+    "Show hidden menu bar items in a separate bar below the menu bar." : {
+      "comment" : "Annotation under the Use-Thaw-Bar toggle in the Global section of the Displays pane.",
+      "localizations" : {}
+    },
+    "This will overwrite the settings of %d display(s) with the global template and may briefly relaunch apps with menu bar items." : {
+      "comment" : "Alert message variant shown before applying the global template to all displays when no profile is active. %d is the number of affected displays.",
+      "localizations" : {}
+    },
+    "This will overwrite the settings of %d display(s) with the global template and may briefly relaunch apps with menu bar items. Save the global template to the active profile \"%@\", or save it to every profile." : {
+      "comment" : "Alert message variant shown before applying the global template to all displays while a profile is active. %d is the number of affected displays. %@ is the active profile name.",
+      "localizations" : {}
     }
   },
   "version" : "1.1"

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -21,6 +21,13 @@ final class DisplaySettingsManager: ObservableObject {
     /// Per-display configurations, keyed by display UUID string.
     @Published var configurations: [String: DisplayIceBarConfiguration] = [:]
 
+    /// The global configuration template applied to all displays by the
+    /// Apply-to-All action in the Displays pane and used as the seed for
+    /// newly connected displays. Persisted independently from
+    /// configurations so the template survives display disconnects, and
+    /// captured by every Profile so each profile carries its own global.
+    @Published var globalConfiguration: DisplayIceBarConfiguration = .defaultConfiguration
+
     /// Cache of previously-seen displays (name + notch state), keyed by
     /// display UUID. Lets the Displays pane show settings rows for
     /// disconnected displays so users can edit them without having to
@@ -74,6 +81,8 @@ final class DisplaySettingsManager: ObservableObject {
     private func captureCurrentlyConnectedDisplays() {
         var updated = knownDisplays
         var changed = false
+        var seededConfigurations = configurations
+        var configurationsChanged = false
         for screen in NSScreen.screens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 continue
@@ -85,9 +94,22 @@ final class DisplaySettingsManager: ObservableObject {
                 updated[uuid] = entry
                 changed = true
             }
+            // Seed an entry for newly-detected displays from the current
+            // global template so first-time connections inherit the
+            // user's chosen defaults instead of falling through to
+            // DisplayIceBarConfiguration.defaultConfiguration at read time.
+            // Existing entries are left alone so per-display overrides
+            // are preserved across reconnects.
+            if seededConfigurations[uuid] == nil {
+                seededConfigurations[uuid] = globalConfiguration
+                configurationsChanged = true
+            }
         }
         if changed {
             knownDisplays = updated
+        }
+        if configurationsChanged {
+            configurations = seededConfigurations
         }
     }
 
@@ -119,6 +141,14 @@ final class DisplaySettingsManager: ObservableObject {
         // empty dict) is not silently re-seeded from on-disk system spacing.
         if persistedData == nil {
             seedConfigurationsFromSystemSpacing()
+        }
+        if let data = Defaults.data(forKey: .globalDisplayConfiguration) {
+            do {
+                globalConfiguration = try decoder.decode(DisplayIceBarConfiguration.self, from: data)
+                diagLog.info("Loaded global display configuration template")
+            } catch {
+                diagLog.error("Failed to decode global display configuration: \(error)")
+            }
         }
         if let data = Defaults.data(forKey: .knownDisplays) {
             do {
@@ -227,6 +257,20 @@ final class DisplaySettingsManager: ObservableObject {
                     Defaults.set(data, forKey: .knownDisplays)
                 } catch {
                     diagLog.error("Failed to encode known display cache: \(error)")
+                }
+            }
+            .store(in: &c)
+
+        $globalConfiguration
+            .dropFirst()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] config in
+                guard let self else { return }
+                do {
+                    let data = try encoder.encode(config)
+                    Defaults.set(data, forKey: .globalDisplayConfiguration)
+                } catch {
+                    diagLog.error("Failed to encode global display configuration: \(error)")
                 }
             }
             .store(in: &c)
@@ -668,6 +712,25 @@ final class DisplaySettingsManager: ObservableObject {
         var newConfigurations = configurations
         newConfigurations[uuid] = updated
         configurations = newConfigurations
+    }
+
+    /// Overwrites the configuration of every known display (connected and
+    /// previously-seen but currently disconnected) with the current
+    /// globalConfiguration. Returns the list of affected UUIDs. Drives a
+    /// single assignment to configurations so the persistence sink and
+    /// applyActiveDisplaySpacing each fire once.
+    @discardableResult
+    func applyGlobalToAllKnownDisplays() -> [String] {
+        let targets = allDisplays().map(\.id)
+        guard !targets.isEmpty else { return [] }
+        var updated = configurations
+        for uuid in targets {
+            updated[uuid] = globalConfiguration
+        }
+        if updated != configurations {
+            configurations = updated
+        }
+        return targets
     }
 
     /// Toggles the Thaw Bar for the display with the active menu bar.

--- a/Thaw/Settings/Models/Profile.swift
+++ b/Thaw/Settings/Models/Profile.swift
@@ -281,6 +281,7 @@ struct ProfileContent {
     var advancedSettings: AdvancedSettingsSnapshot
     var hotkeys: [String: Data]
     var displayConfigurations: [String: DisplayIceBarConfiguration]
+    var globalDisplayConfiguration: DisplayIceBarConfiguration
     var appearanceConfiguration: MenuBarAppearanceConfigurationV2
     var menuBarLayout: MenuBarLayoutSnapshot
     var automation: ProfileAutomation?
@@ -290,6 +291,7 @@ struct ProfileContent {
         advancedSettings: AdvancedSettingsSnapshot,
         hotkeys: [String: Data],
         displayConfigurations: [String: DisplayIceBarConfiguration],
+        globalDisplayConfiguration: DisplayIceBarConfiguration = Defaults.DefaultValue.globalDisplayConfiguration,
         appearanceConfiguration: MenuBarAppearanceConfigurationV2,
         menuBarLayout: MenuBarLayoutSnapshot,
         automation: ProfileAutomation? = nil
@@ -298,6 +300,7 @@ struct ProfileContent {
         self.advancedSettings = advancedSettings
         self.hotkeys = hotkeys
         self.displayConfigurations = displayConfigurations
+        self.globalDisplayConfiguration = globalDisplayConfiguration
         self.appearanceConfiguration = appearanceConfiguration
         self.menuBarLayout = menuBarLayout
         self.automation = automation
@@ -316,6 +319,7 @@ struct Profile: Codable, Identifiable {
     var advancedSettings: AdvancedSettingsSnapshot
     var hotkeys: [String: Data]
     var displayConfigurations: [String: DisplayIceBarConfiguration]
+    var globalDisplayConfiguration: DisplayIceBarConfiguration
     var appearanceConfiguration: MenuBarAppearanceConfigurationV2
     var menuBarLayout: MenuBarLayoutSnapshot
     var automation: ProfileAutomation?
@@ -337,6 +341,7 @@ struct Profile: Codable, Identifiable {
             advancedSettings: advancedSettings,
             hotkeys: hotkeys,
             displayConfigurations: displayConfigurations,
+            globalDisplayConfiguration: globalDisplayConfiguration,
             appearanceConfiguration: appearanceConfiguration,
             menuBarLayout: menuBarLayout,
             automation: automation
@@ -354,6 +359,7 @@ struct Profile: Codable, Identifiable {
         case advancedSettings
         case hotkeys
         case displayConfigurations
+        case globalDisplayConfiguration
         case appearanceConfiguration
         case menuBarLayout
         case automation
@@ -374,6 +380,7 @@ struct Profile: Codable, Identifiable {
         self.advancedSettings = content.advancedSettings
         self.hotkeys = content.hotkeys
         self.displayConfigurations = content.displayConfigurations
+        self.globalDisplayConfiguration = content.globalDisplayConfiguration
         self.appearanceConfiguration = content.appearanceConfiguration
         self.menuBarLayout = content.menuBarLayout
         self.automation = content.automation
@@ -438,6 +445,11 @@ struct Profile: Codable, Identifiable {
             [String: DisplayIceBarConfiguration].self,
             forKey: .displayConfigurations
         ) ?? Defaults.DefaultValue.displayIceBarConfigurations
+
+        globalDisplayConfiguration = try container.decodeIfPresent(
+            DisplayIceBarConfiguration.self,
+            forKey: .globalDisplayConfiguration
+        ) ?? Defaults.DefaultValue.globalDisplayConfiguration
 
         appearanceConfiguration = try container.decodeIfPresent(
             MenuBarAppearanceConfigurationV2.self,

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -206,6 +206,7 @@ final class ProfileManager: ObservableObject {
                 advancedSettings: AdvancedSettingsSnapshot.capture(from: appState.settings.advanced),
                 hotkeys: Defaults.dictionary(forKey: .hotkeys) as? [String: Data] ?? [:],
                 displayConfigurations: appState.settings.displaySettings.configurations,
+                globalDisplayConfiguration: appState.settings.displaySettings.globalConfiguration,
                 appearanceConfiguration: appState.appearanceManager.configuration,
                 menuBarLayout: captureCurrentLayout(from: appState)
             )
@@ -438,6 +439,9 @@ final class ProfileManager: ObservableObject {
         // Apply display configurations
         appState.settings.displaySettings.configurations = profile.displayConfigurations
 
+        // Apply global display configuration template
+        appState.settings.displaySettings.globalConfiguration = profile.globalDisplayConfiguration
+
         // Apply appearance configuration
         appState.appearanceManager.configuration = profile.appearanceConfiguration
 
@@ -616,6 +620,7 @@ final class ProfileManager: ObservableObject {
         )
         profile.hotkeys = Defaults.dictionary(forKey: .hotkeys) as? [String: Data] ?? [:]
         profile.displayConfigurations = appState.settings.displaySettings.configurations
+        profile.globalDisplayConfiguration = appState.settings.displaySettings.globalConfiguration
         profile.appearanceConfiguration = appState.appearanceManager.configuration
     }
 
@@ -681,6 +686,43 @@ final class ProfileManager: ObservableObject {
             var profile = try loadProfile(id: meta.id)
             let base = profile.displayConfigurations[displayUUID] ?? .defaultConfiguration
             profile.displayConfigurations[displayUUID] = base.withItemSpacingOffset(offset)
+            profile.modifiedAt = now
+            pending.append(profile)
+        }
+        for profile in pending {
+            let data = try encoder.encode(profile)
+            try data.write(to: profileURL(for: profile.id), options: .atomic)
+        }
+        for profile in pending {
+            if let index = profiles.firstIndex(where: { $0.id == profile.id }) {
+                profiles[index].modifiedAt = profile.modifiedAt
+            }
+        }
+        saveManifest()
+    }
+
+    /// Writes the given configuration into every profile's
+    /// globalDisplayConfiguration field. When propagateToDisplays is true,
+    /// every per-display entry in each profile is also overwritten so a
+    /// later profile reapply does not revert the broadcast. Mirrors the
+    /// load-all-first, single-manifest-write shape of
+    /// updateAllProfilesItemSpacingOffset so partial writes do not leave
+    /// some profiles updated and others not.
+    func updateAllProfilesGlobalConfiguration(
+        _ config: DisplayIceBarConfiguration,
+        propagateToDisplays: Bool
+    ) throws {
+        let now = Date()
+        var pending: [Profile] = []
+        pending.reserveCapacity(profiles.count)
+        for meta in profiles {
+            var profile = try loadProfile(id: meta.id)
+            profile.globalDisplayConfiguration = config
+            if propagateToDisplays {
+                for uuid in profile.displayConfigurations.keys {
+                    profile.displayConfigurations[uuid] = config
+                }
+            }
             profile.modifiedAt = now
             pending.append(profile)
         }

--- a/Thaw/Settings/Models/SettingsResetter.swift
+++ b/Thaw/Settings/Models/SettingsResetter.swift
@@ -71,5 +71,6 @@ extension AppSettings {
     /// Resets Display settings to their default values.
     func resetDisplay() {
         displaySettings.configurations = Defaults.DefaultValue.displayIceBarConfigurations
+        displaySettings.globalConfiguration = Defaults.DefaultValue.globalDisplayConfiguration
     }
 }

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -9,6 +9,11 @@
 import SwiftUI
 
 struct DisplaySettingsPane: View {
+    /// Sentinel key for the Global section's draft spacing slider, kept
+    /// distinct from real display UUIDs so the Global section can share the
+    /// per-display draftSpacing dictionary without colliding.
+    private static let globalDraftKey = "__global__"
+
     @EnvironmentObject var appState: AppState
     @ObservedObject var displaySettings: DisplaySettingsManager
 
@@ -22,6 +27,10 @@ struct DisplaySettingsPane: View {
     /// Set by requestSpacingApply when a prompt is required; the alert binds
     /// to its non-nil state. Nil when no alert is showing.
     @State private var pendingSpacingApply: PendingSpacingApply?
+    /// Pending global broadcast held while the global confirmation alert
+    /// is shown. Set by requestGlobalApply; the alert binds to its
+    /// non-nil state. Nil when no alert is showing.
+    @State private var pendingGlobalApply: PendingGlobalApply?
     @State private var errorMessage: String?
     @State private var showingError = false
 
@@ -35,8 +44,18 @@ struct DisplaySettingsPane: View {
         let activeProfileName: String?
     }
 
+    /// A global-apply request awaiting user confirmation.
+    private struct PendingGlobalApply: Equatable {
+        let displayCount: Int
+        let activeProfileID: UUID?
+        let activeProfileName: String?
+    }
+
     var body: some View {
         IceForm {
+            IceSection {
+                globalSection()
+            }
             ForEach(displaySettings.allDisplays()) { display in
                 IceSection {
                     displayRow(for: display)
@@ -52,6 +71,16 @@ struct DisplaySettingsPane: View {
             presenting: pendingSpacingApply,
             actions: { pending in spacingConfirmationButtons(for: pending) },
             message: { pending in Text(spacingConfirmationMessage(for: pending)) }
+        )
+        .alert(
+            String(localized: "Apply global settings to all displays?"),
+            isPresented: Binding(
+                get: { pendingGlobalApply != nil },
+                set: { if !$0 { pendingGlobalApply = nil } }
+            ),
+            presenting: pendingGlobalApply,
+            actions: { pending in globalConfirmationButtons(for: pending) },
+            message: { pending in Text(globalConfirmationMessage(for: pending)) }
         )
         .alert("Error", isPresented: $showingError) {
             Button("OK") { errorMessage = nil }
@@ -388,6 +417,282 @@ struct DisplaySettingsPane: View {
             return String(localized: "Applying this spacing change will briefly relaunch all apps with menu bar items.")
         case (false, false):
             return ""
+        }
+    }
+
+    // MARK: - Global Section
+
+    /// Renders the Global controls at the top of the Displays pane. Edits
+    /// here are staged on displaySettings.globalConfiguration only; the
+    /// Apply button broadcasts the template to every known display via
+    /// requestGlobalApply.
+    @ViewBuilder
+    private func globalSection() -> some View {
+        let useIceBar = Binding<Bool>(
+            get: { displaySettings.globalConfiguration.useIceBar },
+            set: { displaySettings.globalConfiguration = displaySettings.globalConfiguration.withUseIceBar($0) }
+        )
+        let location = Binding<IceBarLocation>(
+            get: { displaySettings.globalConfiguration.iceBarLocation },
+            set: { displaySettings.globalConfiguration = displaySettings.globalConfiguration.withIceBarLocation($0) }
+        )
+        let alwaysShowHiddenItems = Binding<Bool>(
+            get: { displaySettings.globalConfiguration.alwaysShowHiddenItems },
+            set: { displaySettings.globalConfiguration = displaySettings.globalConfiguration.withAlwaysShowHiddenItems($0) }
+        )
+        let layout = Binding<IceBarLayout>(
+            get: { displaySettings.globalConfiguration.iceBarLayout },
+            set: { displaySettings.globalConfiguration = displaySettings.globalConfiguration.withIceBarLayout($0) }
+        )
+        let gridColumns = Binding<Int>(
+            get: { displaySettings.globalConfiguration.gridColumns },
+            set: { displaySettings.globalConfiguration = displaySettings.globalConfiguration.withGridColumns($0) }
+        )
+
+        HStack {
+            Spacer()
+            Text("Global")
+                .font(.headline)
+            Spacer()
+        }
+
+        Toggle("Always show hidden items", isOn: alwaysShowHiddenItems)
+            .disabled(useIceBar.wrappedValue)
+            .annotation {
+                if useIceBar.wrappedValue {
+                    Text("Not available because the \(Constants.displayName) Bar is enabled in the global template.")
+                } else {
+                    Text("Always show hidden menu bar items in the menu bar.")
+                }
+            }
+
+        Toggle("Use \(Constants.displayName) Bar", isOn: useIceBar)
+            .annotation("Show hidden menu bar items in a separate bar below the menu bar.")
+
+        if useIceBar.wrappedValue {
+            IcePicker("Location", selection: location) {
+                ForEach(IceBarLocation.allCases) { loc in
+                    Text(loc.localized).tag(loc)
+                }
+            }
+            .annotation {
+                switch location.wrappedValue {
+                case .dynamic:
+                    Text("The \(Constants.displayName) Bar's location changes based on context.")
+                case .mousePointer:
+                    Text("The \(Constants.displayName) Bar is centered below the mouse pointer.")
+                case .iceIcon:
+                    Text("The \(Constants.displayName) Bar is centered below the \(Constants.displayName) icon.")
+                case .leftAligned:
+                    Text("The \(Constants.displayName) Bar is aligned to the left edge of the display.")
+                case .rightAligned:
+                    Text("The \(Constants.displayName) Bar is aligned to the right edge of the display.")
+                }
+            }
+
+            IcePicker("Layout", selection: layout) {
+                ForEach(IceBarLayout.allCases) { lay in
+                    Text(lay.localized).tag(lay)
+                }
+            }
+            .annotation {
+                switch layout.wrappedValue {
+                case .horizontal:
+                    Text("Items are arranged in a single horizontal row.")
+                case .vertical:
+                    Text("Items are stacked vertically in a single column.")
+                case .grid:
+                    Text("Items are arranged in a grid with multiple columns.")
+                }
+            }
+
+            if layout.wrappedValue == .grid {
+                let gridColumnsDouble = Binding<Double>(
+                    get: { Double(gridColumns.wrappedValue) },
+                    set: { gridColumns.wrappedValue = Int($0) }
+                )
+                LabeledContent {
+                    IceSlider(
+                        value: gridColumnsDouble,
+                        in: 2 ... 10,
+                        step: 1
+                    ) {
+                        Text(verbatim: "\(gridColumns.wrappedValue)")
+                    }
+                } label: {
+                    Text("Columns")
+                        .frame(minWidth: maxSliderLabelWidth, alignment: .leading)
+                        .onFrameChange { frame in
+                            maxSliderLabelWidth = max(maxSliderLabelWidth, frame.width)
+                        }
+                }
+                .annotation("Maximum number of items per row in the grid layout.")
+            }
+        }
+
+        globalSpacingRow()
+
+        LabeledContent {
+            Button("Apply to All Displays") {
+                requestGlobalApply()
+            }
+            .disabled(!canApplyGlobal)
+        } label: {
+            Text("Broadcast")
+        }
+        .annotation("Apply the global template above to every connected and previously-seen display. Newly connected displays are also seeded from this template.")
+    }
+
+    /// Spacing slider for the Global template. Uses a sentinel draft key so
+    /// it can share the per-display draftSpacing dictionary.
+    @ViewBuilder
+    private func globalSpacingRow() -> some View {
+        let savedOffset = displaySettings.globalConfiguration.itemSpacingOffset
+        let draft = draftSpacing[Self.globalDraftKey] ?? CGFloat(savedOffset)
+
+        let sliderBinding = Binding<CGFloat>(
+            get: { draftSpacing[Self.globalDraftKey] ?? CGFloat(savedOffset) },
+            set: { newValue in
+                draftSpacing[Self.globalDraftKey] = newValue
+                // Stage the draft into the global template immediately so
+                // the Apply-to-All button broadcasts the spacing along with
+                // the other controls. The relaunch wave only fires when
+                // Apply-to-All writes to the per-display configurations,
+                // so this assignment is cheap.
+                displaySettings.globalConfiguration = displaySettings.globalConfiguration
+                    .withItemSpacingOffset(Double(newValue))
+            }
+        )
+
+        let labelKey: LocalizedStringKey = switch draft {
+        case -16: "none"
+        case 0: "default"
+        case 16: "max"
+        default: LocalizedStringKey(draft.formatted())
+        }
+
+        LabeledContent {
+            IceSlider(
+                labelKey,
+                value: sliderBinding,
+                in: -16 ... 16,
+                step: 2
+            )
+        } label: {
+            Text("Menu bar item spacing")
+        }
+        .annotation(
+            "Applying briefly relaunches apps with menu bar items so they pick up the new spacing."
+        )
+        .onChange(of: savedOffset) { _, newValue in
+            // Sync draft when the saved value changes externally
+            // (profile load, reset).
+            draftSpacing[Self.globalDraftKey] = CGFloat(newValue)
+        }
+    }
+
+    /// Returns true when the Apply-to-All button should be enabled. The
+    /// button activates when at least one known display has a configuration
+    /// that differs from the current global template; otherwise the
+    /// broadcast would be a no-op.
+    private var canApplyGlobal: Bool {
+        let target = displaySettings.globalConfiguration
+        let displays = displaySettings.allDisplays()
+        guard !displays.isEmpty else { return false }
+        return displays.contains { display in
+            displaySettings.configuration(forUUID: display.id) != target
+        }
+    }
+
+    // MARK: - Global Apply Confirmation
+
+    /// Routes the Apply-to-All button through the confirmation alert when a
+    /// profile is active. When no profile is active, the broadcast still
+    /// asks for confirmation because it overwrites every per-display entry,
+    /// which is destructive.
+    private func requestGlobalApply() {
+        let displayCount = displaySettings.allDisplays().count
+        let activeID = appState.profileManager.activeProfileID
+        let activeName = activeID.flatMap { id in
+            appState.profileManager.profiles.first(where: { $0.id == id })?.name
+        }
+        pendingGlobalApply = PendingGlobalApply(
+            displayCount: displayCount,
+            activeProfileID: activeID,
+            activeProfileName: activeName
+        )
+    }
+
+    /// Pushes the global template to every known display via the manager's
+    /// broadcast helper. The Combine sink in DisplaySettingsManager picks
+    /// the resulting configurations change up and drives the relaunch wave
+    /// for the active display on the next main-queue dispatch.
+    private func commitGlobalApply() {
+        displaySettings.applyGlobalToAllKnownDisplays()
+    }
+
+    @ViewBuilder
+    private func globalConfirmationButtons(for pending: PendingGlobalApply) -> some View {
+        if pending.activeProfileID != nil {
+            Button(String(localized: "Update Active Profile"), role: .destructive) {
+                if let id = pending.activeProfileID {
+                    // Snapshot the previous configurations so a save failure
+                    // can roll the live state back rather than leaving the
+                    // broadcast applied without a matching profile entry,
+                    // which the next reapply would revert.
+                    let previousConfigurations = displaySettings.configurations
+                    commitGlobalApply()
+                    do {
+                        try appState.profileManager.updateProfile(
+                            id: id,
+                            scope: .configurationOnly,
+                            appState: appState
+                        )
+                    } catch {
+                        displaySettings.configurations = previousConfigurations
+                        errorMessage = error.localizedDescription
+                        showingError = true
+                    }
+                } else {
+                    commitGlobalApply()
+                }
+            }
+            Button(String(localized: "Update All Profiles"), role: .destructive) {
+                let previousConfigurations = displaySettings.configurations
+                commitGlobalApply()
+                do {
+                    try appState.profileManager.updateAllProfilesGlobalConfiguration(
+                        displaySettings.globalConfiguration,
+                        propagateToDisplays: true
+                    )
+                } catch {
+                    displaySettings.configurations = previousConfigurations
+                    errorMessage = error.localizedDescription
+                    showingError = true
+                }
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        } else {
+            Button(String(localized: "Apply"), role: .destructive) {
+                commitGlobalApply()
+            }
+            Button(String(localized: "Cancel"), role: .cancel) {}
+        }
+    }
+
+    private func globalConfirmationMessage(for pending: PendingGlobalApply) -> String {
+        let profileName = pending.activeProfileName ?? ""
+        if pending.activeProfileID != nil {
+            return String(
+                format: String(localized: "This will overwrite the settings of %d display(s) with the global template and may briefly relaunch apps with menu bar items. Save the global template to the active profile \"%@\", or save it to every profile."),
+                pending.displayCount,
+                profileName
+            )
+        } else {
+            return String(
+                format: String(localized: "This will overwrite the settings of %d display(s) with the global template and may briefly relaunch apps with menu bar items."),
+                pending.displayCount
+            )
         }
     }
 }

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -197,6 +197,7 @@ extension Defaults {
         // MARK: Display Settings
 
         static let displayIceBarConfigurations: [String: DisplayIceBarConfiguration] = [:]
+        static let globalDisplayConfiguration: DisplayIceBarConfiguration = .defaultConfiguration
     }
 }
 
@@ -219,6 +220,7 @@ extension Defaults {
         case rehideStrategy = "RehideStrategy"
         case rehideInterval = "RehideInterval"
         case displayIceBarConfigurations = "DisplayIceBarConfigurations"
+        case globalDisplayConfiguration = "GlobalDisplayConfiguration"
         case knownDisplays = "KnownDisplays"
 
         // MARK: Hotkeys Settings


### PR DESCRIPTION
## What does this PR do?

Adds a Global section to the Displays settings pane that configures one shared `DisplayIceBarConfiguration` template and broadcasts it to every known display (currently connected and previously seen). The template also seeds any newly connected display so first-time connections inherit the user's chosen defaults instead of `DisplayIceBarConfiguration.defaultConfiguration`.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A. `Profile.init(from:)` uses `decodeIfPresent` for the new `globalDisplayConfiguration` field, so existing on-disk profiles continue to load and default to `DisplayIceBarConfiguration.defaultConfiguration`.

## What is the current behavior?

Each connected display has its own editable section in the Displays pane, and there is no UI surface for "apply this configuration to all displays at once." Users with multiple displays (or who frequently change setups) had to repeat their preferences for every display, and a newly connected display always landed on the hardcoded `DisplayIceBarConfiguration.defaultConfiguration` until it was manually configured.

Issue Number: #633

## What is the new behavior?

A new Global section sits at the top of the Displays pane with the same controls as a per-display row (`Use Thaw Bar`, `Location`, `Layout`, `Columns`, `Always show hidden items`, `Menu bar item spacing`). Editing these stages changes to `displaySettings.globalConfiguration` in memory; nothing is propagated until the user clicks `Apply to All Displays`. That button gates through a confirmation alert: with no profile active it asks for a single confirmation; with a profile active it offers `Update Active Profile` and `Update All Profiles` paths that mirror the existing spacing-apply flow, with a rollback of `displaySettings.configurations` if the profile save throws.

The broadcast itself goes through a new `DisplaySettingsManager.applyGlobalToAllKnownDisplays()` helper that writes the template into every UUID returned by `allDisplays()` in a single `configurations` assignment, so the persistence sink and `applyActiveDisplaySpacing` each fire once. The `Update All Profiles` path calls a new `ProfileManager.updateAllProfilesGlobalConfiguration(_:propagateToDisplays:)` that mirrors the existing `updateAllProfilesItemSpacingOffset` load-all-first, single-manifest-write shape, optionally rewriting every per-display entry in each profile so a later profile reapply does not revert the broadcast.

The Global template is persisted independently via a new `globalDisplayConfiguration` `UserDefaults` key (so it survives display disconnects and "no active profile" states) and is also captured per profile via the new `Profile.globalDisplayConfiguration` field. `SettingsResetter.resetDisplay()` resets the Global template alongside the per-display dictionary.

`DisplaySettingsManager.captureCurrentlyConnectedDisplays()` now seeds an entry from the Global template for any newly-detected display UUID that has no existing configuration. Existing per-display overrides survive disconnect / reconnect because the seed only fills empty slots. The seed runs in the same buffered pass as the `knownDisplays` cache update so a single `configurations` assignment fires per detection wave.

## PR Checklist

- [x] I've built and run the app locally
- [x] I've checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

All 11 new user-visible strings are registered in `Thaw/Resources/Localizable.xcstrings` with `comment` annotations and empty `localizations` dicts, matching the convention used by the prior spacing-prompt commit. The Crowdin sync will pick them up on the next pass.

The `SettingsURIHandler` already exposes scope-based per-display setters (`allEnabled`, `allNonIceBar`, etc.) but no new `global` URI scope is introduced in this PR. That is a natural follow-up if external automation needs to drive the Global template.

Closes #633

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Global" section to the Displays pane for configuring a display template.
  * Users can now apply global display settings (ice bar enable, location, layout, and menu bar visibility) to all displays at once.
  * Global settings are now preserved when saving and loading profiles.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/stonerl/Thaw/pull/646?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->