### PR TITLE
fix(resolution): stabilize Control Center widgets on a single display

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -79,6 +79,17 @@ extension Bridging {
 extension Bridging {
     // MARK: Private Display Helpers
 
+    /// A display to exclude from Thaw's display enumeration while it exists.
+    ///
+    /// Set to the identifier of the transient virtual display that
+    /// VirtualDisplayProvoker creates to provoke marker-pair resolution on a
+    /// single-display machine, and cleared when it is removed. Filtering it
+    /// here keeps the phantom out of every display list derived from
+    /// getActiveDisplayList (including the active-menu-bar-display lookup),
+    /// so it never drives profile auto-switch or per-display state. nil during
+    /// normal operation, which makes the filter a no-op.
+    nonisolated(unsafe) static var excludedDisplayID: CGDirectDisplayID?
+
     private static func getActiveDisplayCount() -> UInt32? {
         var count: UInt32 = 0
         let result = CGGetActiveDisplayList(0, nil, &count)
@@ -98,6 +109,9 @@ extension Bridging {
         guard result == .success else {
             diagLog.error("CGGetActiveDisplayList failed with error \(result.logString)")
             return []
+        }
+        if let excluded = excludedDisplayID {
+            list.removeAll { $0 == excluded }
         }
         return list
     }

--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import Cocoa
+import os
 @preconcurrency import ScreenCaptureKit
 
 // MARK: - Bridging
@@ -88,7 +89,17 @@ extension Bridging {
     /// getActiveDisplayList (including the active-menu-bar-display lookup),
     /// so it never drives profile auto-switch or per-display state. nil during
     /// normal operation, which makes the filter a no-op.
-    nonisolated(unsafe) static var excludedDisplayID: CGDirectDisplayID?
+    ///
+    /// Backed by an unfair lock: the MainActor writer (VirtualDisplayProvoker)
+    /// and the off-MainActor readers (the nonisolated image-capture tasks reach
+    /// it through getActiveMenuBarDisplayID) would otherwise race on this
+    /// non-atomic optional.
+    static var excludedDisplayID: CGDirectDisplayID? {
+        get { excludedDisplayIDStorage.withLock { $0 } }
+        set { excludedDisplayIDStorage.withLock { $0 = newValue } }
+    }
+
+    private static let excludedDisplayIDStorage = OSAllocatedUnfairLock<CGDirectDisplayID?>(initialState: nil)
 
     private static func getActiveDisplayCount() -> UInt32? {
         var count: UInt32 = 0

--- a/Thaw.xcodeproj/project.pbxproj
+++ b/Thaw.xcodeproj/project.pbxproj
@@ -583,6 +583,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stonerl.Thaw;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Thaw/Thaw-Bridging-Header.h";
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};
@@ -621,6 +622,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.stonerl.Thaw;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_OBJC_BRIDGING_HEADER = "Thaw/Thaw-Bridging-Header.h";
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 6.0;
 			};

--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -52,6 +52,11 @@ final class AppState: ObservableObject {
     /// Manager for settings profiles.
     let profileManager = ProfileManager()
 
+    /// Briefly adds a virtual display on single-display machines so the window
+    /// server publishes the marker windows needed to resolve unidentified menu
+    /// bar items, then tears it down.
+    private(set) lazy var virtualDisplayProvoker = VirtualDisplayProvoker(appState: self)
+
     /// Manager for app updates.
     let updatesManager = UpdatesManager()
 
@@ -65,7 +70,7 @@ final class AppState: ObservableObject {
     private var openWindows = Set<IceWindowIdentifier>()
 
     /// Track last known screen count to detect disconnects.
-    private var lastKnownScreenCount = NSScreen.screens.count
+    private var lastKnownScreenCount = NSScreen.managedScreens.count
 
     /// Prevent repeated restart attempts.
     private var isRestarting = false
@@ -274,9 +279,18 @@ final class AppState: ObservableObject {
             }
             .store(in: &c)
 
+        // After each cache cycle settles, let the provoker decide whether to
+        // briefly add a virtual display to resolve any single-display orphans.
+        itemManager.$itemCache
+            .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.virtualDisplayProvoker.considerProvoking()
+            }
+            .store(in: &c)
+
         NotificationCenter.default.publisher(for: NSApplication.didChangeScreenParametersNotification)
             .debounce(for: .seconds(0.5), scheduler: DispatchQueue.main)
-            .map { _ in NSScreen.screens.count }
+            .map { _ in NSScreen.managedScreens.count }
             .sink { [weak self] count in
                 guard let self else { return }
                 defer { self.lastKnownScreenCount = count }

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceManager.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceManager.swift
@@ -69,7 +69,7 @@ final class MenuBarAppearanceManager: ObservableObject {
                 while let panel = overlayPanels.popFirst() {
                     panel.close()
                 }
-                if Set(overlayPanels.map(\.owningScreen)) != Set(NSScreen.screens) {
+                if Set(overlayPanels.map(\.owningScreen)) != Set(NSScreen.managedScreens) {
                     configureOverlayPanels(with: configuration)
                 }
             }
@@ -171,7 +171,7 @@ final class MenuBarAppearanceManager: ObservableObject {
         }
 
         var overlayPanels = Set<MenuBarOverlayPanel>()
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             let panel = MenuBarOverlayPanel(appState: appState, owningScreen: screen)
             overlayPanels.insert(panel)
             panel.needsShow = true

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -138,6 +138,37 @@ enum LayoutSolver {
         let previousWindowIDs: [CGWindowID]
     }
 
+    // MARK: - Current flat construction
+
+    /// Flattens the three current sections into the single ordered identifier
+    /// sequence the profile-apply planner consumes, inserting the hidden and
+    /// always-hidden control items at their section boundaries.
+    ///
+    /// Order is: visible items, hidden control item, hidden items, always-
+    /// hidden control item (when present), always-hidden items. The visible
+    /// control item is already part of the visible array (it is not filtered
+    /// out upstream the way the hidden and always-hidden control items are), so
+    /// it is not reinserted here.
+    ///
+    /// Pure over its inputs. Shared by applyProfileLayout and the log-replay
+    /// harness so both build currentFlat identically.
+    nonisolated static func flattenCurrentSections(
+        visible: [String],
+        hidden: [String],
+        alwaysHidden: [String],
+        hiddenCtrlUID: String,
+        ahCtrlUID: String?
+    ) -> [String] {
+        var result = visible
+        result.append(hiddenCtrlUID)
+        result.append(contentsOf: hidden)
+        if let ahCtrlUID {
+            result.append(ahCtrlUID)
+        }
+        result.append(contentsOf: alwaysHidden)
+        return result
+    }
+
     // MARK: - Unmanaged partition
 
     /// Returns the subset of currentFlat that should be routed through
@@ -155,6 +186,17 @@ enum LayoutSolver {
     /// cache cycle. Visible-control-item exclusion was the omission
     /// that caused the field-reported "Thaw icon keeps moving" bug.
     ///
+    /// Unresolved generic Control Center items (uniqueIdentifiers passed in
+    /// unresolvedGenericCCUIDs) are also excluded. These are widgets macOS
+    /// hosts under Control Center that Thaw cannot yet attribute to their
+    /// owning app (e.g. Little Snitch's agent before its marker window
+    /// appears): they fall back to the com.apple.controlcenter namespace,
+    /// never match a profile entry, and would otherwise be relocated as
+    /// unmanaged arrivals on every cycle. Leaving them in place until they
+    /// resolve was the fix for the field-reported "Little Snitch keeps moving"
+    /// bug. The caller computes the set from items whose tag is a Control
+    /// Center generic item and whose sourcePID is nil.
+    ///
     /// Input order is preserved, since downstream consumers (LCS
     /// planner) treat the result as the iteration order for placement.
     /// Pure over its inputs.
@@ -163,13 +205,15 @@ enum LayoutSolver {
         desiredUIDs: Set<String>,
         hiddenCtrlUID: String?,
         ahCtrlUID: String?,
-        visibleCtrlUID: String?
+        visibleCtrlUID: String?,
+        unresolvedGenericCCUIDs: Set<String>
     ) -> [String] {
         currentFlat.filter { uid in
             !desiredUIDs.contains(uid)
                 && uid != hiddenCtrlUID
                 && uid != ahCtrlUID
                 && uid != visibleCtrlUID
+                && !unresolvedGenericCCUIDs.contains(uid)
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1305,11 +1305,15 @@ final class MenuBarItemManager: ObservableObject {
             }
             .store(in: &c)
 
-        // Periodic check for new menu bar items that appeared after the
-        // launch notification follow-ups (e.g. background-only apps like
-        // OneDrive that register their NSStatusItem late). Lightweight
-        // windowID comparison bails fast when nothing changed.
-        cacheTickCancellable = Timer.publish(every: 60, on: .main, in: .common)
+        // Rescan on menu bar window-list changes. cacheItemsIfNeeded compares
+        // the current items-only window IDs against the cached set and recaches
+        // only when they differ, so this catches both late-registering items
+        // (background-only apps like OneDrive) and the transient bundle-ID
+        // marker windows that source-PID marker-pair resolution depends on,
+        // which can appear and disappear between sparser app-event triggers. A
+        // short interval keeps marker-pair latency low; the windowID comparison
+        // bails fast and triggers no recache when nothing changed.
+        cacheTickCancellable = Timer.publish(every: 3, on: .main, in: .common)
             .autoconnect()
             .sink { [weak self] _ in
                 Task { [weak self] in
@@ -1779,6 +1783,38 @@ extension MenuBarItemManager {
             }
         }
         MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
+    }
+
+    /// Whether a startup or profile-apply settling period is currently active.
+    ///
+    /// During settling the menu bar is still converging and items are
+    /// transiently unresolved before the spatial AX, marker-pair, and
+    /// elimination passes finish. Consumers that react to unresolved items
+    /// (VirtualDisplayProvoker) must wait until this is false, otherwise they
+    /// would treat normal cold-boot churn as genuinely-stuck orphans.
+    ///
+    /// Tracks `isInStartupSettling` only: that flag is cleared when the period
+    /// ends, whereas `startupSettlingTask` keeps referencing the finished task
+    /// and so would report settling forever after the first period.
+    var isSettling: Bool {
+        isInStartupSettling
+    }
+
+    /// The window IDs of currently-cached menu bar items that have no resolved
+    /// source PID and are not Thaw control items.
+    ///
+    /// These are the items that may still need marker-pair resolution. On a
+    /// single display the bundle-ID marker windows are absent, so these stay
+    /// unresolved; VirtualDisplayProvoker uses this to decide when to briefly
+    /// add a virtual display so the markers publish. The caller is expected to
+    /// ignore the result while isSettling is true, since cold-boot churn
+    /// surfaces transient unresolved items here.
+    func unresolvedOrphanWindowIDs() -> Set<CGWindowID> {
+        Set(
+            itemCache.managedItems
+                .filter { $0.sourcePID == nil && !$0.isControlItem }
+                .map(\.windowID)
+        )
     }
 
     /// Caches the current menu bar items, regardless of whether the
@@ -5564,7 +5600,7 @@ extension MenuBarItemManager {
         // planFullSortSequence's early-return check to fail against a
         // single-divider desiredFiltered and the notched full-sort
         // path to regenerate the entire sequence every cycle.
-        var currentFlat = [String]()
+        var sectionUIDs = [MenuBarSection.Name: [String]]()
         for sectionName in [MenuBarSection.Name.visible, .hidden, .alwaysHidden] {
             let sectionItems = items.filter { item in
                 guard isProfileItem(item) else { return false }
@@ -5575,13 +5611,18 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug(
                 "applyProfileLayout: current \(sectionName.logString) has \(sectionItems.count) items: \(sectionItems.map(\.uniqueIdentifier))"
             )
-            currentFlat.append(contentsOf: sectionItems.map(\.uniqueIdentifier))
-            if sectionName == .visible {
-                currentFlat.append(hiddenCtrlUID)
-            } else if sectionName == .hidden, let ahCtrlUID {
-                currentFlat.append(ahCtrlUID)
-            }
+            sectionUIDs[sectionName] = sectionItems.map(\.uniqueIdentifier)
         }
+        // Flatten with control items at the section boundaries via the shared
+        // pure helper, so this path and the log-replay harness build currentFlat
+        // identically.
+        var currentFlat = LayoutSolver.flattenCurrentSections(
+            visible: sectionUIDs[.visible] ?? [],
+            hidden: sectionUIDs[.hidden] ?? [],
+            alwaysHidden: sectionUIDs[.alwaysHidden] ?? [],
+            hiddenCtrlUID: hiddenCtrlUID,
+            ahCtrlUID: ahCtrlUID
+        )
 
         // Filter desired sequence to only items present in the current bar.
         let currentSet = Set(currentFlat)
@@ -5597,12 +5638,24 @@ extension MenuBarItemManager {
         // leftmost" behavior.
         let visibleCtrlUID = items.first(where: { $0.tag == .visibleControlItem })?.uniqueIdentifier
         let desiredSet = Set(desiredFiltered)
+        // Generic Control Center items (Item-N title) with no resolved source
+        // PID are widgets macOS hosts under Control Center that Thaw cannot yet
+        // attribute to their owning app (e.g. Little Snitch's agent before its
+        // marker window appears). They fall back to the com.apple.controlcenter
+        // namespace, never match a profile entry, and so would be relocated as
+        // unmanaged arrivals on every cycle. Exclude them until they resolve.
+        let unresolvedGenericCCUIDs = Set(
+            items
+                .filter { $0.tag.isControlCenterGenericItem && $0.sourcePID == nil }
+                .map(\.uniqueIdentifier)
+        )
         let unmanagedUIDs = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: currentFlat,
             desiredUIDs: desiredSet,
             hiddenCtrlUID: hiddenCtrlUID,
             ahCtrlUID: ahCtrlUID,
-            visibleCtrlUID: visibleCtrlUID
+            visibleCtrlUID: visibleCtrlUID,
+            unresolvedGenericCCUIDs: unresolvedGenericCCUIDs
         )
         if !unmanagedUIDs.isEmpty {
             // Build a DesiredLayout for the profile-apply context: the
@@ -5913,6 +5966,11 @@ extension MenuBarItemManager {
 
             let desiredHiddenSet = Set(itemOrder["hidden"] ?? [])
             let desiredAHSet = Set(itemOrder["alwaysHidden"] ?? [])
+            // Logged for the log-replay harness so the desired visible set is
+            // captured rather than inferred from current visible minus control
+            // items and unresolved orphans. Not consulted by Phase 1's section
+            // arithmetic, which only crosses hidden and always-hidden.
+            let desiredVisibleSet = Set(itemOrder["visible"] ?? [])
 
             // Check if AH_ctrl needs to move: items changing between hidden↔alwaysHidden.
             let wrongInHidden = currentHiddenSet.subtracting(desiredHiddenSet).intersection(desiredAHSet)
@@ -5947,6 +6005,9 @@ extension MenuBarItemManager {
             )
             MenuBarItemManager.diagLog.debug(
                 "Profile layout Phase 1: desiredAH=\(desiredAHSet.sorted())"
+            )
+            MenuBarItemManager.diagLog.debug(
+                "Profile layout Phase 1: desiredVisible=\(desiredVisibleSet.sorted())"
             )
 
             if crossSectionMoves > 0 || totalSectionMismatch > 0, let ahCtrlUID {

--- a/Thaw/MenuBar/MenuBarManager.swift
+++ b/Thaw/MenuBar/MenuBarManager.swift
@@ -513,7 +513,7 @@ final class MenuBarManager: ObservableObject {
 
         let targetScreens: [NSScreen]
         if isAdaptiveActive {
-            targetScreens = NSScreen.screens
+            targetScreens = NSScreen.managedScreens
         } else if isSettingsVisible {
             targetScreens = [settingsWindow?.screen].compactMap(\.self)
         } else {
@@ -587,7 +587,7 @@ final class MenuBarManager: ObservableObject {
                     try? await Task.sleep(for: .seconds(1))
                 }
                 await self.updateAverageColorInfoAsync()
-                let allCaptured = NSScreen.screens.allSatisfy {
+                let allCaptured = NSScreen.managedScreens.allSatisfy {
                     self.averageColors.keys.contains($0.displayID)
                 }
                 if allCaptured { return }

--- a/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
+++ b/Thaw/Settings/Models/DisplayIceBarConfiguration.swift
@@ -129,7 +129,7 @@ struct DisplayIceBarConfiguration: Codable, Equatable {
         location: IceBarLocation
     ) -> [String: DisplayIceBarConfiguration] {
         var configs = [String: DisplayIceBarConfiguration]()
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 continue
             }

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -83,7 +83,7 @@ final class DisplaySettingsManager: ObservableObject {
         var changed = false
         var seededConfigurations = configurations
         var configurationsChanged = false
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 continue
             }
@@ -205,7 +205,7 @@ final class DisplaySettingsManager: ObservableObject {
         }
         let offset = Double(onDisk - Self.systemSpacingDefault)
         var seeded = configurations
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 continue
             }
@@ -292,7 +292,17 @@ final class DisplaySettingsManager: ObservableObject {
             .debounce(for: .seconds(1), scheduler: DispatchQueue.main)
             .sink { [weak self] _ in
                 guard let self else { return }
-                diagLog.info("Screen parameters changed — \(NSScreen.screens.count) screen(s) connected")
+                // Ignore the self-inflicted parameter change from the virtual
+                // display the provoker briefly creates and tears down. Reacting
+                // to it (a no-op spacing preflight) cancels the in-flight item
+                // cache cycle mid-resolution and surfaces a bar of orphans for
+                // several seconds. The phantom never changes the active menu bar
+                // display, so there is nothing here to apply.
+                if let until = VirtualDisplayProvoker.displayReactionsSuppressedUntil, Date() < until {
+                    diagLog.info("Screen parameters changed during virtual-display provoke; ignoring self-inflicted event")
+                    return
+                }
+                diagLog.info("Screen parameters changed — \(NSScreen.managedScreens.count) screen(s) connected")
                 captureCurrentlyConnectedDisplays()
                 let currentUUID = Bridging.getActiveMenuBarDisplayUUID()
                 if Self.shouldSkipSpacingApply(
@@ -406,7 +416,7 @@ final class DisplaySettingsManager: ObservableObject {
 
         // Validate specific UUID if provided (defense-in-depth)
         if let uuid = specificUUID {
-            let connectedUUIDs = NSScreen.screens.compactMap { Bridging.getDisplayUUIDString(for: $0.displayID) }
+            let connectedUUIDs = NSScreen.managedScreens.compactMap { Bridging.getDisplayUUIDString(for: $0.displayID) }
             let hasConfig = configurations[uuid] != nil
             guard connectedUUIDs.contains(uuid) || hasConfig else {
                 diagLog.warning("DisplaySettingsManager: Ignoring change for unknown display UUID '\(uuid)'")
@@ -536,7 +546,7 @@ final class DisplaySettingsManager: ObservableObject {
     private func setIceBarLocation(_ location: IceBarLocation, scope: SettingsURIHandler.PerDisplayScope) {
         if scope == .allEnabledDisplays {
             // Update all displays that have IceBar enabled
-            for screen in NSScreen.screens {
+            for screen in NSScreen.managedScreens {
                 guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
                 let config = configurations[uuid] ?? .defaultConfiguration
                 if config.useIceBar {
@@ -558,7 +568,7 @@ final class DisplaySettingsManager: ObservableObject {
     /// Sets iceBarLayout for displays based on scope.
     private func setIceBarLayout(_ layout: IceBarLayout, scope: SettingsURIHandler.PerDisplayScope) {
         if scope == .allEnabledDisplays {
-            for screen in NSScreen.screens {
+            for screen in NSScreen.managedScreens {
                 guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
                 let config = configurations[uuid] ?? .defaultConfiguration
                 if config.useIceBar {
@@ -580,7 +590,7 @@ final class DisplaySettingsManager: ObservableObject {
     /// Sets gridColumns for displays based on scope.
     private func setGridColumns(_ columns: Int, scope: SettingsURIHandler.PerDisplayScope) {
         if scope == .allEnabledDisplays {
-            for screen in NSScreen.screens {
+            for screen in NSScreen.managedScreens {
                 guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
                 let config = configurations[uuid] ?? .defaultConfiguration
                 if config.useIceBar {
@@ -603,7 +613,7 @@ final class DisplaySettingsManager: ObservableObject {
     private func setAlwaysShowHiddenItems(_ value: Bool, scope: SettingsURIHandler.PerDisplayScope) {
         if scope == .allNonIceBarDisplays {
             // Update all displays that do NOT have IceBar enabled
-            for screen in NSScreen.screens {
+            for screen in NSScreen.managedScreens {
                 guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
                 let config = configurations[uuid] ?? .defaultConfiguration
                 if !config.useIceBar {
@@ -619,7 +629,7 @@ final class DisplaySettingsManager: ObservableObject {
     private func toggleAlwaysShowHiddenItems(scope: SettingsURIHandler.PerDisplayScope) {
         if scope == .allNonIceBarDisplays {
             // Toggle on all displays that do NOT have IceBar enabled
-            for screen in NSScreen.screens {
+            for screen in NSScreen.managedScreens {
                 guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
                 let config = configurations[uuid] ?? .defaultConfiguration
                 if !config.useIceBar {
@@ -760,7 +770,7 @@ final class DisplaySettingsManager: ObservableObject {
 
     /// Returns info about all currently connected displays.
     func connectedDisplays() -> [DisplayInfo] {
-        NSScreen.screens.compactMap { screen in
+        NSScreen.managedScreens.compactMap { screen in
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 return nil
             }

--- a/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
@@ -460,7 +460,7 @@ struct ProfileSettingsPane: View {
     /// any disconnected displays that still have a profile association.
     private func allDisplays() -> [DisplayInfo] {
         let knownDisplays = appState.settings.displaySettings.knownDisplays
-        var displays = NSScreen.screens.compactMap { screen -> DisplayInfo? in
+        var displays = NSScreen.managedScreens.compactMap { screen -> DisplayInfo? in
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else {
                 return nil
             }

--- a/Thaw/Thaw-Bridging-Header.h
+++ b/Thaw/Thaw-Bridging-Header.h
@@ -1,0 +1,11 @@
+//
+//  Thaw-Bridging-Header.h
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+//  Objective-C declarations exposed to Swift in the Thaw app target.
+
+#import "VirtualDisplay/ThawVirtualDisplay.h"

--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -612,6 +612,21 @@ extension NSScreen {
         return screens.first { $0.displayID == displayID }
     }
 
+    /// The connected screens excluding Thaw's transient resolver virtual
+    /// display.
+    ///
+    /// VirtualDisplayProvoker may briefly add a virtual display to provoke
+    /// marker-pair resolution on a single-display machine. Enumerating this
+    /// instead of screens keeps that phantom out of per-display state (Thaw's
+    /// Displays settings, overlay panels, average-color capture, screen-count
+    /// logic). Identical to screens whenever no virtual display is active.
+    static var managedScreens: [NSScreen] {
+        guard let excluded = Bridging.excludedDisplayID else {
+            return screens
+        }
+        return screens.filter { $0.displayID != excluded }
+    }
+
     /// The display identifier of the screen.
     var displayID: CGDirectDisplayID {
         // Value and type are guaranteed here, so force casting is okay.
@@ -667,7 +682,7 @@ extension NSScreen {
     /// Removes cache entries for displays that are no longer connected.
     /// This prevents memory growth when displays are reconnected (which assigns new display IDs).
     static func cleanupDisconnectedDisplayCaches() {
-        let connectedDisplayIDs = Set(NSScreen.screens.map(\.displayID))
+        let connectedDisplayIDs = Set(NSScreen.managedScreens.map(\.displayID))
         displayCache.withLock { cache in
             cache.menuBarHeights = cache.menuBarHeights.filter { connectedDisplayIDs.contains($0.key) }
             cache.menuFrames = cache.menuFrames.filter { connectedDisplayIDs.contains($0.key) }

--- a/Thaw/Utilities/SettingsURIHandler.swift
+++ b/Thaw/Utilities/SettingsURIHandler.swift
@@ -975,7 +975,7 @@ enum SettingsURIHandler {
 
         // Per-display settings
         var displaysData: [String: [String: Any]] = [:]
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
             displaysData[uuid] = getDisplayInfo(screen: screen, uuid: uuid)
         }
@@ -1006,7 +1006,7 @@ enum SettingsURIHandler {
 
         if let uuid {
             // Check if UUID matches a connected display
-            let connectedUUIDs = NSScreen.screens.compactMap { Bridging.getDisplayUUIDString(for: $0.displayID) }
+            let connectedUUIDs = NSScreen.managedScreens.compactMap { Bridging.getDisplayUUIDString(for: $0.displayID) }
             let isConnected = connectedUUIDs.contains(uuid)
             let hasPersisted = configurations[uuid] != nil
 
@@ -1053,7 +1053,7 @@ enum SettingsURIHandler {
     private static func getAllDisplays(requestId: String) -> [String: Any] {
         var displays: [[String: Any]] = []
 
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let uuid = Bridging.getDisplayUUIDString(for: screen.displayID) else { continue }
             var info = getDisplayInfo(screen: screen, uuid: uuid)
             info["uuid"] = uuid
@@ -1070,7 +1070,7 @@ enum SettingsURIHandler {
     /// Gets a specific display by UUID.
     private static func getSpecificDisplay(uuid: String, requestId: String) -> [String: Any] {
         // Find screen with matching UUID
-        for screen in NSScreen.screens {
+        for screen in NSScreen.managedScreens {
             guard let screenUUID = Bridging.getDisplayUUIDString(for: screen.displayID),
                   screenUUID == uuid else { continue }
 

--- a/Thaw/VirtualDisplay/ThawVirtualDisplay.h
+++ b/Thaw/VirtualDisplay/ThawVirtualDisplay.h
@@ -1,0 +1,34 @@
+//
+//  ThawVirtualDisplay.h
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+#import <CoreGraphics/CoreGraphics.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/// Creates a headless virtual display via the private CoreGraphics
+/// CGVirtualDisplay API. Used to make the window server behave as multi-display
+/// so that, on a single physical display, it publishes the bundle-ID "marker"
+/// windows that source-PID marker-pair resolution depends on.
+///
+/// Returns an opaque, retained handle, or NULL when the private API is
+/// unavailable or creation fails (the implementation resolves the classes at
+/// runtime and catches Objective-C exceptions, so an absent or changed API
+/// degrades to NULL rather than crashing). Pass the handle to
+/// ThawVirtualDisplayDestroy to remove the display.
+void *_Nullable ThawVirtualDisplayCreate(void);
+
+/// The CGDirectDisplayID of a handle created by ThawVirtualDisplayCreate, or
+/// 0 when the handle is NULL.
+uint32_t ThawVirtualDisplayGetID(void *_Nullable handle);
+
+/// Releases the handle and removes the virtual display.
+void ThawVirtualDisplayDestroy(void *_Nullable handle);
+
+NS_ASSUME_NONNULL_END

--- a/Thaw/VirtualDisplay/ThawVirtualDisplay.m
+++ b/Thaw/VirtualDisplay/ThawVirtualDisplay.m
@@ -1,0 +1,119 @@
+//
+//  ThawVirtualDisplay.m
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+#import "ThawVirtualDisplay.h"
+
+// Private CoreGraphics interfaces (CGVirtualDisplay*), declared locally. The
+// classes are resolved at runtime via NSClassFromString and the whole creation
+// path is wrapped in @try/@catch, so a missing class or a renamed selector
+// degrades to NULL instead of crashing the app. These are the long-standing
+// symbol/property names used by tools such as BetterDisplay.
+@interface CGVirtualDisplayDescriptor : NSObject
+@property (nonatomic, strong) dispatch_queue_t queue;
+@property (nonatomic, copy) NSString *name;
+@property (nonatomic, assign) NSUInteger maxPixelsWide;
+@property (nonatomic, assign) NSUInteger maxPixelsHigh;
+@property (nonatomic, assign) CGSize sizeInMillimeters;
+@property (nonatomic, assign) uint32_t productID;
+@property (nonatomic, assign) uint32_t vendorID;
+@property (nonatomic, assign) uint32_t serialNum;
+@end
+
+@interface CGVirtualDisplayMode : NSObject
+- (instancetype)initWithWidth:(NSUInteger)width
+                       height:(NSUInteger)height
+                  refreshRate:(double)refreshRate;
+@end
+
+@interface CGVirtualDisplaySettings : NSObject
+@property (nonatomic, assign) NSUInteger hiDPI;
+@property (nonatomic, copy) NSArray<CGVirtualDisplayMode *> *modes;
+@end
+
+@interface CGVirtualDisplay : NSObject
+- (instancetype)initWithDescriptor:(CGVirtualDisplayDescriptor *)descriptor;
+- (BOOL)applySettings:(CGVirtualDisplaySettings *)settings;
+@property (nonatomic, readonly) uint32_t displayID;
+@end
+
+void *ThawVirtualDisplayCreate(void) {
+    Class descriptorClass = NSClassFromString(@"CGVirtualDisplayDescriptor");
+    Class settingsClass = NSClassFromString(@"CGVirtualDisplaySettings");
+    Class modeClass = NSClassFromString(@"CGVirtualDisplayMode");
+    Class displayClass = NSClassFromString(@"CGVirtualDisplay");
+    if (!descriptorClass || !settingsClass || !modeClass || !displayClass) {
+        NSLog(@"[ThawVirtualDisplay] CGVirtualDisplay classes unavailable; cannot create");
+        return NULL;
+    }
+
+    @try {
+        const NSUInteger width = 1920;
+        const NSUInteger height = 1080;
+
+        CGVirtualDisplayDescriptor *descriptor = [[descriptorClass alloc] init];
+        descriptor.queue = dispatch_get_main_queue();
+        descriptor.name = @"Thaw Resolver";
+        descriptor.maxPixelsWide = width;
+        descriptor.maxPixelsHigh = height;
+        descriptor.sizeInMillimeters = CGSizeMake(600.0, 340.0);
+        descriptor.productID = 0x1234;
+        descriptor.vendorID = 0x3456;
+        descriptor.serialNum = 0x0001;
+
+        CGVirtualDisplay *display = [[displayClass alloc] initWithDescriptor:descriptor];
+        if (!display) {
+            NSLog(@"[ThawVirtualDisplay] initWithDescriptor returned nil");
+            return NULL;
+        }
+
+        CGVirtualDisplayMode *mode = [[modeClass alloc] initWithWidth:width
+                                                               height:height
+                                                          refreshRate:60.0];
+        if (!mode) {
+            NSLog(@"[ThawVirtualDisplay] mode init returned nil");
+            return NULL;
+        }
+
+        CGVirtualDisplaySettings *settings = [[settingsClass alloc] init];
+        settings.hiDPI = 0;
+        settings.modes = @[mode];
+
+        if (![display applySettings:settings]) {
+            NSLog(@"[ThawVirtualDisplay] applySettings failed");
+            return NULL;
+        }
+
+        // Retain across the C boundary; ThawVirtualDisplayDestroy releases it,
+        // and deallocating the CGVirtualDisplay removes the display.
+        return (void *)CFBridgingRetain(display);
+    } @catch (NSException *exception) {
+        NSLog(@"[ThawVirtualDisplay] creation raised %@: %@", exception.name, exception.reason);
+        return NULL;
+    }
+}
+
+uint32_t ThawVirtualDisplayGetID(void *handle) {
+    if (!handle) {
+        return 0;
+    }
+    @try {
+        CGVirtualDisplay *display = (__bridge CGVirtualDisplay *)handle;
+        return display.displayID;
+    } @catch (NSException *exception) {
+        return 0;
+    }
+}
+
+void ThawVirtualDisplayDestroy(void *handle) {
+    if (!handle) {
+        return;
+    }
+    // Transfers ownership back to ARC and releases; dealloc removes the display.
+    CFBridgingRelease(handle);
+}

--- a/Thaw/VirtualDisplay/VirtualDisplay.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplay.swift
@@ -1,0 +1,64 @@
+//
+//  VirtualDisplay.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+
+/// A headless virtual display created via the private CGVirtualDisplay API.
+///
+/// On macOS 26 the bundle-ID "marker" windows that source-PID marker-pair
+/// resolution relies on are only published by the window server when two or
+/// more displays exist. On a single physical display they are absent, so
+/// Control-Center-hosted widgets (Little Snitch's agent, Timemator, etc.) stay
+/// unresolved. Briefly adding a virtual display makes the window server publish
+/// those markers so the existing marker-pair pass can resolve the orphans; the
+/// resolved windowID -> PID mappings persist in the cache after the display is
+/// removed, so it only needs to be present long enough to resolve once.
+final class VirtualDisplay {
+    private let handle: UnsafeMutableRawPointer
+    private var isValid = true
+
+    /// The display identifier assigned by the window server, or 0 if unknown.
+    let displayID: CGDirectDisplayID
+
+    private init(handle: UnsafeMutableRawPointer, displayID: CGDirectDisplayID) {
+        self.handle = handle
+        self.displayID = displayID
+    }
+
+    /// Whether the private CGVirtualDisplay class is present at runtime. When
+    /// false, creation would fail, so callers can skip the attempt entirely.
+    static var isSupported: Bool {
+        NSClassFromString("CGVirtualDisplay") != nil
+    }
+
+    /// Creates a virtual display, or returns nil when the private API is
+    /// unavailable or creation fails (the shim resolves the classes at runtime
+    /// and catches Objective-C exceptions, so this never crashes).
+    static func create() -> VirtualDisplay? {
+        guard let handle = ThawVirtualDisplayCreate() else {
+            return nil
+        }
+        return VirtualDisplay(handle: handle, displayID: ThawVirtualDisplayGetID(handle))
+    }
+
+    /// Removes the virtual display. Idempotent.
+    func invalidate() {
+        guard isValid else {
+            return
+        }
+        isValid = false
+        ThawVirtualDisplayDestroy(handle)
+    }
+
+    deinit {
+        if isValid {
+            ThawVirtualDisplayDestroy(handle)
+        }
+    }
+}

--- a/Thaw/VirtualDisplay/VirtualDisplay.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplay.swift
@@ -23,7 +23,8 @@ final class VirtualDisplay {
     private let handle: UnsafeMutableRawPointer
     private var isValid = true
 
-    /// The display identifier assigned by the window server, or 0 if unknown.
+    /// The display identifier assigned by the window server. Always non-zero;
+    /// create returns nil when no valid identifier is available.
     let displayID: CGDirectDisplayID
 
     private init(handle: UnsafeMutableRawPointer, displayID: CGDirectDisplayID) {
@@ -44,7 +45,16 @@ final class VirtualDisplay {
         guard let handle = ThawVirtualDisplayCreate() else {
             return nil
         }
-        return VirtualDisplay(handle: handle, displayID: ThawVirtualDisplayGetID(handle))
+        let displayID = ThawVirtualDisplayGetID(handle)
+        guard displayID != 0 else {
+            // Without a valid display ID the phantom cannot be excluded from
+            // display enumeration (Bridging.excludedDisplayID would only filter
+            // the null display), so it would leak into per-display behaviours.
+            // Treat it as a creation failure and tear the handle down.
+            ThawVirtualDisplayDestroy(handle)
+            return nil
+        }
+        return VirtualDisplay(handle: handle, displayID: displayID)
     }
 
     /// Removes the virtual display. Idempotent.

--- a/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
@@ -1,0 +1,308 @@
+//
+//  VirtualDisplayProvoker.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import AppKit
+import Foundation
+
+/// Briefly creates a virtual display when, on a single physical display, menu
+/// bar items remain unresolved (nil sourcePID), so the window server publishes
+/// the bundle-ID marker windows that marker-pair resolution needs. Once the
+/// orphans resolve, their windowID -> PID mappings persist in the cache (and
+/// the elimination sticky map), so the display only has to be present long
+/// enough to resolve once, then it is torn down.
+///
+/// Extensive timing is logged so the settle latency (display created -> markers
+/// published -> orphans resolved) can be measured from the field.
+@MainActor
+final class VirtualDisplayProvoker {
+    private let diagLog = DiagLog(category: "VirtualDisplayProvoke")
+    private weak var appState: AppState?
+
+    private var display: VirtualDisplay?
+    private var isProvoking = false
+    /// Whether the one-time support log has been emitted.
+    private var hasLoggedSupport = false
+    /// Rate-limits the per-call decision trace.
+    private var lastDecisionLog = Date.distantPast
+    /// Whether a grace-expiry re-check is already scheduled.
+    private var recheckScheduled = false
+
+    /// While a provoke runs and for a short window after teardown, creating
+    /// and removing the virtual display each post a
+    /// didChangeScreenParametersNotification. Those fire even though the phantom
+    /// is excluded from display enumeration, and subscribers debounce them
+    /// (DisplaySettingsManager coalesces for 1s), so they land after teardown
+    /// when excludedDisplayID is already nil. Display-change subscribers read
+    /// this to ignore the self-inflicted churn instead of reacting to it: a
+    /// screen-parameters reaction was observed cancelling the in-flight item
+    /// cache cycle mid-resolution, surfacing a whole bar of orphans for several
+    /// seconds until the next recache. The window extends past teardown so the
+    /// debounced notifications are still covered when they arrive.
+    @MainActor static var displayReactionsSuppressedUntil: Date?
+
+    /// When each currently-unresolved orphan windowID was first observed.
+    private var firstSeenUnresolved = [CGWindowID: Date]()
+    /// Last provoke attempt per windowID, for the cooldown.
+    private var lastAttempt = [CGWindowID: Date]()
+
+    /// How long an orphan must stay unresolved before provoking, so we do not
+    /// fire for items the normal AX / marker pass resolves within a cycle.
+    private let unresolvedGrace: TimeInterval = 3
+    /// Minimum time between provoke attempts for the same windowID, so an
+    /// orphan that cannot resolve even with a display does not flicker-loop.
+    private let attemptCooldown: TimeInterval = 300
+    /// Maximum time to keep the virtual display up waiting for resolution.
+    private let maxHold: TimeInterval = 12
+    /// Poll cadence while waiting for markers to publish and orphans to resolve.
+    private let pollInterval: Duration = .milliseconds(250)
+
+    init(appState: AppState) {
+        self.appState = appState
+        startPeriodicEvaluation()
+    }
+
+    /// Re-evaluates on a steady cadence so a stuck orphan is provoked even when
+    /// menu bar item-cache changes (the other trigger) are sparse once the bar
+    /// is idle. considerProvoking is cheap and early-returns unless a single
+    /// display has an unresolved orphan, so a short interval is inexpensive.
+    private func startPeriodicEvaluation() {
+        Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                guard let self else {
+                    return
+                }
+                self.considerProvoking()
+            }
+        }
+    }
+
+    /// Re-evaluates whether to run a provoke cycle. Cheap and safe to call
+    /// after every cache cycle; it pulls the current orphan set and display
+    /// count itself and no-ops unless the conditions hold.
+    func considerProvoking() {
+        // Log support state once so an absent CGVirtualDisplay (which otherwise
+        // makes this method return silently) is visible in the field log.
+        if !hasLoggedSupport {
+            hasLoggedSupport = true
+            diagLog.info("VirtualDisplayProvoke: CGVirtualDisplay supported=\(VirtualDisplay.isSupported)")
+        }
+
+        guard !isProvoking, VirtualDisplay.isSupported, let appState else {
+            return
+        }
+
+        let displayCount = NSScreen.managedScreens.count
+        let orphans = appState.itemManager.unresolvedOrphanWindowIDs()
+        let settling = appState.itemManager.isSettling
+        let now = Date()
+        let shouldLogDecision = now.timeIntervalSince(lastDecisionLog) >= 5
+
+        // Only single-display machines lack the marker windows. Multi-display
+        // (physical or virtual) already publishes them. managedScreens excludes
+        // any virtual display we created.
+        guard displayCount == 1, !orphans.isEmpty else {
+            firstSeenUnresolved.removeAll()
+            lastAttempt.removeAll()
+            return
+        }
+
+        // Wait out settling (cold boot, profile apply): items are transiently
+        // unresolved then; only once it ends has the normal pipeline (spatial
+        // AX, marker-pair, elimination) had its chance, so a still-unresolved
+        // item is genuinely stuck. Clearing firstSeenUnresolved here measures
+        // the grace from after settling, never from cold-boot churn.
+        guard !settling else {
+            firstSeenUnresolved.removeAll()
+            if shouldLogDecision {
+                lastDecisionLog = now
+                diagLog.info("VirtualDisplayProvoke: deferring while settling (orphans \(orphans.sorted()))")
+            }
+            return
+        }
+
+        // Forget state for windowIDs that are no longer orphaned.
+        firstSeenUnresolved = firstSeenUnresolved.filter { orphans.contains($0.key) }
+        lastAttempt = lastAttempt.filter { orphans.contains($0.key) }
+        for windowID in orphans where firstSeenUnresolved[windowID] == nil {
+            firstSeenUnresolved[windowID] = now
+        }
+
+        let eligible = orphans.filter { windowID in
+            guard
+                let firstSeen = firstSeenUnresolved[windowID],
+                now.timeIntervalSince(firstSeen) >= unresolvedGrace
+            else {
+                return false
+            }
+            if let attempted = lastAttempt[windowID], now.timeIntervalSince(attempted) < attemptCooldown {
+                return false
+            }
+            return true
+        }
+
+        guard !eligible.isEmpty else {
+            // Diagnostic: a single-display orphan that is not (yet) provoked.
+            // Shows why so a non-firing case is explainable from the field log.
+            if shouldLogDecision {
+                lastDecisionLog = now
+                let ages = orphans.sorted().map { windowID in
+                    let age = firstSeenUnresolved[windowID].map { now.timeIntervalSince($0) } ?? 0
+                    return "\(windowID):\(String(format: "%.1f", age))s"
+                }
+                let cooled = orphans.sorted().filter { windowID in
+                    lastAttempt[windowID].map { now.timeIntervalSince($0) < attemptCooldown } ?? false
+                }
+                diagLog.info(
+                    "VirtualDisplayProvoke: not yet eligible (orphan ages \(ages), grace \(unresolvedGrace)s, cooldown-blocked \(cooled))"
+                )
+            }
+            // Re-check at grace expiry so firing does not depend on an incidental
+            // cache cycle landing after the grace elapses.
+            scheduleRecheckIfNeeded()
+            return
+        }
+
+        // Claim the in-flight slot synchronously so a concurrent call cannot
+        // spawn a second provoke before the task starts.
+        isProvoking = true
+        let targets = Set(eligible)
+        lastDecisionLog = now
+        diagLog.info("VirtualDisplayProvoke: eligible \(targets.sorted()); starting provoke")
+        Task { await runProvoke(targets: targets) }
+    }
+
+    /// Schedules a single re-evaluation after the grace period so a stuck
+    /// orphan provokes even when no further cache cycle happens to occur.
+    private func scheduleRecheckIfNeeded() {
+        guard !recheckScheduled else {
+            return
+        }
+        recheckScheduled = true
+        Task { [weak self] in
+            try? await Task.sleep(for: .seconds(3.5))
+            guard let self else {
+                return
+            }
+            self.recheckScheduled = false
+            self.considerProvoking()
+        }
+    }
+
+    private func runProvoke(targets: Set<CGWindowID>) async {
+        defer { isProvoking = false }
+        guard let appState else {
+            return
+        }
+
+        let attemptTime = Date()
+        for windowID in targets {
+            lastAttempt[windowID] = attemptTime
+        }
+
+        let start = Date()
+        diagLog.info(
+            "VirtualDisplayProvoke: single display with \(targets.count) unresolved orphan(s) \(targets.sorted()); creating virtual display"
+        )
+        guard let display = VirtualDisplay.create() else {
+            // Report which private classes resolved so a binding failure on a
+            // given macOS version is diagnosable from Thaw's own log (the ObjC
+            // shim's detail goes to the system log, which the tester may not
+            // capture).
+            diagLog.error(
+                "VirtualDisplayProvoke: CGVirtualDisplay creation failed; cannot provoke. Classes present: "
+                    + "descriptor=\(NSClassFromString("CGVirtualDisplayDescriptor") != nil), "
+                    + "display=\(NSClassFromString("CGVirtualDisplay") != nil), "
+                    + "mode=\(NSClassFromString("CGVirtualDisplayMode") != nil), "
+                    + "settings=\(NSClassFromString("CGVirtualDisplaySettings") != nil)"
+            )
+            return
+        }
+        self.display = display
+        // Exclude our phantom from Thaw's display enumeration so it never
+        // pollutes per-display state (the Displays settings panel, overlay
+        // panels, profile auto-switch, etc.) while it briefly exists. The
+        // marker windows it makes the window server publish are unaffected.
+        Bridging.excludedDisplayID = display.displayID
+        // Suppress display-change reactions for the lifetime of the phantom so
+        // its creation notification is ignored; converted to a bounded grace at
+        // teardown to also cover the debounced removal notification.
+        Self.displayReactionsSuppressedUntil = .distantFuture
+        diagLog.info(
+            "VirtualDisplayProvoke: created virtual display id=\(display.displayID); polling for marker-pair resolution"
+        )
+
+        var resolvedAll = false
+        while Date().timeIntervalSince(start) < maxHold {
+            try? await Task.sleep(for: pollInterval)
+            let stillUnresolved = await unresolvedTargets(targets)
+            let elapsed = Date().timeIntervalSince(start)
+            diagLog.info(
+                "VirtualDisplayProvoke: +\(String(format: "%.2f", elapsed))s \(targets.count - stillUnresolved.count)/\(targets.count) target orphan(s) resolved"
+            )
+            if stillUnresolved.isEmpty {
+                resolvedAll = true
+                diagLog.info(
+                    "VirtualDisplayProvoke: all targets resolved \(String(format: "%.2f", elapsed))s after display creation"
+                )
+                break
+            }
+        }
+        if !resolvedAll {
+            diagLog.info(
+                "VirtualDisplayProvoke: gave up after \(String(format: "%.2f", maxHold))s; some orphans still unresolved (retry after cooldown)"
+            )
+        }
+
+        Bridging.excludedDisplayID = nil
+        display.invalidate()
+        self.display = nil
+        // Keep suppressing past teardown so the removal's debounced
+        // (and any coalesced creation) screen-parameters notification, which
+        // arrives about a second later, is still ignored.
+        Self.displayReactionsSuppressedUntil = Date().addingTimeInterval(2.0)
+        diagLog.info(
+            "VirtualDisplayProvoke: removed virtual display \(String(format: "%.2f", Date().timeIntervalSince(start)))s after creation"
+        )
+
+        // Persistence check: the one-shot only works if the resolved windowID
+        // -> PID mappings survive the display being removed. Read fresh (which
+        // returns the XPC's cached PIDs now that the marker is gone) and report
+        // how many targets are still resolved.
+        let stillUnresolved = await unresolvedTargets(targets)
+        diagLog.info(
+            "VirtualDisplayProvoke: after teardown \(targets.count - stillUnresolved.count)/\(targets.count) target(s) still resolved (persistence check)"
+        )
+
+        // Propagate the freshly resolved sourcePIDs into the manager's
+        // published item cache. The provoke only updates the XPC's PID cache;
+        // without this the cached items keep their pre-provoke nil sourcePID
+        // (the icon stays labelled com.apple.controlcenter:Item-0, and any
+        // layout pass in the meantime treats it as an orphan) until an
+        // unrelated event happens to trigger the next full cache cycle. The
+        // phantom is gone and its screen-parameters notifications are
+        // suppressed, so this refresh runs cleanly, no cancellation, no orphan
+        // flash. Skipped when nothing resolved, since the cache is already
+        // up to date in that case.
+        if stillUnresolved.count < targets.count {
+            await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+        }
+    }
+
+    /// Returns which of the given target windowIDs are still unresolved, read
+    /// from a fresh getMenuBarItems. This both drives the XPC scan (so marker-
+    /// pair resolution runs while the marker window is present) and reads the
+    /// authoritative result, rather than the cached itemCache whose refresh can
+    /// be dropped by the in-flight cache gate during the rapid provoke poll.
+    private func unresolvedTargets(_ targets: Set<CGWindowID>) async -> Set<CGWindowID> {
+        let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        return targets.filter { windowID in
+            items.contains { $0.windowID == windowID && $0.sourcePID == nil }
+        }
+    }
+}

--- a/ThawTests/Fixtures/LittleSnitchOrphanLog.swift
+++ b/ThawTests/Fixtures/LittleSnitchOrphanLog.swift
@@ -1,0 +1,53 @@
+//
+//  LittleSnitchOrphanLog.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+/// A trimmed, verbatim excerpt from a field-captured Thaw log used as the
+/// first fixture for the profile-layout log-replay harness.
+///
+/// Source: thaw_2026-05-29_17-13-13.log (a ~23k-line capture reported by a
+/// user whose Little Snitch agent kept moving on launch). Only the lines the
+/// harness parses are retained, copied without modification:
+///
+///   - the Missing sourcePID warning that proves the Little Snitch agent icon
+///     (windowID 64, namespaced com.apple.controlcenter:Item-0) had no
+///     resolved source process for most of the session;
+///   - one buggy applyProfileLayout cycle at 17:13:37 where the unresolved
+///     orphan is the sole item routed through planUnmanagedPlacement and then
+///     physically moved;
+///   - one clean applyProfileLayout cycle at 18:01:11, after marker-pair
+///     resolution renamed the same physical item to
+///     at.obdev.littlesnitch.agent:Item-0, where nothing is unmanaged.
+///
+/// Thaw does not log the desired visible set (only desiredHidden / desiredAH),
+/// which is why the harness reconstructs it; see the harness for how.
+enum LittleSnitchOrphanLog {
+    static let text = """
+    2026-05-29 17:13:15.062 [WARNING] [MenuBarItemManager] Missing sourcePID for <com.apple.controlcenter:Item-0 (windowID: 64)>
+    2026-05-29 17:13:37.430 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 3 items: ["com.stonerl.Thaw:Thaw.ControlItem.Visible", "com.apple.controlcenter:Item-0", "com.rogueamoeba.soundsource:SSMainAppMenuIcon"]
+    2026-05-29 17:13:37.430 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 5 items: ["com.microsoft.OneDrive-mac:Item-0", "app.updatest.Updatest:Item-0", "org.eduvpn.app:Item-0", "com.wireguard.macos:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine"]
+    2026-05-29 17:13:37.431 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 7 items: ["com.governikus.ausweisapp2:Item-0", "pl.maketheweb.pixelsnap2:Item-0", "pl.maketheweb.cleanshotx:Item-0", "org.languagetool.desktop:Item-0", "com.DanPristupov.Fork:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0"]
+    2026-05-29 17:13:37.433 [DEBUG] [MenuBarItemManager] Profile layout: planUnmanagedPlacement com.apple.controlcenter:Item-0 -> newItemAnchored(section=visible section, anchor=com.apple.controlcenter:Item-0, relation=leftOfAnchor)
+    2026-05-29 17:13:37.433 [DEBUG] [MenuBarItemManager] Profile layout: 1 unmanaged item(s) placed via planUnmanagedPlacement
+    2026-05-29 17:13:37.436 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: ahCtrlUID=com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden, crossSectionMoves=0, totalSectionMismatch=0
+    2026-05-29 17:13:37.436 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: currentHidden=["app.updatest.Updatest:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine", "com.microsoft.OneDrive-mac:Item-0", "com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden", "com.wireguard.macos:Item-0", "org.eduvpn.app:Item-0"]
+    2026-05-29 17:13:37.436 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: currentAH=["com.DanPristupov.Fork:Item-0", "com.governikus.ausweisapp2:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0", "org.languagetool.desktop:Item-0", "pl.maketheweb.cleanshotx:Item-0", "pl.maketheweb.pixelsnap2:Item-0"]
+    2026-05-29 17:13:37.436 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredHidden=["app.updatest.Updatest:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine", "com.microsoft.OneDrive-mac:Item-0", "com.wireguard.macos:Item-0", "org.eduvpn.app:Item-0"]
+    2026-05-29 17:13:37.436 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredAH=["com.DanPristupov.Fork:Item-0", "com.c-command.SpamSieve:com.c-command.spamsieve", "com.governikus.ausweisapp2:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0", "org.languagetool.desktop:Item-0", "pl.maketheweb.cleanshotx:Item-0", "pl.maketheweb.pixelsnap2:Item-0"]
+    2026-05-29 17:13:37.536 [INFO] [MenuBarItemManager] Moving <com.apple.controlcenter:Item-0 (windowID: 64)> to right of <com.rogueamoeba.soundsource:SSMainAppMenuIcon (windowID: 51) (windowID: 51)> on display 1
+    2026-05-29 17:59:54.647 [INFO] [SourcePIDCache] SourcePIDCache marker-pair resolution: windowID=5992 → PID 843 via marker windowID=6558 (title=at.obdev.littlesnitch.agent)
+    2026-05-29 18:01:11.245 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 3 items: ["com.stonerl.Thaw:Thaw.ControlItem.Visible", "com.rogueamoeba.soundsource:SSMainAppMenuIcon", "at.obdev.littlesnitch.agent:Item-0"]
+    2026-05-29 18:01:11.246 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 5 items: ["com.microsoft.OneDrive-mac:Item-0", "app.updatest.Updatest:Item-0", "org.eduvpn.app:Item-0", "com.wireguard.macos:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine"]
+    2026-05-29 18:01:11.246 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 7 items: ["com.governikus.ausweisapp2:Item-0", "pl.maketheweb.pixelsnap2:Item-0", "pl.maketheweb.cleanshotx:Item-0", "org.languagetool.desktop:Item-0", "com.DanPristupov.Fork:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0"]
+    2026-05-29 18:01:11.247 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: ahCtrlUID=com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden, crossSectionMoves=0, totalSectionMismatch=0
+    2026-05-29 18:01:11.247 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: currentHidden=["app.updatest.Updatest:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine", "com.microsoft.OneDrive-mac:Item-0", "com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden", "com.wireguard.macos:Item-0", "org.eduvpn.app:Item-0"]
+    2026-05-29 18:01:11.247 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: currentAH=["com.DanPristupov.Fork:Item-0", "com.governikus.ausweisapp2:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0", "org.languagetool.desktop:Item-0", "pl.maketheweb.cleanshotx:Item-0", "pl.maketheweb.pixelsnap2:Item-0"]
+    2026-05-29 18:01:11.247 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredHidden=["app.updatest.Updatest:Item-0", "com.apple.systemuiserver:com.apple.menuextra.TimeMachine", "com.microsoft.OneDrive-mac:Item-0", "com.wireguard.macos:Item-0", "org.eduvpn.app:Item-0"]
+    2026-05-29 18:01:11.247 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredAH=["com.DanPristupov.Fork:Item-0", "com.c-command.SpamSieve:com.c-command.spamsieve", "com.governikus.ausweisapp2:Item-0", "com.shortery-app.Shortery:Item-0", "de.fauler-apfel.CMD-Z:Item-0", "org.languagetool.desktop:Item-0", "pl.maketheweb.cleanshotx:Item-0", "pl.maketheweb.pixelsnap2:Item-0"]
+    2026-05-29 18:01:11.255 [INFO] [MenuBarItemManager] Moving <com.rogueamoeba.soundsource:SSMainAppMenuIcon (windowID: 51) (windowID: 51)> to right of <at.obdev.littlesnitch.agent:Item-0 (windowID: 5992) (windowID: 5992)> on display 1
+    """
+}

--- a/ThawTests/FlattenCurrentSectionsTests.swift
+++ b/ThawTests/FlattenCurrentSectionsTests.swift
@@ -1,0 +1,65 @@
+//
+//  FlattenCurrentSectionsTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Tests for LayoutSolver.flattenCurrentSections, the pure helper that builds
+/// the ordered currentFlat sequence applyProfileLayout and the log-replay
+/// harness both consume.
+final class FlattenCurrentSectionsTests: XCTestCase {
+    private let hiddenCtrl = "com.stonerl.Thaw:Thaw.ControlItem.Hidden"
+    private let ahCtrl = "com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden"
+
+    /// Items are laid out visible, hidden control, hidden, always-hidden
+    /// control, always-hidden. The visible control item rides along in the
+    /// visible array and is not reinserted.
+    func testOrderWithAlwaysHiddenPresent() {
+        let visibleCtrl = "com.stonerl.Thaw:Thaw.ControlItem.Visible"
+        let result = LayoutSolver.flattenCurrentSections(
+            visible: [visibleCtrl, "a:Item-0", "b:Item-0"],
+            hidden: ["c:Item-0"],
+            alwaysHidden: ["d:Item-0"],
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: ahCtrl
+        )
+
+        XCTAssertEqual(
+            result,
+            [visibleCtrl, "a:Item-0", "b:Item-0", hiddenCtrl, "c:Item-0", ahCtrl, "d:Item-0"]
+        )
+    }
+
+    /// With no always-hidden control item, its boundary marker is omitted but
+    /// any always-hidden items still follow the hidden section.
+    func testAlwaysHiddenControlOmittedWhenNil() {
+        let result = LayoutSolver.flattenCurrentSections(
+            visible: ["a:Item-0"],
+            hidden: ["b:Item-0"],
+            alwaysHidden: ["c:Item-0"],
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: nil
+        )
+
+        XCTAssertEqual(result, ["a:Item-0", hiddenCtrl, "b:Item-0", "c:Item-0"])
+    }
+
+    /// Empty sections still emit the hidden control item, which marks the
+    /// visible/hidden boundary.
+    func testEmptySectionsEmitOnlyHiddenControl() {
+        let result = LayoutSolver.flattenCurrentSections(
+            visible: [],
+            hidden: [],
+            alwaysHidden: [],
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: nil
+        )
+
+        XCTAssertEqual(result, [hiddenCtrl])
+    }
+}

--- a/ThawTests/PartitionUnmanagedUIDsTests.swift
+++ b/ThawTests/PartitionUnmanagedUIDsTests.swift
@@ -43,7 +43,8 @@ final class PartitionUnmanagedUIDsTests: XCTestCase {
             desiredUIDs: [],
             hiddenCtrlUID: hidden,
             ahCtrlUID: ah,
-            visibleCtrlUID: visible
+            visibleCtrlUID: visible,
+            unresolvedGenericCCUIDs: []
         )
 
         XCTAssertEqual(result, [app])
@@ -64,7 +65,8 @@ final class PartitionUnmanagedUIDsTests: XCTestCase {
             desiredUIDs: [saved],
             hiddenCtrlUID: hidden,
             ahCtrlUID: nil,
-            visibleCtrlUID: visible
+            visibleCtrlUID: visible,
+            unresolvedGenericCCUIDs: []
         )
 
         XCTAssertEqual(result, [unsaved])
@@ -83,10 +85,32 @@ final class PartitionUnmanagedUIDsTests: XCTestCase {
             desiredUIDs: [saved],
             hiddenCtrlUID: nil,
             ahCtrlUID: nil,
-            visibleCtrlUID: nil
+            visibleCtrlUID: nil,
+            unresolvedGenericCCUIDs: []
         )
 
         XCTAssertEqual(result, [unsaved])
+    }
+
+    /// Items passed in unresolvedGenericCCUIDs are excluded even though they
+    /// are absent from desiredUIDs and are not control items. This is the
+    /// Little Snitch orphan case: a Control-Center-hosted widget with no
+    /// resolved source PID must not be treated as an unmanaged arrival and
+    /// relocated.
+    func testUnresolvedGenericCCUIDsAreExcluded() {
+        let orphan = "com.apple.controlcenter:Item-0"
+        let app = "com.example.app:Item-0"
+
+        let result = LayoutSolver.partitionUnmanagedUIDs(
+            currentFlat: [orphan, app],
+            desiredUIDs: [],
+            hiddenCtrlUID: nil,
+            ahCtrlUID: nil,
+            visibleCtrlUID: nil,
+            unresolvedGenericCCUIDs: [orphan]
+        )
+
+        XCTAssertEqual(result, [app])
     }
 
     /// Input order is preserved. The LCS planner iterates the result in
@@ -103,7 +127,8 @@ final class PartitionUnmanagedUIDsTests: XCTestCase {
             desiredUIDs: [],
             hiddenCtrlUID: nil,
             ahCtrlUID: nil,
-            visibleCtrlUID: nil
+            visibleCtrlUID: nil,
+            unresolvedGenericCCUIDs: []
         )
 
         XCTAssertEqual(result, [c, a, b])
@@ -117,7 +142,8 @@ final class PartitionUnmanagedUIDsTests: XCTestCase {
             desiredUIDs: ["com.example.app:Item-0"],
             hiddenCtrlUID: "h",
             ahCtrlUID: "ah",
-            visibleCtrlUID: "v"
+            visibleCtrlUID: "v",
+            unresolvedGenericCCUIDs: []
         )
 
         XCTAssertTrue(result.isEmpty)

--- a/ThawTests/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/ProfileLayoutLogReplayTests.swift
@@ -1,0 +1,447 @@
+//
+//  ProfileLayoutLogReplayTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+/// Log-replay harness for the profile-layout decision path.
+///
+/// Parses real Thaw log lines into per-cycle records and drives the actual
+/// pure planner (LayoutSolver.partitionUnmanagedUIDs) with inputs
+/// reconstructed from those records. This characterizes "given the menu bar
+/// shape Thaw observed on this cycle, did the planner deem the right items
+/// unmanaged" without standing up the async orchestrator, AX, or the Window
+/// Server. New field logs become regression fixtures by adding another
+/// excerpt and another expectation.
+///
+/// Fixture one is LittleSnitchOrphanLog: a user whose Little Snitch agent
+/// kept moving on launch. Its agent icon is hosted by Control Center with no
+/// resolvable source PID, so it is namespaced com.apple.controlcenter:Item-0
+/// and, not matching the profile's at.obdev.littlesnitch.agent:Item-0 entry,
+/// is treated as an unmanaged new arrival and relocated every cycle until
+/// marker-pair resolution finally identifies it ~46 minutes in.
+///
+/// The Layer-1 fix excludes unresolved generic Control Center orphans from the
+/// unmanaged set inside the live partitioner. Two tests pin it down:
+/// testWithoutExclusionTheOrphanWouldBeUnmanaged documents the bug mechanism
+/// (with no exclusion the orphan is classified unmanaged, matching the field
+/// log), and testBuggyCycleDoesNotPlanMoveForUnresolvedOrphan is the regression
+/// lock that fails before the fix and passes after it.
+final class ProfileLayoutLogReplayTests: XCTestCase {
+    private let orphanUID = "com.apple.controlcenter:Item-0"
+
+    // MARK: Parser characterization
+
+    /// The parser recovers both applyProfileLayout cycles and the field
+    /// verdict each one logged: one unmanaged item in the buggy cycle, none
+    /// in the post-resolution clean cycle.
+    func testParserRecoversBothCyclesAndLoggedVerdicts() throws {
+        let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
+
+        XCTAssertEqual(parsed.cycles.count, 2)
+        XCTAssertTrue(
+            parsed.unresolvedSourcePIDBaseUIDs.contains(orphanUID),
+            "Missing sourcePID line should mark the orphan as unresolved"
+        )
+
+        let buggy = try XCTUnwrap(parsed.cycles.first)
+        XCTAssertEqual(buggy.loggedUnmanagedUIDs, [orphanUID])
+        XCTAssertTrue(buggy.currentVisible.contains(orphanUID))
+
+        let clean = try XCTUnwrap(parsed.cycles.last)
+        XCTAssertEqual(clean.loggedUnmanagedUIDs, [])
+        XCTAssertTrue(clean.currentVisible.contains("at.obdev.littlesnitch.agent:Item-0"))
+    }
+
+    // MARK: Bug mechanism (documents what the exclusion is responsible for)
+
+    /// With no orphan exclusion (unresolvedGenericCCUIDs empty), replaying the
+    /// buggy cycle through the real partitioner reproduces the field verdict
+    /// exactly: the unresolved Little Snitch orphan is the sole item routed to
+    /// planUnmanagedPlacement, which is what dragged it on every cycle. The
+    /// unmanaged set is reconstructed independently of the planUnmanagedPlace-
+    /// ment log lines (the orphan is identified via the Missing sourcePID
+    /// signal), so matching them is a genuine characterization, not a tautology.
+    func testWithoutExclusionTheOrphanWouldBeUnmanaged() throws {
+        let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
+        let buggy = try XCTUnwrap(parsed.cycles.first)
+        let inputs = buggy.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
+
+        XCTAssertEqual(inputs.unresolvedGenericCCOrphans, [orphanUID])
+
+        let result = LayoutSolver.partitionUnmanagedUIDs(
+            currentFlat: inputs.currentFlat,
+            desiredUIDs: inputs.desiredUIDs,
+            hiddenCtrlUID: inputs.hiddenCtrlUID,
+            ahCtrlUID: inputs.ahCtrlUID,
+            visibleCtrlUID: inputs.visibleCtrlUID,
+            unresolvedGenericCCUIDs: []
+        )
+
+        XCTAssertEqual(result, buggy.loggedUnmanagedUIDs)
+        XCTAssertEqual(result, [orphanUID])
+    }
+
+    // MARK: Regression lock for Layer 1 (red before the fix, green after)
+
+    /// Replaying the buggy cycle through the live partitioner, passing the
+    /// orphan set the orchestrator now computes, the unresolved Little Snitch
+    /// orphan is no longer classified unmanaged, so no unmanaged placement (and
+    /// therefore no move) is planned for it. This fails before Layer 1 applies
+    /// unresolvedGenericCCUIDs and passes once it does.
+    func testBuggyCycleDoesNotPlanMoveForUnresolvedOrphan() throws {
+        let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
+        let buggy = try XCTUnwrap(parsed.cycles.first)
+        let inputs = buggy.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
+
+        // The field log confirms this orphan WAS classified unmanaged and moved.
+        XCTAssertTrue(buggy.loggedUnmanagedUIDs.contains(orphanUID))
+        XCTAssertEqual(inputs.unresolvedGenericCCOrphans, [orphanUID])
+
+        let result = LayoutSolver.partitionUnmanagedUIDs(
+            currentFlat: inputs.currentFlat,
+            desiredUIDs: inputs.desiredUIDs,
+            hiddenCtrlUID: inputs.hiddenCtrlUID,
+            ahCtrlUID: inputs.ahCtrlUID,
+            visibleCtrlUID: inputs.visibleCtrlUID,
+            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+        )
+
+        XCTAssertFalse(
+            result.contains(orphanUID),
+            "Unresolved Little Snitch orphan must not be classified unmanaged"
+        )
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: Baseline: the clean cycle stays clean
+
+    /// After marker-pair resolution the same physical item is namespaced
+    /// at.obdev.littlesnitch.agent:Item-0, which the profile knows, so the
+    /// unchanged partitioner already deems nothing unmanaged. This guards
+    /// against a fix that over-suppresses correctly-identified items.
+    func testCleanCycleHasNoUnmanagedUnderCurrentPartition() throws {
+        let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
+        let clean = try XCTUnwrap(parsed.cycles.last)
+        let inputs = clean.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
+
+        XCTAssertTrue(inputs.unresolvedGenericCCOrphans.isEmpty)
+
+        let result = LayoutSolver.partitionUnmanagedUIDs(
+            currentFlat: inputs.currentFlat,
+            desiredUIDs: inputs.desiredUIDs,
+            hiddenCtrlUID: inputs.hiddenCtrlUID,
+            ahCtrlUID: inputs.ahCtrlUID,
+            visibleCtrlUID: inputs.visibleCtrlUID,
+            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+        )
+
+        XCTAssertEqual(result, clean.loggedUnmanagedUIDs)
+        XCTAssertTrue(result.isEmpty)
+    }
+
+    // MARK: Live wiring: control identifiers come from live tags
+
+    /// The control identifiers the harness feeds the partitioner are derived
+    /// from the live control-item tags, and they match what the field log
+    /// recorded. If a control item's namespace or title changes in the Thaw
+    /// codebase, this fails rather than silently diverging from real logs.
+    func testLiveControlItemUIDsMatchTheFieldLog() throws {
+        let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
+        let buggy = try XCTUnwrap(parsed.cycles.first)
+
+        XCTAssertEqual(
+            MenuBarItemTag.alwaysHiddenControlItem.tagIdentifier,
+            buggy.ahCtrlUID,
+            "Live always-hidden control tag should equal the logged ahCtrlUID"
+        )
+        XCTAssertTrue(
+            buggy.currentVisible.contains(MenuBarItemTag.visibleControlItem.tagIdentifier),
+            "Live visible control tag should appear in the logged visible section"
+        )
+    }
+
+    // MARK: Hardening: prefer the logged desiredVisible over inference
+
+    /// With the Phase 1 desiredVisible line present, the harness uses it
+    /// verbatim instead of inferring desired-visible from the current bar.
+    /// Constructed so the two paths disagree: `com.example.extra:Item-0` is a
+    /// non-orphan visible item the profile does not cover, so inference (which
+    /// keeps every non-orphan visible item) would wrongly treat it as desired
+    /// and never flag it, whereas the logged desiredVisible omits it and the
+    /// partitioner correctly classifies it unmanaged, matching the log.
+    func testLoggedDesiredVisibleIsUsedInsteadOfInference() throws {
+        let log = """
+        2026-05-30 09:00:00.000 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 3 items: ["com.stonerl.Thaw:Thaw.ControlItem.Visible", "com.example.extra:Item-0", "com.rogueamoeba.soundsource:SSMainAppMenuIcon"]
+        2026-05-30 09:00:00.001 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 0 items: []
+        2026-05-30 09:00:00.002 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 0 items: []
+        2026-05-30 09:00:00.003 [DEBUG] [MenuBarItemManager] Profile layout: planUnmanagedPlacement com.example.extra:Item-0 -> newItemDefault(section=hidden section)
+        2026-05-30 09:00:00.004 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: ahCtrlUID=com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden, crossSectionMoves=0, totalSectionMismatch=0
+        2026-05-30 09:00:00.004 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredHidden=[]
+        2026-05-30 09:00:00.004 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredAH=[]
+        2026-05-30 09:00:00.004 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredVisible=["com.rogueamoeba.soundsource:SSMainAppMenuIcon"]
+        """
+
+        let parsed = ProfileLayoutLogReplay.parse(log)
+        let cycle = try XCTUnwrap(parsed.cycles.first)
+        XCTAssertEqual(cycle.desiredVisible, ["com.rogueamoeba.soundsource:SSMainAppMenuIcon"])
+
+        let inputs = cycle.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
+        XCTAssertTrue(inputs.unresolvedGenericCCOrphans.isEmpty)
+
+        let result = LayoutSolver.partitionUnmanagedUIDs(
+            currentFlat: inputs.currentFlat,
+            desiredUIDs: inputs.desiredUIDs,
+            hiddenCtrlUID: inputs.hiddenCtrlUID,
+            ahCtrlUID: inputs.ahCtrlUID,
+            visibleCtrlUID: inputs.visibleCtrlUID,
+            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+        )
+
+        XCTAssertEqual(result, ["com.example.extra:Item-0"])
+        XCTAssertEqual(result, cycle.loggedUnmanagedUIDs)
+    }
+}
+
+/// Parses Thaw profile-layout log text into replayable cycles and drives the
+/// real partitioner. Kept test-only; it models just enough of one
+/// applyProfileLayout cycle to characterize the unmanaged-item decision.
+enum ProfileLayoutLogReplay {
+    /// One applyProfileLayout cycle reconstructed from the log.
+    struct Cycle {
+        var currentVisible: [String] = []
+        var currentHidden: [String] = []
+        var currentAlwaysHidden: [String] = []
+        var desiredHidden: [String] = []
+        var desiredAlwaysHidden: [String] = []
+        /// The desired visible set, present only in logs from builds that emit
+        /// the Phase 1 desiredVisible line. nil for older captures, in which
+        /// case partitionInputs reconstructs it.
+        var desiredVisible: [String]?
+        var ahCtrlUID: String?
+        /// UIDs the log actually routed through planUnmanagedPlacement this
+        /// cycle (the field verdict the harness characterizes against).
+        var loggedUnmanagedUIDs: [String] = []
+    }
+
+    /// The parsed result: the ordered cycles plus the set of menu bar items
+    /// the log reported as having no resolved source PID.
+    struct Parsed {
+        let cycles: [Cycle]
+        let unresolvedSourcePIDBaseUIDs: Set<String>
+    }
+
+    /// Inputs reconstructed for one cycle, shaped for partitionUnmanagedUIDs.
+    struct PartitionInputs {
+        let currentFlat: [String]
+        let desiredUIDs: Set<String>
+        let hiddenCtrlUID: String?
+        let ahCtrlUID: String?
+        let visibleCtrlUID: String?
+        /// Unresolved generic Control Center items present this cycle (nil
+        /// sourcePID, Item-N title). These are what the proposed fix excludes.
+        let unresolvedGenericCCOrphans: Set<String>
+    }
+
+    private static let visibleCtrlUID = "com.stonerl.Thaw:Thaw.ControlItem.Visible"
+    private static let hiddenCtrlUID = "com.stonerl.Thaw:Thaw.ControlItem.Hidden"
+
+    static func parse(_ text: String) -> Parsed {
+        var cycles = [Cycle]()
+        var unresolved = Set<String>()
+        var current: Cycle?
+
+        func flush() {
+            if let current {
+                cycles.append(current)
+            }
+        }
+
+        for rawLine in text.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = String(rawLine)
+
+            if let match = line.firstMatch(of: /Missing sourcePID for <(.+?) \(windowID: \d+\)>/) {
+                unresolved.insert(String(match.output.1))
+                continue
+            }
+
+            if let match = line.firstMatch(
+                of: /applyProfileLayout: current (visible|hidden|always-hidden) section has \d+ items: \[(.*)\]/
+            ) {
+                let section = String(match.output.1)
+                let uids = quotedStrings(in: match.output.2)
+                // A "current visible section" line opens a new cycle.
+                if section == "visible" {
+                    flush()
+                    current = Cycle()
+                    current?.currentVisible = uids
+                } else if section == "hidden" {
+                    current?.currentHidden = uids
+                } else {
+                    current?.currentAlwaysHidden = uids
+                }
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Profile layout Phase 1: ahCtrlUID=([^,]+),/) {
+                current?.ahCtrlUID = String(match.output.1)
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Profile layout Phase 1: desiredHidden=\[(.*)\]/) {
+                current?.desiredHidden = quotedStrings(in: match.output.1)
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Profile layout Phase 1: desiredAH=\[(.*)\]/) {
+                current?.desiredAlwaysHidden = quotedStrings(in: match.output.1)
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Profile layout Phase 1: desiredVisible=\[(.*)\]/) {
+                current?.desiredVisible = quotedStrings(in: match.output.1)
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Profile layout: planUnmanagedPlacement (\S+) ->/) {
+                current?.loggedUnmanagedUIDs.append(String(match.output.1))
+                continue
+            }
+        }
+        flush()
+
+        return Parsed(cycles: cycles, unresolvedSourcePIDBaseUIDs: unresolved)
+    }
+
+    /// Builds a live MenuBarItemTag from a logged uniqueIdentifier so the
+    /// harness exercises the real tag predicates (isControlCenterGenericItem,
+    /// isControlItem) and the real identifier format rather than reimplementing
+    /// them. Identifiers are `namespace:title[:index]`; only a trailing
+    /// all-digits component is the instance index, and titles may themselves
+    /// contain dots (e.g. com.apple.menuextra.TimeMachine) but not colons.
+    static func makeTag(fromUID uid: String, windowID: CGWindowID) -> MenuBarItemTag {
+        var parts = uid.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+        let namespace = parts.removeFirst()
+        var instanceIndex = 0
+        if parts.count > 1, let last = parts.last, let index = Int(last), String(index) == last {
+            instanceIndex = index
+            parts.removeLast()
+        }
+        let title = parts.joined(separator: ":")
+        return MenuBarItemTag(
+            namespace: .string(namespace),
+            title: title,
+            windowID: windowID,
+            instanceIndex: instanceIndex
+        )
+    }
+
+    /// Builds live MenuBarItem objects for a cycle's current bar. Section
+    /// membership and sourcePID resolution are observed state replayed from the
+    /// log (an item is unresolved when its identifier appeared in a Missing
+    /// sourcePID warning); everything derived from these items afterwards uses
+    /// live Thaw code.
+    static func makeCurrentItems(
+        sectionOrderedUIDs: [String],
+        unresolvedSourcePIDBaseUIDs: Set<String>,
+        windowIDBase: CGWindowID
+    ) -> [MenuBarItem] {
+        sectionOrderedUIDs.enumerated().map { offset, uid in
+            let windowID = windowIDBase + CGWindowID(offset)
+            let tag = makeTag(fromUID: uid, windowID: windowID)
+            let resolved = !unresolvedSourcePIDBaseUIDs.contains(uid)
+            return MenuBarItem.fixture(
+                tag: tag,
+                windowID: windowID,
+                sourcePID: resolved ? pid_t(Int(windowID)) : nil
+            )
+        }
+    }
+
+    /// Extracts the quoted UIDs from a logged array body like
+    /// `"a", "b", "c"`.
+    private static func quotedStrings(in body: Substring) -> [String] {
+        body.matches(of: /"([^"]+)"/).map { String($0.output.1) }
+    }
+}
+
+extension ProfileLayoutLogReplay.Cycle {
+    /// Reconstructs partitionUnmanagedUIDs inputs for this cycle.
+    ///
+    /// When the log carries the Phase 1 desiredVisible line (builds that emit
+    /// it), that captured set is used verbatim, so nothing about the desired
+    /// layout is inferred. For older captures that predate the line, the
+    /// visible desired set is reconstructed as the current visible items that
+    /// are neither control items nor unresolved generic Control Center
+    /// orphans, which is sound for those fixtures because the field log
+    /// confirmed the orphan was the only visible item the profile did not
+    /// cover.
+    func partitionInputs(unresolvedSourcePIDBaseUIDs: Set<String>) -> ProfileLayoutLogReplay.PartitionInputs {
+        // Control identifiers come from the live control-item tags, not
+        // hardcoded strings, so a change to control-item identity is caught.
+        let visibleCtrl = MenuBarItemTag.visibleControlItem.tagIdentifier
+        let hiddenCtrl = MenuBarItemTag.hiddenControlItem.tagIdentifier
+        let ahCtrl = MenuBarItemTag.alwaysHiddenControlItem.tagIdentifier
+
+        // Live items for the current bar, per section; everything below is
+        // derived from them through live Thaw code (uniqueIdentifier,
+        // isControlCenterGenericItem) rather than from string heuristics.
+        let visibleItems = ProfileLayoutLogReplay.makeCurrentItems(
+            sectionOrderedUIDs: currentVisible,
+            unresolvedSourcePIDBaseUIDs: unresolvedSourcePIDBaseUIDs,
+            windowIDBase: 9000
+        )
+        let hiddenItems = ProfileLayoutLogReplay.makeCurrentItems(
+            sectionOrderedUIDs: currentHidden,
+            unresolvedSourcePIDBaseUIDs: unresolvedSourcePIDBaseUIDs,
+            windowIDBase: 9100
+        )
+        let ahItems = ProfileLayoutLogReplay.makeCurrentItems(
+            sectionOrderedUIDs: currentAlwaysHidden,
+            unresolvedSourcePIDBaseUIDs: unresolvedSourcePIDBaseUIDs,
+            windowIDBase: 9200
+        )
+
+        // currentFlat is built by the SAME pure helper applyProfileLayout uses,
+        // so the harness exercises the real flatten / boundary-control logic.
+        let currentFlat = LayoutSolver.flattenCurrentSections(
+            visible: visibleItems.map(\.uniqueIdentifier),
+            hidden: hiddenItems.map(\.uniqueIdentifier),
+            alwaysHidden: ahItems.map(\.uniqueIdentifier),
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: ahCtrl
+        )
+
+        // The exact condition the Layer-1 fix will exclude: a generic Control
+        // Center item (Item-N title) with no resolved source PID. Computed with
+        // the live predicate so the harness tracks the production predicate.
+        let orphans = Set(
+            (visibleItems + hiddenItems + ahItems)
+                .filter { $0.tag.isControlCenterGenericItem && $0.sourcePID == nil }
+                .map(\.uniqueIdentifier)
+        )
+
+        let desiredVisibleUIDs = desiredVisible ?? currentVisible.filter { uid in
+            uid != visibleCtrl && uid != hiddenCtrl && uid != ahCtrl && !orphans.contains(uid)
+        }
+
+        let desiredUIDs = Set(desiredHidden)
+            .union(desiredAlwaysHidden)
+            .union(desiredVisibleUIDs)
+
+        return ProfileLayoutLogReplay.PartitionInputs(
+            currentFlat: currentFlat,
+            desiredUIDs: desiredUIDs,
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: ahCtrl,
+            visibleCtrlUID: visibleCtrl,
+            unresolvedGenericCCOrphans: orphans
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Little Snitch (and other Control Center-hosted menu bar widgets) being mis-identified as `com.apple.controlcenter:Item-0` and relocated on launch when only a single display is connected, by stopping the relocation of unresolved orphans and briefly creating a hidden virtual display to force the marker windows that source-PID resolution needs.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

On macOS 26 every menu bar status item is hosted by Control Center, so `kCGWindowOwnerPID` and the AX owner point at Control Center rather than the creating app. The XPC `SourcePIDCache` recovers the real owner by pairing each icon with a bundle-ID-titled marker window, but the window server only publishes those markers when two or more displays are present. On a single display the markers never appear, so a widget whose status item Control Center hosts without its own `AXExtrasMenuBar` (Little Snitch's agent) stays unidentified as `com.apple.controlcenter:Item-0` and gets relocated by the layout pass, so it keeps moving on launch and only matches once the marker happens to surface much later.
Issue Number: #643

## What is the new behavior?

- Layer 1: `partitionUnmanagedUIDs` leaves a generic Control Center item with a nil source PID in place instead of treating it as unmanaged and moving it, so an unidentified widget never jumps around while resolution is pending.
- Virtual-display provoke: when exactly one display is connected and an orphan stays unresolved past a short grace, `VirtualDisplayProvoker` briefly creates a headless `CGVirtualDisplay` (bound through an Objective-C shim around the private API) so the window server publishes the marker windows; marker-pair then resolves the orphan to its real owner, typically within ~0.8s, and the display is torn down.
- Persistence and convergence: the resolved windowID-to-PID mapping persists in the XPC cache after teardown, and the provoker refreshes the manager's published item cache once resolution is confirmed, so the icon converges to its real identity immediately instead of waiting for an unrelated cache cycle. A 300s per-window cooldown and a 12s hold ceiling bound the mechanism.
- Containment: the phantom is excluded from Thaw's display enumeration via `Bridging.excludedDisplayID` and `NSScreen.managedScreens` so it never affects the Displays settings pane, overlay panels, or profile auto-switch, and its self-inflicted `didChangeScreenParametersNotification` is ignored by `DisplaySettingsManager` for the phantom's lifetime plus a short grace, so it no longer cancels the in-flight item-cache cycle and flashes a bar of orphans.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Validated from field diagnostic logs on macOS 26.5 across multi-display and single-display reboots: on multi-display the provoke correctly stays dormant and marker-pair resolves Little Snitch naturally; on a true single display the provoke resolves Little Snitch to its real owner in ~0.8s, the resolution persists, the visible section converges to `at.obdev.littlesnitch.agent:Item-0`, and the item never moves. A ~24 minute single-display session showed zero orphan-flash blips and zero relocations.

### Notes for reviewers

- The provoke uses the private `CGVirtualDisplay` family via an Objective-C shim (`ThawVirtualDisplay.{h,m}`) wired in through `Thaw-Bridging-Header.h`; classes are resolved with `NSClassFromString` and guarded with `@try`/`@catch`, and `VirtualDisplay.isSupported` gates the whole feature so an absent class on a future OS degrades to a no-op rather than crashing.
- The hidden virtual display uses a hardcoded stable EDID so repeated provokes are not treated as a brand-new display each time.
- Known uncovered edge: if `CGVirtualDisplay` is unavailable (`isSupported == false`), the single-display case has no fallback; this was unobserved in the field, so no fallback was built.

Fixes #643


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added virtual-display support to temporarily create and exclude a transient display to aid menu-bar item resolution on single-display systems.

* **Improvements**
  * Display enumeration now ignores the transient virtual display and uses a managed-screen view across the app.
  * Menu-bar item cache now refreshes more frequently and exposes layout-stabilization state.
  * Adaptive background capture and per-display settings align with managed screens.

* **Tests**
  * New and extended tests for layout flattening, unmanaged-item partitioning, and profile-layout log replay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->