### PR TITLE
fix(menubar): never manage or move system status item clones

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1383,6 +1383,12 @@ extension MenuBarItemManager {
         /// transient sourcePID resolution errors (e.g. stale AX data after moves).
         private(set) var cachedItemPIDs = [CGWindowID: pid_t]()
 
+        /// Window identifiers of the system clone windows seen in the most
+        /// recent cache cycle. cacheItemsIfNeeded filters these out of its
+        /// change comparison so a transient clone appearing or vanishing
+        /// doesn't read as a layout change and trigger a recache.
+        private(set) var cachedCloneWindowIDs = Set<CGWindowID>()
+
         /// Runs the given async closure as a task and waits for it to
         /// complete before returning.
         ///
@@ -1400,6 +1406,11 @@ extension MenuBarItemManager {
             cachedItemWindowIDs = itemWindowIDs
         }
 
+        /// Updates the set of cached system clone window identifiers.
+        func updateCachedCloneWindowIDs(_ ids: Set<CGWindowID>) {
+            cachedCloneWindowIDs = ids
+        }
+
         /// Updates the mapping from window identifiers to source process identifiers.
         func updateCachedItemPIDs(_ pids: [CGWindowID: pid_t]) {
             cachedItemPIDs = pids
@@ -1409,6 +1420,11 @@ extension MenuBarItemManager {
         func clearCachedItemWindowIDs() {
             cachedItemWindowIDs.removeAll()
             cachedItemPIDs.removeAll()
+            // Clear clone IDs alongside the main set so the two don't drift.
+            // Leaving stale clone IDs here would let cacheItemsIfNeeded filter
+            // a recycled windowID out of its comparison before the recache
+            // that follows this reset repopulates the set.
+            cachedCloneWindowIDs.removeAll()
         }
     }
 
@@ -1879,6 +1895,22 @@ extension MenuBarItemManager {
 
         MenuBarItemManager.diagLog.debug("cacheItemsRegardless: getMenuBarItems returned \(items.count) items")
 
+        // Drop System Status Item Clone windows before any downstream
+        // processing. These are transient duplicates the WindowServer
+        // spawns during screen capture and menu bar animations. Each one
+        // carries a fresh windowID and a nil source PID, and resolves to
+        // an unstable namespace, so they must never be cached, assigned to
+        // a section, placed via planUnmanagedPlacement, or moved. Removing
+        // them here also keeps their windowIDs out of the stored set
+        // below, so a clone appearing or vanishing can't trip the
+        // windowID-change trigger that dispatches a bulk re-layout.
+        let cloneWindowIDs = Set(items.filter(\.isSystemClone).map(\.windowID))
+        if !cloneWindowIDs.isEmpty {
+            let cloneDescriptions = items.filter(\.isSystemClone).map(\.tag.description)
+            MenuBarItemManager.diagLog.debug("cacheItemsRegardless: dropping \(cloneWindowIDs.count) system clone window(s): \(cloneDescriptions)")
+            items.removeAll(where: \.isSystemClone)
+        }
+
         // Reconcile resolved sourcePIDs against previously known values to
         // prevent transient resolution errors (e.g. stale AX data after item
         // moves) from corrupting item identities. SourcePIDCache does spatial
@@ -1950,8 +1982,15 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.error("cacheItemsRegardless: getMenuBarItems returned ZERO items even after retry; this is the root cause of 'Loading menu bar items' being stuck")
         }
 
-        let itemWindowIDs = currentItemWindowIDs ?? items.reversed().map(\.windowID)
+        // currentItemWindowIDs comes straight from the bridging window
+        // list and may still contain clone IDs; items has already been
+        // filtered, so strip any clone IDs to keep the stored set in sync
+        // with the managed item set. The fallback branch is clone-free
+        // because items is filtered.
+        let itemWindowIDs = (currentItemWindowIDs ?? items.reversed().map(\.windowID))
+            .filter { !cloneWindowIDs.contains($0) }
         cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
+        cacheActor.updateCachedCloneWindowIDs(cloneWindowIDs)
 
         await MainActor.run {
             MenuBarItemTag.Namespace.pruneUUIDCache(keeping: Set(itemWindowIDs))
@@ -2223,7 +2262,16 @@ extension MenuBarItemManager {
     /// the hidden and always-hidden sections are correctly ordered,
     /// arranging them into valid positions if needed.
     func cacheItemsIfNeeded() async {
-        let itemWindowIDs = Bridging.getMenuBarWindowList(option: [.itemsOnly, .activeSpace])
+        let rawWindowIDs = Bridging.getMenuBarWindowList(option: [.itemsOnly, .activeSpace])
+        // Exclude windowIDs already known to be system clones so their
+        // churn doesn't read as a layout change. A brand-new clone whose
+        // windowID hasn't been learned yet still triggers one recache,
+        // which resolves it, records it, and drops it; from then on its
+        // presence and removal are ignored.
+        let cloneIDs = cacheActor.cachedCloneWindowIDs
+        let itemWindowIDs = cloneIDs.isEmpty
+            ? rawWindowIDs
+            : rawWindowIDs.filter { !cloneIDs.contains($0) }
         let cachedIDs = cacheActor.cachedItemWindowIDs
         if cachedIDs != itemWindowIDs {
             MenuBarItemManager.diagLog.debug("cacheItemsIfNeeded: window IDs changed (\(cachedIDs.count) cached vs \(itemWindowIDs.count) current), triggering recache")
@@ -3257,6 +3305,16 @@ extension MenuBarItemManager {
         watchdogTimeout: DispatchTimeInterval? = nil,
         maxMoveAttempts: Int = 8
     ) async throws {
+        // System clone windows are transient WindowServer duplicates that
+        // must never be moved. Refuse here as a final safety net so no
+        // planning path can drag a phantom and displace real items. The
+        // planners filter clones earlier; this backstops every move caller.
+        // A no-op is correct: the clone has no managed position to restore
+        // and will vanish on its own, so there's nothing to fail or retry.
+        guard !item.isSystemClone else {
+            MenuBarItemManager.diagLog.warning("Skipping move for \(item.logString) - system status item clone")
+            return
+        }
         guard item.isMovable else {
             throw EventError.itemNotMovable(item)
         }
@@ -5530,6 +5588,12 @@ extension MenuBarItemManager {
 
         // Discover current items and build current flat sequence (right-to-left).
         var items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        // Drop transient System Status Item Clone windows before planning.
+        // partitionUnmanagedUIDs would otherwise classify a clone as an
+        // unmanaged item and anchor it into a section, dragging a phantom
+        // and reshuffling the bar. This fetch is independent of the cache
+        // path, so it needs its own filter.
+        items.removeAll(where: \.isSystemClone)
         guard var itemsCopy = Optional(items),
               let controlItems = ControlItemPair(
                   items: &itemsCopy,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -72,8 +72,16 @@ struct MenuBarItemTag: Hashable, CustomStringConvertible {
     /// A Boolean value that indicates whether the item identified
     /// by this tag is a system-created clone of an actual item,
     /// and therefore invalid for management.
+    ///
+    /// The title is a stable name the WindowServer assigns to clone
+    /// windows, but the namespace varies: it can be a UUID, the owning
+    /// process name (Window Server) when the source PID never resolves,
+    /// or even a real bundle ID when the clone spatially mis-matches a
+    /// nearby app. Matching on the title alone catches every variant;
+    /// gating on a UUID namespace missed the process-name and bundle-ID
+    /// clones seen in the field.
     var isSystemClone: Bool {
-        namespace.isUUID && title == "System Status Item Clone"
+        title == "System Status Item Clone"
     }
 
     /// A textual representation of the tag.

--- a/ThawTests/MenuBarItemTagTests.swift
+++ b/ThawTests/MenuBarItemTagTests.swift
@@ -401,13 +401,23 @@ final class MenuBarItemTagTests: XCTestCase {
         XCTAssertTrue(tag.isSystemClone)
     }
 
-    func testIsNotSystemCloneWithStringNamespace() {
-        let tag = MenuBarItemTag(
-            namespace: .string("com.example.app"),
+    func testIsSystemCloneWithStringNamespace() {
+        // Field logs show clones carry a non-UUID namespace: the owning
+        // process name (Window Server) when the source PID never resolves,
+        // or a real bundle ID when the clone spatially mis-matches a nearby
+        // app. The title is the reliable discriminator, so a string
+        // namespace with the clone title must still count as a clone.
+        let processNamespaceClone = MenuBarItemTag(
+            namespace: .string("Window Server"),
+            title: "System Status Item Clone"
+        )
+        let bundleNamespaceClone = MenuBarItemTag(
+            namespace: .string("com.google.drivefs"),
             title: "System Status Item Clone"
         )
 
-        XCTAssertFalse(tag.isSystemClone)
+        XCTAssertTrue(processNamespaceClone.isSystemClone)
+        XCTAssertTrue(bundleNamespaceClone.isSystemClone)
     }
 
     func testIsNotSystemCloneWithDifferentTitle() {


### PR DESCRIPTION
## What does this PR do?

Stops transient `System Status Item Clone` windows (spawned by the WindowServer during screen capture and menu bar animations) from being treated as real menu bar items. It corrects the `isSystemClone` detection and excludes clones at the structural chokepoints so they are never cached, sectioned, placed, moved, or allowed to trigger a re-layout.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

`MenuBarItemTag.isSystemClone` only matched clones whose namespace was a UUID, but the clones that actually occur in the field carry string namespaces: the owning process name (`Window Server`) when the source PID never resolves, or a real bundle ID (`com.google.drivefs`) when the clone spatially mis-matches a nearby app. The predicate returned `false` for every real clone, so they bypassed every guard that depended on it. This caused two failures: a clone appearing or disappearing changed the tracked windowID set, so `windowIDsChanged` dispatched a full bulk re-layout (a ~29-move menu bar churn with LCS sorting disabled); and since #604 added the unmanaged-item placer, clones were classified as unmanaged by `partitionUnmanagedUIDs` and physically dragged via `planUnmanagedPlacement`, displacing real items.
Issue Number: #662

## What is the new behavior?

`isSystemClone` now matches on the WindowServer-assigned title (`System Status Item Clone`) regardless of namespace, which makes every existing clone guard fire. Clones are then excluded at the chokepoints rather than per-call-site: `cacheItemsRegardless` drops them from the resolved items and keeps their IDs out of the stored windowID set (so their churn no longer trips the windowID-change trigger); `cacheItemsIfNeeded` ignores known clone IDs so a lingering clone no longer re-triggers a recache every poll; `applyProfileLayout` filters clones from its own fetch before `partitionUnmanagedUIDs`; and `move()` refuses to move a clone as a final no-op backstop covering every move caller. With no clone present the menu bar (the common case) all changes are no-ops, so steady-state behaviour is unchanged.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

Regression scope: the clone-gets-placed-and-moved symptom was introduced between `2.0.0-beta.12` and `2.0.0-beta.13` by `e5d3556d` (#604, "consolidate icon-restore paths via LayoutReconciler"), which added the active unmanaged-item placer. The narrow `isSystemClone` predicate was a pre-existing latent gap that #604 made visible. The old `testIsNotSystemCloneWithStringNamespace` test encoded the incorrect assumption and is replaced by `testIsSystemCloneWithStringNamespace`, covering the process-name and bundle-ID namespaces seen in the field.

Fixes #662


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented transient system-clone menu items from affecting caching, layout, reordering, and move operations (clones are filtered out and moves are no-opped).
  * Made clone detection more reliable across differing identifier formats so clones are consistently ignored.

* **Tests**
  * Added/updated tests to cover clone detection with varied identifier types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->