### PR TITLE
fix(automation): size hook label column to widest localized string

### DIFF
--- a/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
@@ -21,6 +21,9 @@ struct AutomationSettingsPane: View {
     /// Bumped whenever a per-profile hook write completes, so SwiftUI
     /// re-reads the latest values from ProfileManager.
     @State private var profileHookRevision: Int = 0
+    /// Shared width for the hook-row label column, sized to the widest
+    /// localized label so longer translations never wrap mid-word.
+    @State private var hookLabelWidth: CGFloat = 90
 
     var body: some View {
         IceForm {
@@ -51,6 +54,9 @@ struct AutomationSettingsPane: View {
                 selectedHookProfileID = appState.profileManager.activeProfileID
                     ?? updated.first?.id
             }
+        }
+        .onPreferenceChange(HookLabelWidthKey.self) { width in
+            hookLabelWidth = max(width, 90)
         }
     }
 
@@ -344,12 +350,14 @@ struct AutomationSettingsPane: View {
 
             HookRow(
                 label: "Pre-apply",
-                hook: $hookSettings.globalPreHook
+                hook: $hookSettings.globalPreHook,
+                labelWidth: hookLabelWidth
             )
 
             HookRow(
                 label: "Post-apply",
-                hook: $hookSettings.globalPostHook
+                hook: $hookSettings.globalPostHook,
+                labelWidth: hookLabelWidth
             )
         }
     }
@@ -382,12 +390,14 @@ struct AutomationSettingsPane: View {
             } else if let profileID = selectedHookProfileID {
                 HookRow(
                     label: "Pre-apply",
-                    hook: bindingForProfileHook(profileID: profileID, phase: .pre)
+                    hook: bindingForProfileHook(profileID: profileID, phase: .pre),
+                    labelWidth: hookLabelWidth
                 )
 
                 HookRow(
                     label: "Post-apply",
-                    hook: bindingForProfileHook(profileID: profileID, phase: .post)
+                    hook: bindingForProfileHook(profileID: profileID, phase: .post),
+                    labelWidth: hookLabelWidth
                 )
 
                 Divider()
@@ -440,15 +450,35 @@ struct AutomationSettingsPane: View {
 
 // MARK: - HookRow
 
+/// Collects the widest natural label width across all hook rows so the
+/// label column can be sized to fit the longest localized string.
+private struct HookLabelWidthKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
 private struct HookRow: View {
     let label: LocalizedStringKey
     @Binding var hook: HookScript?
+    let labelWidth: CGFloat
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 8) {
                 Text(label)
-                    .frame(width: 90, alignment: .leading)
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear.preference(
+                                key: HookLabelWidthKey.self,
+                                value: proxy.size.width
+                            )
+                        }
+                    )
+                    .frame(minWidth: labelWidth, alignment: .leading)
 
                 Text(displayPath)
                     .font(.system(size: 12).monospaced())
@@ -475,7 +505,7 @@ private struct HookRow: View {
 
             if hook != nil {
                 HStack(spacing: 16) {
-                    Spacer().frame(width: 90)
+                    Spacer().frame(width: labelWidth)
 
                     Toggle("Enabled", isOn: enabledBinding)
                         .toggleStyle(.checkbox)
@@ -500,7 +530,7 @@ private struct HookRow: View {
 
                 if let warning = validationWarning {
                     HStack(spacing: 6) {
-                        Spacer().frame(width: 90)
+                        Spacer().frame(width: labelWidth)
                         Image(systemName: "exclamationmark.triangle.fill")
                             .foregroundStyle(.orange)
                         Text(warning)


### PR DESCRIPTION
## What does this PR do?

Fixes a layout bug in the Automation settings pane where the Global Hooks and Per-Profile Hooks rows rendered their `Pre-apply` / `Post-apply` labels in a fixed-width column that was too narrow for longer localized strings, so the text wrapped and broke mid-word.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

In `HookRow` (`AutomationSettingsPane.swift`) the label column was hard-coded to `.frame(width: 90)`, with matching `Spacer().frame(width: 90)` indents on the sub-rows. That width fits the English `Pre-apply` / `Post-apply` labels but is too narrow for longer translations such as the Polish `Przed zastosowaniem` / `Po zastosowaniu` (also reproduced in Spanish), so words break mid-line and the column looks broken.
Issue Number: #650

## What is the new behavior?

The hook label column now sizes itself to the widest localized label instead of a fixed 90pt. Each `HookRow` measures its label's natural width via a `GeometryReader` background and reports it through a new `HookLabelWidthKey` preference; the pane collects the maximum into `hookLabelWidth` and feeds it back to every `HookRow` (both global and per-profile). Labels use `.lineLimit(1)` with `.fixedSize(horizontal: true)` so they never wrap, and the `.frame(minWidth: labelWidth)` plus the matching `Spacer().frame(width: labelWidth)` keep the rows aligned. The column still collapses back to the 90pt minimum for short labels, so the fix is locale-agnostic rather than a per-language width bump.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

### Notes for reviewers

Worth a quick visual check in a long-label locale (Polish or Spanish) to confirm `Pre-apply` / `Post-apply` no longer wrap and that the two rows in each group stay aligned. The shared-width approach means the column tracks the widest of all four hook labels on screen at once.

Fixes #650


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved layout of automation settings to ensure hook labels display and align correctly without wrapping, even with longer localized text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->