### PR TITLE
fix(resolution): resolve Control-Center-hosted items by title

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -393,6 +393,53 @@ final class SourcePIDCache {
             }
         }
 
+        // Corroborated spatial fallback for Control-Center-hosted items
+        // whose own app DOES publish an extras-bar AX child, but offset from
+        // the CG window center by more than the strict 1pt pass tolerates.
+        // The hosting CG slot is wider than the real icon, so their centers
+        // diverge: AirBuddy's by ~2pt, SpamSieve's by up to ~8pt. Accept the
+        // nearest such child within a generous radius ONLY when the window's
+        // reverse-DNS title is in an owner relationship with the app's bundle
+        // identifier (HostedItemOwnership). The title corroboration, not the
+        // distance, is what makes this safe: a nearby unrelated neighbor
+        // (WireGuard's slot beside Updatest at ~2pt) fails the owner check and
+        // is left for later passes. Runs BEFORE marker-pair so items that have
+        // their own AX child are claimed here and never reach that fallback.
+        // Empirically the furthest correct owner-corroborated match across
+        // captured logs is ~15pt; 20 leaves margin while staying well inside
+        // a neighbor's slot. The owner check is the real guard.
+        let hostedExtrasMatchRadius: CGFloat = 20
+        for app in apps {
+            if unresolvedWindows.isEmpty { break }
+            guard let appBundleID = app.bundleIdentifier else { continue }
+            let candidateWindows = allWindows.filter {
+                unresolvedWindows.contains($0.windowID)
+                    && HostedItemOwnership.titleIndicatesOwner($0.title, bundleID: appBundleID)
+            }
+            guard !candidateWindows.isEmpty else { continue }
+            autoreleasepool {
+                guard let bar = app.getOrCreateExtrasMenuBar() else { return }
+                let childCenters = AXHelpers.children(for: bar).compactMap { child -> CGPoint? in
+                    guard AXHelpers.enabledAttribute(child) != false,
+                          let frame = AXHelpers.frame(for: child)
+                    else {
+                        return nil
+                    }
+                    return frame.center
+                }
+                guard !childCenters.isEmpty else { return }
+                for window in candidateWindows {
+                    let target = window.bounds.center
+                    let nearest = childCenters.lazy.map { $0.distance(to: target) }.min()
+                        ?? .greatestFiniteMagnitude
+                    guard nearest <= hostedExtrasMatchRadius else { continue }
+                    totalMatchesFound += 1
+                    unresolvedWindows.remove(window.windowID)
+                    state.withLock { $0.pids[window.windowID] = app.processIdentifier }
+                }
+            }
+        }
+
         // Marker-pair PID resolution.
         //
         // On macOS 26 some widgets (Little Snitch's agent observed in

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -163,3 +163,51 @@ enum MarkerPairResolver {
         }
     }
 }
+
+/// Decides whether a Control-Center-hosted menu bar window's title
+/// indicates which application owns it, used by SourcePIDCache's
+/// corroborated spatial fallback to attribute an icon whose own app
+/// publishes an extras-bar AX child offset too far for the strict 1pt
+/// pass (AirBuddy's icon sits ~2pt off, SpamSieve up to ~8pt).
+///
+/// Some widgets carry a reverse-DNS title on the icon window itself
+/// (codes.rambo.AirBuddy.Menu, com.c-command.spamsieve) even though the
+/// CG window is owned by Control Center. Pairing that title against a
+/// candidate app's bundle identifier corroborates a loose spatial match,
+/// so a nearby unrelated neighbor can never be mis-attributed the way a
+/// bare distance threshold would allow.
+enum HostedItemOwnership {
+    /// Returns true when title and bundleID, treated as reverse-DNS
+    /// strings, are in an owner relationship: they agree on at least two
+    /// leading components, and either one is a full component-prefix of
+    /// the other or their first differing component is a prefix of its
+    /// counterpart.
+    ///
+    /// This matches codes.rambo.AirBuddy.Menu to codes.rambo.AirBuddyHelper
+    /// and com.c-command.spamsieve to com.c-command.SpamSieve, while
+    /// rejecting same-vendor different-app pairs such as
+    /// pl.maketheweb.pixelsnap2 vs pl.maketheweb.cleanshotx and unrelated
+    /// neighbors such as com.wireguard.macos vs app.updatest.Updatest.
+    /// Comparison is case-insensitive. Generic titles without a reverse-DNS
+    /// shape (Item-0, empty) never qualify.
+    static func titleIndicatesOwner(_ title: String?, bundleID: String) -> Bool {
+        guard let title, !title.isEmpty else { return false }
+        let titleParts = title.lowercased().split(separator: ".", omittingEmptySubsequences: false)
+        let bundleParts = bundleID.lowercased().split(separator: ".", omittingEmptySubsequences: false)
+        // A reverse-DNS-shaped title has at least three components; a bundle
+        // id at least two. Demanding three on the title keeps two-component
+        // or generic titles out.
+        guard titleParts.count >= 3, bundleParts.count >= 2 else { return false }
+        let shared = zip(titleParts, bundleParts).prefix { $0 == $1 }.count
+        // Require agreement on at least the vendor plus one component so a
+        // bare vendor prefix (com.apple, pl.maketheweb) is never enough.
+        guard shared >= 2 else { return false }
+        // One component array is a full prefix of the other.
+        if shared == titleParts.count || shared == bundleParts.count { return true }
+        // Otherwise the first differing component must be a prefix of its
+        // counterpart (airbuddy vs airbuddyhelper), which is what separates
+        // AirBuddy from same-vendor different-app pairs.
+        return titleParts[shared].hasPrefix(bundleParts[shared])
+            || bundleParts[shared].hasPrefix(titleParts[shared])
+    }
+}

