### PR TITLE
refactor(displays): warn when per-display spacing differs

### DIFF
--- a/Thaw/Resources/Assets.xcassets/WarningColor.colorset/Contents.json
+++ b/Thaw/Resources/Assets.xcassets/WarningColor.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.220",
+          "green" : "0.650",
+          "red" : "0.820"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -1,6 +1,17 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches." : {
+      "comment" : "A warning that mismatched per-display spacing causes a menu bar app relaunch wave when a display is connected.",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches."
+          }
+        }
+      }
+    },
     "No menu bar items available" : {
       "comment" : "Text shown in the per-item hotkeys list when there are no menu bar items to assign a hotkey to."
     },

--- a/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AutomationSettingsPane.swift
@@ -532,10 +532,10 @@ private struct HookRow: View {
                     HStack(spacing: 6) {
                         Spacer().frame(width: labelWidth)
                         Image(systemName: "exclamationmark.triangle.fill")
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(Color.warning)
                         Text(warning)
                             .font(.caption)
-                            .foregroundStyle(.orange)
+                            .foregroundStyle(Color.warning)
                     }
                 }
             }

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -56,6 +56,9 @@ struct DisplaySettingsPane: View {
             IceSection {
                 globalSection()
             }
+            CalloutBox(systemImage: "exclamationmark.triangle.fill", font: .callout, foregroundStyle: Color.warning) {
+                Text("Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches.")
+            }
             ForEach(displaySettings.allDisplays()) { display in
                 IceSection {
                     displayRow(for: display)


### PR DESCRIPTION
## What does this PR do?

Adds a warning callout to the Displays pane explaining that per-display spacing mismatches relaunch every menu bar app when a display is connected, and centralises warning styling into a shared `WarningColor` asset.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [x] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

The Displays pane only documents the spacing relaunch cost via the per-row annotation under each `Menu bar item spacing` slider, which describes the brief relaunch that happens on apply. It does not surface that keeping different spacing values across displays triggers a relaunch wave every time a display whose configured spacing differs from the current spacing is connected. Warning styling is also defined ad hoc: the automation hook validation warning uses an inline `.orange` literal.

Issue Number: #641

## What is the new behavior?

A warning callout now sits between the Global template section and the first per-display section, using `exclamationmark.triangle.fill` and the new warning tint, telling the user that connecting a display whose spacing differs relaunches every menu bar app and to keep spacing consistent to avoid it. A shared `WarningColor` colorset (muted mustard, sRGB) is added and consumed via the generated `Color.warning` symbol, and both the new callout and the existing automation hook validation warning now use it so warning styling lives in one place. The callout string is added to `Localizable.xcstrings` for translation.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

The new `WarningColor` asset is a single universal value, consistent with how `AccentColor` is defined; it does not vary by light/dark appearance. The `Color.warning` symbol is generated from the asset catalog (Xcode strips the trailing `Color` from the asset name), matching the existing `Color.defaultLayoutBar` pattern.

Ref #641


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a warning in Display Settings to alert users that connecting displays with different spacing configurations causes menu bar apps to relaunch, recommending consistent spacing across all connected displays.

* **Style**
  * Updated warning indicator styling to use a standardized warning color throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->