### PR TITLE
fix(resolution): harden single-display Control Center widget resolution

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -509,38 +509,55 @@ final class SourcePIDCache {
             let unresolvedWindowInfos = allWindows.filter { unresolvedWindows.contains($0.windowID) }
             for window in unresolvedWindowInfos {
                 let target = window.bounds.center
-                var bestDistance = CGFloat.greatestFiniteMagnitude
-                var bestLabel = "(none)"
-                var bestFrame: CGRect?
+                // Collect every extras-bar child across all apps as a candidate,
+                // not just the single closest, so the diag shows whether the match
+                // is unique. Option A only needs the closest child's enabled state;
+                // Option B (dropping the isEnabled guard) needs to know whether a
+                // second, competing or explicitly-disabled candidate sits within the
+                // match radius, which would make dropping the guard a misattribution
+                // risk. Both questions are answered from one log this way.
+                var candidates: [(distance: CGFloat, label: String, frame: CGRect, enabled: Bool?)] = []
                 for app in apps {
                     guard let bar = app.getOrCreateExtrasMenuBar() else { continue }
-                    let children = AXHelpers.children(for: bar)
-                    for child in children {
+                    let label = app.bundleIdentifier ?? app.localizedName ?? "pid=\(app.processIdentifier)"
+                    for child in AXHelpers.children(for: bar) {
                         guard let frame = AXHelpers.frame(for: child) else { continue }
-                        let d = frame.center.distance(to: target)
-                        if d < bestDistance {
-                            bestDistance = d
-                            bestLabel = app.bundleIdentifier ?? app.localizedName ?? "pid=\(app.processIdentifier)"
-                            bestFrame = frame
-                        }
+                        candidates.append((frame.center.distance(to: target), label, frame, AXHelpers.enabledAttribute(child)))
                     }
                 }
+                let nearest = candidates.sorted { $0.distance < $1.distance }
+                let best = nearest.first
                 let cgOwner = window.owningApplication.map { app in
                     "\(app.bundleIdentifier ?? app.localizedName ?? "?"):pid=\(app.processIdentifier)"
                 } ?? "nil"
+                // closestAXEnabled distinguishes absent (nil) from explicitly false
+                // (Option A); nearest lists the top candidates with their enabled
+                // state so we can tell whether dropping the isEnabled guard entirely
+                // (Option B) would still match uniquely or pull in a competing or
+                // disabled child from another app.
+                let nearestDesc = nearest.prefix(3).map {
+                    "\($0.label)@\(String(format: "%.1f", $0.distance))(enabled=\($0.enabled.map { "\($0)" } ?? "nil"))"
+                }.joined(separator: ", ")
                 SourcePIDCache.diagLog.debug(
-                    "SourcePIDCache diag unresolved: windowID=\(window.windowID) title=\(window.title ?? "nil") bounds=\(window.bounds) center=\(target) | cgOwner=\(cgOwner) ownerName=\(window.ownerName ?? "nil") | closestAXFrame=\(bestFrame.map { "\($0)" } ?? "nil") in app=\(bestLabel) distance=\(bestDistance)"
+                    "SourcePIDCache diag unresolved: windowID=\(window.windowID) title=\(window.title ?? "nil") bounds=\(window.bounds) center=\(target) | cgOwner=\(cgOwner) ownerName=\(window.ownerName ?? "nil") | closestAXFrame=\(best.map { "\($0.frame)" } ?? "nil") in app=\(best?.label ?? "(none)") distance=\(best?.distance ?? .greatestFiniteMagnitude) closestAXEnabled=\(best?.enabled.map { "\($0)" } ?? "nil") | nearest=[\(nearestDesc)]"
                 )
             }
 
             for app in apps {
                 guard let bar = app.getOrCreateExtrasMenuBar() else { continue }
                 let children = AXHelpers.children(for: bar)
-                let frames = children.compactMap { AXHelpers.frame(for: $0) }
-                guard !frames.isEmpty else { continue }
+                // Include each child's raw enabled value (nil = attribute absent)
+                // so a child that the matching pass skips on the isEnabled guard
+                // is visible here next to its frame.
+                let childDescs = children.compactMap { child -> String? in
+                    guard let frame = AXHelpers.frame(for: child) else { return nil }
+                    let enabled = AXHelpers.enabledAttribute(child).map { "\($0)" } ?? "nil"
+                    return "(x=\(frame.minX),y=\(frame.minY),w=\(frame.width),h=\(frame.height),enabled=\(enabled))"
+                }
+                guard !childDescs.isEmpty else { continue }
                 let label = app.bundleIdentifier ?? app.localizedName ?? "pid=\(app.processIdentifier)"
                 SourcePIDCache.diagLog.debug(
-                    "SourcePIDCache diag app=\(label) extrasBar children=\(children.count) frames=\(frames.map { "(x=\($0.minX),y=\($0.minY),w=\($0.width),h=\($0.height))" }.joined(separator: " "))"
+                    "SourcePIDCache diag app=\(label) extrasBar children=\(children.count) frames=\(childDescs.joined(separator: " "))"
                 )
             }
         }

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -366,7 +366,13 @@ final class SourcePIDCache {
                 let children = AXHelpers.children(for: bar)
                 for child in children {
                     totalChildrenChecked += 1
-                    guard AXHelpers.isEnabled(child),
+                    // Skip only children the app marks explicitly disabled. A
+                    // missing AXEnabled attribute (nil) is treated as enabled:
+                    // some status items hosted by Control Center (The Clock's
+                    // among them) never publish AXEnabled, and treating absent as
+                    // disabled would drop an otherwise exact positional match and
+                    // leave the item unresolved.
+                    guard AXHelpers.enabledAttribute(child) != false,
                           let childFrame = AXHelpers.frame(for: child)
                     else {
                         continue
@@ -510,12 +516,11 @@ final class SourcePIDCache {
             for window in unresolvedWindowInfos {
                 let target = window.bounds.center
                 // Collect every extras-bar child across all apps as a candidate,
-                // not just the single closest, so the diag shows whether the match
-                // is unique. Option A only needs the closest child's enabled state;
-                // Option B (dropping the isEnabled guard) needs to know whether a
-                // second, competing or explicitly-disabled candidate sits within the
-                // match radius, which would make dropping the guard a misattribution
-                // risk. Both questions are answered from one log this way.
+                // not just the single closest, so the diagnostic shows whether the
+                // nearest match is unique or whether a competing child sits within
+                // the match radius. Paired with each candidate's enabled state and
+                // distance, this is usually enough to see why an item failed to
+                // resolve (wrong distance, missing AXEnabled, or ambiguity).
                 var candidates: [(distance: CGFloat, label: String, frame: CGRect, enabled: Bool?)] = []
                 for app in apps {
                     guard let bar = app.getOrCreateExtrasMenuBar() else { continue }
@@ -530,11 +535,10 @@ final class SourcePIDCache {
                 let cgOwner = window.owningApplication.map { app in
                     "\(app.bundleIdentifier ?? app.localizedName ?? "?"):pid=\(app.processIdentifier)"
                 } ?? "nil"
-                // closestAXEnabled distinguishes absent (nil) from explicitly false
-                // (Option A); nearest lists the top candidates with their enabled
-                // state so we can tell whether dropping the isEnabled guard entirely
-                // (Option B) would still match uniquely or pull in a competing or
-                // disabled child from another app.
+                // closestAXEnabled distinguishes a missing AXEnabled attribute (nil)
+                // from an explicitly disabled child, and nearest lists the top
+                // candidates with their owning app and enabled state, so a future
+                // unresolved item can be diagnosed from a single log line.
                 let nearestDesc = nearest.prefix(3).map {
                     "\($0.label)@\(String(format: "%.1f", $0.distance))(enabled=\($0.enabled.map { "\($0)" } ?? "nil"))"
                 }.joined(separator: ", ")
@@ -547,8 +551,8 @@ final class SourcePIDCache {
                 guard let bar = app.getOrCreateExtrasMenuBar() else { continue }
                 let children = AXHelpers.children(for: bar)
                 // Include each child's raw enabled value (nil = attribute absent)
-                // so a child that the matching pass skips on the isEnabled guard
-                // is visible here next to its frame.
+                // next to its frame, so a child the matching pass excluded as
+                // explicitly disabled is visible here.
                 let childDescs = children.compactMap { child -> String? in
                     guard let frame = AXHelpers.frame(for: child) else { return nil }
                     let enabled = AXHelpers.enabledAttribute(child).map { "\($0)" } ?? "nil"

--- a/Shared/Utilities/AXHelpers.swift
+++ b/Shared/Utilities/AXHelpers.swift
@@ -41,6 +41,14 @@ enum AXHelpers {
         queue.sync { try? element.attribute(.enabled) } ?? false
     }
 
+    /// The raw AXEnabled attribute, or nil when the element does not expose it.
+    /// isEnabled collapses a missing attribute to false, so it cannot tell
+    /// "explicitly disabled" from "attribute absent"; this keeps that distinction
+    /// for diagnostics.
+    static func enabledAttribute(_ element: UIElement) -> Bool? {
+        queue.sync { try? element.attribute(.enabled) }
+    }
+
     static func frame(for element: UIElement) -> CGRect? {
         queue.sync { try? element.attribute(.frame) }
     }

--- a/Shared/Utilities/AXHelpers.swift
+++ b/Shared/Utilities/AXHelpers.swift
@@ -42,9 +42,11 @@ enum AXHelpers {
     }
 
     /// The raw AXEnabled attribute, or nil when the element does not expose it.
-    /// isEnabled collapses a missing attribute to false, so it cannot tell
-    /// "explicitly disabled" from "attribute absent"; this keeps that distinction
-    /// for diagnostics.
+    /// isEnabled collapses a missing attribute to false, so it cannot tell an
+    /// explicitly disabled element from one that simply does not publish the
+    /// attribute. Callers that must keep that distinction use this: source-PID
+    /// matching treats absent as enabled, and the unresolved-item diagnostics
+    /// report it verbatim.
     static func enabledAttribute(_ element: UIElement) -> Bool? {
         queue.sync { try? element.attribute(.enabled) }
     }

--- a/Thaw/VirtualDisplay/ThawVirtualDisplay.m
+++ b/Thaw/VirtualDisplay/ThawVirtualDisplay.m
@@ -53,15 +53,21 @@ void *ThawVirtualDisplayCreate(void) {
     }
 
     @try {
-        const NSUInteger width = 1920;
-        const NSUInteger height = 1080;
+        // Keep the phantom as small as the window server will accept. It only
+        // has to exist so the marker windows are published; nothing is ever
+        // rendered on it, so a tiny framebuffer minimises its footprint in the
+        // display arrangement. 640x480 is the smallest standard mode that is
+        // reliably accepted; smaller modes risk applySettings rejecting it,
+        // which would defeat the whole provoke.
+        const NSUInteger width = 640;
+        const NSUInteger height = 480;
 
         CGVirtualDisplayDescriptor *descriptor = [[descriptorClass alloc] init];
         descriptor.queue = dispatch_get_main_queue();
         descriptor.name = @"Thaw Resolver";
         descriptor.maxPixelsWide = width;
         descriptor.maxPixelsHigh = height;
-        descriptor.sizeInMillimeters = CGSizeMake(600.0, 340.0);
+        descriptor.sizeInMillimeters = CGSizeMake(200.0, 150.0);
         descriptor.productID = 0x1234;
         descriptor.vendorID = 0x3456;
         descriptor.serialNum = 0x0001;

--- a/Thaw/VirtualDisplay/VirtualDisplay.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplay.swift
@@ -57,31 +57,42 @@ final class VirtualDisplay {
         return VirtualDisplay(handle: handle, displayID: displayID)
     }
 
-    /// Keeps the real display the system main display and parks this phantom to
-    /// its right, so adding the phantom never relocates the menu bar or reshuffles
-    /// the user's windows. macOS places a freshly added display at the global
-    /// origin in some arrangements, which makes it the main display (the main
-    /// display is whichever sits at the origin); when that happens the menu bar
-    /// and windows jump onto the tiny phantom and the screen visibly snaps small
-    /// until teardown. Re-anchoring the real display at the origin and offsetting
-    /// the phantom undoes that. realMain must be captured before the phantom is
-    /// created, while the real display is still the only one.
-    func excludeFromMainDisplay(realMain: CGDirectDisplayID) {
+    /// The per-call result of one reanchorRealDisplayAsMain transaction, so the
+    /// caller can verify success and log the codes from the field.
+    struct ReanchorResult {
+        let beginOK: Bool
+        let originReal: CGError
+        let originPhantom: CGError
+        let complete: CGError
+
+        var success: Bool { beginOK && complete == .success }
+    }
+
+    /// Anchors realMain at the global origin (the origin defines the main display)
+    /// and parks this phantom immediately to realMain's right, in one display
+    /// configuration transaction. Returns the per-call error codes.
+    ///
+    /// macOS chooses where a freshly added display lands and, on some saved
+    /// arrangements (e.g. a machine that has had an external/AirPlay display), it
+    /// places the phantom at the origin and makes it the main display a moment
+    /// after it comes online; the menu bar and windows then jump onto the tiny
+    /// phantom and the screen visibly snaps small until teardown. A single call
+    /// right after creation can therefore fire before the phantom has taken main
+    /// and do nothing, so the caller re-asserts this in a verify loop for the
+    /// phantom's lifetime rather than assuming one call sticks. macOS clamps the
+    /// phantom adjacent to the real display regardless of how large an offset is
+    /// requested, so the real display's width is used as the offset. realMain must
+    /// be captured before the phantom is created, while it is still the only one.
+    func reanchorRealDisplayAsMain(_ realMain: CGDirectDisplayID) -> ReanchorResult {
         var configRef: CGDisplayConfigRef?
         guard CGBeginDisplayConfiguration(&configRef) == .success, let configRef else {
-            return
+            return ReanchorResult(beginOK: false, originReal: .failure, originPhantom: .failure, complete: .failure)
         }
-        // The main display is the one at the global origin, so anchoring the real
-        // display there guarantees it stays main regardless of where the window
-        // server initially placed the phantom.
-        CGConfigureDisplayOrigin(configRef, realMain, 0, 0)
-        // Place the phantom immediately to the right of the real display so it is
-        // never at the origin and never overlaps the real desktop.
+        let originReal = CGConfigureDisplayOrigin(configRef, realMain, 0, 0)
         let offset = Int32(clamping: CGDisplayPixelsWide(realMain))
-        CGConfigureDisplayOrigin(configRef, displayID, offset, 0)
-        if CGCompleteDisplayConfiguration(configRef, .forSession) != .success {
-            CGCancelDisplayConfiguration(configRef)
-        }
+        let originPhantom = CGConfigureDisplayOrigin(configRef, displayID, offset, 0)
+        let complete = CGCompleteDisplayConfiguration(configRef, .forSession)
+        return ReanchorResult(beginOK: true, originReal: originReal, originPhantom: originPhantom, complete: complete)
     }
 
     /// Removes the virtual display. Idempotent.

--- a/Thaw/VirtualDisplay/VirtualDisplay.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplay.swift
@@ -57,6 +57,33 @@ final class VirtualDisplay {
         return VirtualDisplay(handle: handle, displayID: displayID)
     }
 
+    /// Keeps the real display the system main display and parks this phantom to
+    /// its right, so adding the phantom never relocates the menu bar or reshuffles
+    /// the user's windows. macOS places a freshly added display at the global
+    /// origin in some arrangements, which makes it the main display (the main
+    /// display is whichever sits at the origin); when that happens the menu bar
+    /// and windows jump onto the tiny phantom and the screen visibly snaps small
+    /// until teardown. Re-anchoring the real display at the origin and offsetting
+    /// the phantom undoes that. realMain must be captured before the phantom is
+    /// created, while the real display is still the only one.
+    func excludeFromMainDisplay(realMain: CGDirectDisplayID) {
+        var configRef: CGDisplayConfigRef?
+        guard CGBeginDisplayConfiguration(&configRef) == .success, let configRef else {
+            return
+        }
+        // The main display is the one at the global origin, so anchoring the real
+        // display there guarantees it stays main regardless of where the window
+        // server initially placed the phantom.
+        CGConfigureDisplayOrigin(configRef, realMain, 0, 0)
+        // Place the phantom immediately to the right of the real display so it is
+        // never at the origin and never overlaps the real desktop.
+        let offset = Int32(clamping: CGDisplayPixelsWide(realMain))
+        CGConfigureDisplayOrigin(configRef, displayID, offset, 0)
+        if CGCompleteDisplayConfiguration(configRef, .forSession) != .success {
+            CGCancelDisplayConfiguration(configRef)
+        }
+    }
+
     /// Removes the virtual display. Idempotent.
     func invalidate() {
         guard isValid else {

--- a/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
@@ -47,17 +47,22 @@ final class VirtualDisplayProvoker {
 
     /// When each currently-unresolved orphan windowID was first observed.
     private var firstSeenUnresolved = [CGWindowID: Date]()
-    /// Last provoke attempt per windowID, for the cooldown.
-    private var lastAttempt = [CGWindowID: Date]()
+    /// WindowIDs that a provoke already failed to resolve. Every field case
+    /// resolves within a second of the markers publishing or never resolves at
+    /// all (retrying the same window produced an identical 0/1 each time), so a
+    /// single failed hold means a display will not help this window and we stop
+    /// provoking for it. Keyed on windowID, not source PID, because these orphans
+    /// have no resolvable source PID; the set is in-memory so a relaunch (which
+    /// assigns a fresh windowID) still gets one clean attempt.
+    private var blacklisted = Set<CGWindowID>()
 
     /// How long an orphan must stay unresolved before provoking, so we do not
     /// fire for items the normal AX / marker pass resolves within a cycle.
     private let unresolvedGrace: TimeInterval = 3
-    /// Minimum time between provoke attempts for the same windowID, so an
-    /// orphan that cannot resolve even with a display does not flicker-loop.
-    private let attemptCooldown: TimeInterval = 300
-    /// Maximum time to keep the virtual display up waiting for resolution.
-    private let maxHold: TimeInterval = 12
+    /// Maximum time to keep the virtual display up waiting for resolution. Every
+    /// field resolution landed under a second, so this is generous headroom; a
+    /// window that has not resolved by here is blacklisted rather than retried.
+    private let maxHold: TimeInterval = 4
     /// Poll cadence while waiting for markers to publish and orphans to resolve.
     private let pollInterval: Duration = .milliseconds(250)
 
@@ -108,7 +113,7 @@ final class VirtualDisplayProvoker {
         // any virtual display we created.
         guard displayCount == 1, !orphans.isEmpty else {
             firstSeenUnresolved.removeAll()
-            lastAttempt.removeAll()
+            blacklisted.removeAll()
             return
         }
 
@@ -128,7 +133,7 @@ final class VirtualDisplayProvoker {
 
         // Forget state for windowIDs that are no longer orphaned.
         firstSeenUnresolved = firstSeenUnresolved.filter { orphans.contains($0.key) }
-        lastAttempt = lastAttempt.filter { orphans.contains($0.key) }
+        blacklisted = blacklisted.intersection(orphans)
         for windowID in orphans where firstSeenUnresolved[windowID] == nil {
             firstSeenUnresolved[windowID] = now
         }
@@ -140,10 +145,7 @@ final class VirtualDisplayProvoker {
             else {
                 return false
             }
-            if let attempted = lastAttempt[windowID], now.timeIntervalSince(attempted) < attemptCooldown {
-                return false
-            }
-            return true
+            return !blacklisted.contains(windowID)
         }
 
         guard !eligible.isEmpty else {
@@ -155,16 +157,18 @@ final class VirtualDisplayProvoker {
                     let age = firstSeenUnresolved[windowID].map { now.timeIntervalSince($0) } ?? 0
                     return "\(windowID):\(String(format: "%.1f", age))s"
                 }
-                let cooled = orphans.sorted().filter { windowID in
-                    lastAttempt[windowID].map { now.timeIntervalSince($0) < attemptCooldown } ?? false
-                }
+                let blocked = orphans.sorted().filter { blacklisted.contains($0) }
                 diagLog.info(
-                    "VirtualDisplayProvoke: not yet eligible (orphan ages \(ages), grace \(unresolvedGrace)s, cooldown-blocked \(cooled))"
+                    "VirtualDisplayProvoke: not yet eligible (orphan ages \(ages), grace \(unresolvedGrace)s, blacklisted \(blocked))"
                 )
             }
             // Re-check at grace expiry so firing does not depend on an incidental
-            // cache cycle landing after the grace elapses.
-            scheduleRecheckIfNeeded()
+            // cache cycle landing after the grace elapses. Only worth doing while
+            // a non-blacklisted orphan is still inside its grace window; once every
+            // orphan is blacklisted there is nothing that will become eligible.
+            if orphans.contains(where: { !blacklisted.contains($0) }) {
+                scheduleRecheckIfNeeded()
+            }
             return
         }
 
@@ -200,15 +204,13 @@ final class VirtualDisplayProvoker {
             return
         }
 
-        let attemptTime = Date()
-        for windowID in targets {
-            lastAttempt[windowID] = attemptTime
-        }
-
         let start = Date()
         diagLog.info(
             "VirtualDisplayProvoke: single display with \(targets.count) unresolved orphan(s) \(targets.sorted()); creating virtual display"
         )
+        // Capture the real main display before the phantom exists, so it can be
+        // re-anchored as main once the phantom is added (see excludeFromMainDisplay).
+        let realMain = CGMainDisplayID()
         guard let display = VirtualDisplay.create() else {
             // Report which private classes resolved so a binding failure on a
             // given macOS version is diagnosable from Thaw's own log (the ObjC
@@ -224,6 +226,11 @@ final class VirtualDisplayProvoker {
             return
         }
         self.display = display
+        // Keep the phantom from becoming the main display: macOS may place a
+        // freshly added display at the origin and make it main, which yanks the
+        // menu bar and windows onto the tiny phantom and snaps the screen small
+        // until teardown (issue #661). Re-anchor the real display as main.
+        display.excludeFromMainDisplay(realMain: realMain)
         // Exclude our phantom from Thaw's display enumeration so it never
         // pollutes per-display state (the Displays settings panel, overlay
         // panels, profile auto-switch, etc.) while it briefly exists. The
@@ -255,7 +262,7 @@ final class VirtualDisplayProvoker {
         }
         if !resolvedAll {
             diagLog.info(
-                "VirtualDisplayProvoke: gave up after \(String(format: "%.2f", maxHold))s; some orphans still unresolved (retry after cooldown)"
+                "VirtualDisplayProvoke: gave up after \(String(format: "%.2f", maxHold))s; some orphans still unresolved (blacklisting)"
             )
         }
 
@@ -278,6 +285,17 @@ final class VirtualDisplayProvoker {
         diagLog.info(
             "VirtualDisplayProvoke: after teardown \(targets.count - stillUnresolved.count)/\(targets.count) target(s) still resolved (persistence check)"
         )
+
+        // Blacklist any target the provoke could not resolve so it is not provoked
+        // again. A display either makes the markers publish (resolves within ~1s)
+        // or it does not, in which case repeating the disruption every few minutes
+        // just churns the display arrangement for nothing (issue #661). A relaunch
+        // assigns a fresh windowID, which is not blacklisted, so a genuinely new
+        // instance still gets one clean attempt.
+        if !stillUnresolved.isEmpty {
+            blacklisted.formUnion(stillUnresolved)
+            diagLog.info("VirtualDisplayProvoke: blacklisted \(stillUnresolved.sorted()); will not provoke these again")
+        }
 
         // Propagate the freshly resolved sourcePIDs into the manager's
         // published item cache. The provoke only updates the XPC's PID cache;

--- a/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
+++ b/Thaw/VirtualDisplay/VirtualDisplayProvoker.swift
@@ -226,11 +226,6 @@ final class VirtualDisplayProvoker {
             return
         }
         self.display = display
-        // Keep the phantom from becoming the main display: macOS may place a
-        // freshly added display at the origin and make it main, which yanks the
-        // menu bar and windows onto the tiny phantom and snaps the screen small
-        // until teardown (issue #661). Re-anchor the real display as main.
-        display.excludeFromMainDisplay(realMain: realMain)
         // Exclude our phantom from Thaw's display enumeration so it never
         // pollutes per-display state (the Displays settings panel, overlay
         // panels, profile auto-switch, etc.) while it briefly exists. The
@@ -241,13 +236,29 @@ final class VirtualDisplayProvoker {
         // teardown to also cover the debounced removal notification.
         Self.displayReactionsSuppressedUntil = .distantFuture
         diagLog.info(
-            "VirtualDisplayProvoke: created virtual display id=\(display.displayID); polling for marker-pair resolution"
+            "VirtualDisplayProvoke: created virtual display id=\(display.displayID); realMain=\(realMain), mainAfterCreate=\(CGMainDisplayID()); polling for marker-pair resolution"
         )
+        // Keep the phantom from becoming the main display (issue #661). macOS can
+        // hand a freshly added display main status a moment after it comes online,
+        // so assert it once immediately and again on every poll below rather than
+        // trusting a single call to stick.
+        enforceRealDisplayMain(realMain: realMain, display: display)
 
         var resolvedAll = false
+        // The set of targets still unresolved at the last in-hold poll. Initialised
+        // to all targets so a provoke that somehow never polls counts as a failure.
+        var heldUnresolved = targets
         while Date().timeIntervalSince(start) < maxHold {
             try? await Task.sleep(for: pollInterval)
+            // Re-assert the real display as main: the phantom can take main status
+            // late, after the immediate call above, so this keeps it corrected for
+            // the phantom's whole lifetime.
+            enforceRealDisplayMain(realMain: realMain, display: display)
             let stillUnresolved = await unresolvedTargets(targets)
+            // Remember the last in-hold result: this, taken while the phantom is up
+            // and the markers are present, is the authoritative "did the provoke
+            // resolve it" signal that the blacklist decision uses.
+            heldUnresolved = stillUnresolved
             let elapsed = Date().timeIntervalSince(start)
             diagLog.info(
                 "VirtualDisplayProvoke: +\(String(format: "%.2f", elapsed))s \(targets.count - stillUnresolved.count)/\(targets.count) target orphan(s) resolved"
@@ -286,15 +297,20 @@ final class VirtualDisplayProvoker {
             "VirtualDisplayProvoke: after teardown \(targets.count - stillUnresolved.count)/\(targets.count) target(s) still resolved (persistence check)"
         )
 
-        // Blacklist any target the provoke could not resolve so it is not provoked
-        // again. A display either makes the markers publish (resolves within ~1s)
-        // or it does not, in which case repeating the disruption every few minutes
-        // just churns the display arrangement for nothing (issue #661). A relaunch
-        // assigns a fresh windowID, which is not blacklisted, so a genuinely new
-        // instance still gets one clean attempt.
-        if !stillUnresolved.isEmpty {
-            blacklisted.formUnion(stillUnresolved)
-            diagLog.info("VirtualDisplayProvoke: blacklisted \(stillUnresolved.sorted()); will not provoke these again")
+        // Blacklist any target that did not resolve during the hold (while the
+        // phantom and its markers were present) so it is not provoked again. A
+        // display either makes the markers publish (resolves within ~1s) or it does
+        // not, in which case repeating the disruption every few minutes just churns
+        // the display arrangement for nothing (issue #661). This uses the in-hold
+        // result, not the post-teardown persistence check above: a flapping orphan
+        // can momentarily read as resolved at the instant of that check and thereby
+        // dodge the blacklist, only to provoke again seconds later, observed as a
+        // back-to-back double provoke in the field. A relaunch assigns a fresh
+        // windowID, which is not blacklisted, so a genuinely new instance still gets
+        // one clean attempt.
+        if !heldUnresolved.isEmpty {
+            blacklisted.formUnion(heldUnresolved)
+            diagLog.info("VirtualDisplayProvoke: blacklisted \(heldUnresolved.sorted()); will not provoke these again")
         }
 
         // Propagate the freshly resolved sourcePIDs into the manager's
@@ -310,6 +326,28 @@ final class VirtualDisplayProvoker {
         if stillUnresolved.count < targets.count {
             await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
         }
+    }
+
+    /// Keeps realMain the system main display while the phantom exists. No-ops
+    /// (and stays silent) when the real display is already main, which is the
+    /// normal case on machines where the phantom never takes main. When the
+    /// phantom has taken main it runs one reanchor transaction and logs the
+    /// before/after main display IDs and the transaction return codes, so whether
+    /// the phantom ever hijacks main, and whether the correction lands, is
+    /// auditable from the field log (issue #661). Returns whether the real display
+    /// is main after the call.
+    @discardableResult
+    private func enforceRealDisplayMain(realMain: CGDirectDisplayID, display: VirtualDisplay) -> Bool {
+        let before = CGMainDisplayID()
+        guard before != realMain else {
+            return true
+        }
+        let result = display.reanchorRealDisplayAsMain(realMain)
+        let after = CGMainDisplayID()
+        diagLog.info(
+            "VirtualDisplayProvoke: phantom held main (was \(before), realMain \(realMain)); reanchor begin=\(result.beginOK) originReal=\(result.originReal.rawValue) originPhantom=\(result.originPhantom.rawValue) complete=\(result.complete.rawValue) -> main now \(after)"
+        )
+        return after == realMain
     }
 
     /// Returns which of the given target windowIDs are still unresolved, read


### PR DESCRIPTION
## What does this PR do?

Hardens the single-display Control Center widget resolution introduced in #655 so the transient virtual-display "provoke" can no longer disrupt the screen, and resolves widgets like The Clock directly through the accessibility tree so the provoke is never needed for them. It keeps the real display as the system main display while the phantom exists, bounds the provoke and blacklists windows it cannot resolve, fixes a menu bar item match that wrongly required `AXEnabled`, and adds standing diagnostics for future unresolved widgets.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [x] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

On a single display the provoke briefly creates a headless `CGVirtualDisplay` so the window server publishes the bundle-ID marker windows that source-PID resolution needs. On some arrangements (machines that have had an external or AirPlay display) macOS places the freshly added phantom at the global origin and makes it the main display, so the menu bar and windows jump onto the tiny phantom and the screen visibly snaps small for the duration of the provoke, recurring every few minutes. The provoke also held the phantom for up to 12s and retried the same window every 5 minutes even when a display could never resolve it. Separately, the spatial source-PID pass matched a menu bar item to an app's `AXExtrasMenuBar` child only when `AXHelpers.isEnabled` was true, and `isEnabled` treats a missing `AXEnabled` attribute as false; Control-Center-hosted widgets that do not publish `AXEnabled` (The Clock, `com.fabriceleyne.theclock`) were therefore skipped despite an exact positional match, stayed unresolved, and fell through to the provoke unnecessarily.
Issue Number: #661

## What is the new behavior?

- Never the main display: `VirtualDisplayProvoker` captures the real main display before creating the phantom and calls `enforceRealDisplayMain` immediately after creation and on every poll, re-anchoring the real display at the global origin (which defines the main display) and parking the phantom to its right. macOS hands a freshly added display main status a moment after it comes online, so a single call right after creation is not enough; re-asserting for the phantom's whole lifetime keeps the real display main.
- Smaller phantom: the phantom is created at 640x480 instead of 1920x1080. Nothing is ever rendered on it, so a tiny framebuffer is enough and minimises its footprint in the display arrangement.
- Bounded and self-limiting: the maximum hold drops from 12s to 4s (every field resolution lands under a second), and a window the provoke cannot resolve within one hold is blacklisted for the session instead of retried every 5 minutes. The blacklist decision uses the in-hold result rather than the post-teardown persistence check, so a flapping orphan can no longer dodge the blacklist and re-provoke seconds later.
- Resolve widgets without the provoke: the spatial source-PID match now skips an extras-bar child only when `AXEnabled` is explicitly false, treating an absent attribute as enabled. The Clock reports no `AXEnabled` at an exact positional match, so it now resolves in the accessibility pass and never reaches the provoke, sidestepping the main-display problem entirely for such widgets. The application-menu frame measurement in `Extensions.swift` keeps the stricter `isEnabled` check, since a disabled application menu should not contribute to that width.
- Diagnostics: the source-PID diagnostics now report each unresolved item's closest candidate with its `AXEnabled` state, a nearest-candidate list with owning app and enabled state, and per-child enabled in the per-app extras-bar dump, and `enforceRealDisplayMain` logs the before and after main display IDs with the reconfiguration return codes. These stay in as standing observability for future widgets that fail to resolve.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Validated against field diagnostic logs on macOS 26.5 across several iterations. A log on the fixed build confirmed the never-main behaviour was the remaining gap (the phantom held main through the hold despite a successful reconfiguration call), which the per-poll re-assertion addresses; the never-main reconfiguration was also validated on real single-display hardware. A later log identified The Clock as the lone persistent orphan with `AXEnabled` absent at distance 0 and an unambiguous nearest candidate, confirming the accessibility match is the correct, disruption-free fix for it.

### Notes for reviewers

- The provoke uses the private `CGVirtualDisplay` family via the existing Objective-C shim; the never-main control uses only public `CGConfigureDisplayOrigin` / `CGCompleteDisplayConfiguration`. macOS clamps the phantom adjacent to the real display regardless of the requested offset, so it is placed at the real display's right edge.
- Known residual: on an arrangement where macOS makes the phantom main, it can hold main for up to roughly one poll (~0.4s) before the first re-assertion corrects it; the new instrumentation makes this directly observable from the field log if it needs tightening.
- The `AXEnabled` relaxation is intentionally scoped to the source-PID matcher only; the two `Extensions.swift` callers that measure the application-menu frame are unchanged.

Fixes #661


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar item window resolution to handle missing accessibility attributes gracefully.
  * Enhanced virtual display management to prevent phantom displays from incorrectly becoming the main display.

* **Chores**
  * Optimized virtual display dimensions and size configuration for better window server compatibility.
  * Refined display provoke mechanism with blacklist-based tracking to avoid redundant resolution attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->