--- a/ThawTests/MarkerPairResolverTests.swift
+++ b/ThawTests/MarkerPairResolverTests.swift
@@ -391,3 +391,98 @@ final class MarkerPairResolverTests: XCTestCase {
         XCTAssertEqual(markers.map(\.windowID), [2])
     }
 }
+
+/// Tests for HostedItemOwnership.titleIndicatesOwner, the corroboration
+/// gate behind SourcePIDCache's loose spatial fallback. The accept/reject
+/// cases are drawn directly from captured field logs so the dataset that
+/// motivated the rule stays locked in: every accepted pair is a real
+/// owner match seen unresolved, every rejected pair is a wrong neighbor or
+/// same-vendor different-app collision seen in the same logs.
+final class HostedItemOwnershipTests: XCTestCase {
+    // MARK: - Accept: genuine owner matches observed unresolved in logs
+
+    func testAirBuddyMenuMatchesAirBuddyHelper() {
+        // codes.rambo.AirBuddy.Menu hosted by Control Center, owned by the
+        // helper whose bundle id extends the icon's distinctive component.
+        XCTAssertTrue(
+            HostedItemOwnership.titleIndicatesOwner(
+                "codes.rambo.AirBuddy.Menu",
+                bundleID: "codes.rambo.AirBuddyHelper"
+            )
+        )
+    }
+
+    func testSpamSieveMatchesCaseInsensitively() {
+        XCTAssertTrue(
+            HostedItemOwnership.titleIndicatesOwner(
+                "com.c-command.spamsieve",
+                bundleID: "com.c-command.SpamSieve"
+            )
+        )
+    }
+
+    func testCotypistSubItemMatchesParentBundle() {
+        XCTAssertTrue(
+            HostedItemOwnership.titleIndicatesOwner(
+                "app.cotypist.Cotypist.ModelRepository",
+                bundleID: "app.cotypist.Cotypist"
+            )
+        )
+    }
+
+    // MARK: - Reject: same-vendor different-app collisions
+
+    func testPixelSnapDoesNotMatchCleanShot() {
+        // Both pl.maketheweb, but pixelsnap2 and cleanshotx are distinct
+        // apps; a vendor-only prefix must never be enough.
+        XCTAssertFalse(
+            HostedItemOwnership.titleIndicatesOwner(
+                "pl.maketheweb.pixelsnap2",
+                bundleID: "pl.maketheweb.cleanshotx"
+            )
+        )
+        XCTAssertFalse(
+            HostedItemOwnership.titleIndicatesOwner(
+                "pl.maketheweb.cleanshotx",
+                bundleID: "pl.maketheweb.pixelsnap2"
+            )
+        )
+    }
+
+    // MARK: - Reject: unrelated neighbors that sat within the radius
+
+    func testWireGuardDoesNotMatchUpdatest() {
+        XCTAssertFalse(
+            HostedItemOwnership.titleIndicatesOwner(
+                "com.wireguard.macos",
+                bundleID: "app.updatest.Updatest"
+            )
+        )
+    }
+
+    func testSpamSieveDoesNotMatchAusweisApp() {
+        // Same first component (com) but different vendor; one shared
+        // component is not enough.
+        XCTAssertFalse(
+            HostedItemOwnership.titleIndicatesOwner(
+                "com.c-command.spamsieve",
+                bundleID: "com.governikus.ausweisapp2"
+            )
+        )
+    }
+
+    // MARK: - Reject: non-reverse-DNS and empty titles
+
+    func testGenericTitleNeverMatches() {
+        XCTAssertFalse(HostedItemOwnership.titleIndicatesOwner("Item-0", bundleID: "de.fauler-apfel.CMD-Z"))
+    }
+
+    func testTwoComponentTitleNeverMatches() {
+        XCTAssertFalse(HostedItemOwnership.titleIndicatesOwner("mega.mac", bundleID: "mega.mac"))
+    }
+
+    func testNilAndEmptyTitleNeverMatch() {
+        XCTAssertFalse(HostedItemOwnership.titleIndicatesOwner(nil, bundleID: "codes.rambo.AirBuddyHelper"))
+        XCTAssertFalse(HostedItemOwnership.titleIndicatesOwner("", bundleID: "codes.rambo.AirBuddyHelper"))
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Resolves the source app for menu bar widgets that host their `NSStatusItem` under Control Center while still publishing their own `AXExtrasMenuBar` child (AirBuddy, SpamSieve, Cotypist). These items were never resolved, kept a placeholder `com.apple.controlcenter` identity, and got swept into the hidden section on every profile re-layout. A new corroborated spatial fallback in `SourcePIDCache` attributes them to their real owner using a reverse-DNS title-to-bundle-id match, gated by corroboration rather than a looser distance threshold.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

A widget whose CG window is hosted by Control Center but whose own app publishes an `AXExtrasMenuBar` child (e.g. AirBuddy's `codes.rambo.AirBuddy.Menu`, owned by `codes.rambo.AirBuddyHelper`) fails source-PID resolution. The hosting CG slot is wider than the real icon, so the icon's AX child center sits more than 1pt from the CG window center (AirBuddy ~2pt, SpamSieve up to ~8pt), and the strict 1pt spatial pass rejects it. The item keeps the placeholder `com.apple.controlcenter` namespace, which no longer matches the profile entry saved under the resolved bundle id, so it is treated as unmanaged and `planUnmanagedPlacement` defaults it into the hidden section. The icon "goes into hiding" while pinned to the bar, and re-hides on every subsequent re-layout.
Issue Number: #641

## What is the new behavior?

A corroborated spatial fallback runs after the strict 1pt pass and before the marker-pair pass. For each still-unresolved window whose reverse-DNS title is in an owner relationship with a candidate app's bundle identifier (`HostedItemOwnership.titleIndicatesOwner`: at least two shared leading components, plus a full component-prefix or a first-differing-component prefix, case-insensitive), it accepts that app's nearest enabled extras-bar child within a 20pt backstop radius. The title corroboration, not the distance, is the guard, so a nearby unrelated neighbor is never mis-attributed and a same-vendor different-app pair (`pl.maketheweb.pixelsnap2` vs `pl.maketheweb.cleanshotx`) is rejected. Items handled here have their own AX child, so they resolve on the spatial pass, keep their saved profile section, and never reach the marker-pair fallback or the unresolved diagnostic. The strict 1pt matcher, the marker-pair gate, and the unrelated 10pt and 50pt matchers are unchanged.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

A pure threshold change cannot fix this safely: across 7,634 unresolved diagnostic samples from 63 captured logs (four users, six weeks) the correct and incorrect matches are interleaved by distance. AirBuddy's correct match is at 2.06pt, but `com.wireguard.macos` sits 2.00pt from an unrelated `app.updatest.Updatest` child, and `pl.maketheweb.pixelsnap2` sits 9pt from the different-app `pl.maketheweb.cleanshotx`. The component-aware owner rule was validated against that full dataset: it accepts only AirBuddy, SpamSieve, and Cotypist and rejects every wrong neighbor at any distance. `HostedItemOwnership` lives in the shared module so both the XPC service and the test target reach it without adding a file; `HostedItemOwnershipTests` locks in the accept/reject cases drawn directly from the logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar item detection and resolution, adding a spatial fallback to better identify Control Center–hosted items and reduce misattributions
  * Enhanced proximity and title-based ownership checks to prevent incorrect associations between items and apps

* **Tests**
  * Added comprehensive tests covering hosted-item ownership and detection edge cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->