### PR TITLE
fix(menubar): defer layout while a relaunched app's item re-pairs

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1230,9 +1230,35 @@ final class MenuBarItemManager: ObservableObject {
             for: NSWorkspace.didLaunchApplicationNotification
         )
         .debounce(for: 1, scheduler: DispatchQueue.main)
-        .sink { [weak self] _ in
+        .sink { [weak self] notification in
             guard let self else { return }
-            MenuBarItemManager.diagLog.debug("App launched, refreshing cache for potential new items")
+            let launchedBundleID = (notification.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication)?
+                .bundleIdentifier
+            MenuBarItemManager.diagLog.debug(
+                "App launched\(launchedBundleID.map { " (\($0))" } ?? ""), refreshing cache for potential new items"
+            )
+
+            // If the launched app is one we already track a menu bar item for,
+            // it just relaunched (e.g. an in-app update): its status item is
+            // about to disappear and re-register, churning the bar for a few
+            // seconds. Start a settling period keyed on its bundle ID so the
+            // move pass (applyProfileLayout waits on waitForStartupSettlingToEnd)
+            // and the virtual-display provoke (guarded by isSettling) both hold
+            // off until the item has re-paired. Without this the bulk apply ran
+            // on the transient layout and swept hidden items into the visible
+            // section. The period exits the instant the bundle ID reappears
+            // with a resolved PID (median ~3s in field logs); maxDuration is
+            // only a backstop. Apps with no tracked menu bar item arm nothing,
+            // so there is no deferral for ordinary launches.
+            if let launchedBundleID,
+               MenuBarItemManager.tracksMenuBarItem(bundleID: launchedBundleID, in: self.knownItemIdentifiers)
+            {
+                self.startSettlingPeriod(
+                    reason: "appLaunch",
+                    expectedBundleIDs: [launchedBundleID],
+                    maxDuration: .seconds(8)
+                )
+            }
             Task { [weak self] in
                 await self?.cacheItemsRegardless()
                 // Many apps register their NSStatusItem more than 1s after
@@ -1833,6 +1859,16 @@ extension MenuBarItemManager {
                 .filter { $0.sourcePID == nil && !$0.isControlItem }
                 .map(\.windowID)
         )
+    }
+
+    /// Whether bundleID owns a menu bar item Thaw already tracks: an entry
+    /// in identifiers (each formatted "namespace:title") whose namespace is
+    /// exactly bundleID. The trailing ":" anchors the match so one bundle ID
+    /// can't be a loose prefix of another (org.x.fdm6 must not match
+    /// org.x.fdm6x:Item-0). Used to arm relaunch settling only for apps whose
+    /// status item actually churns the bar when they relaunch.
+    nonisolated static func tracksMenuBarItem(bundleID: String, in identifiers: Set<String>) -> Bool {
+        identifiers.contains { $0.hasPrefix(bundleID + ":") }
     }
 
     /// Caches the current menu bar items, regardless of whether the

--- a/ThawTests/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/ProfileLayoutLogReplayTests.swift
@@ -487,4 +487,21 @@ final class RelaunchSettlingGateTests: XCTestCase {
             MenuBarItemManager.tracksMenuBarItem(bundleID: "org.freedownloadmanager.fdm6", in: [])
         )
     }
+
+    func testControlCenterSingletonItemMatches() {
+        // A simple "namespace:title" entry (title has no dots) still matches
+        // on the namespace.
+        XCTAssertTrue(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "com.apple.controlcenter", in: tracked)
+        )
+    }
+
+    func testAirBuddyWithMultiComponentTitleMatches() {
+        // The title here is itself reverse-DNS shaped
+        // (codes.rambo.AirBuddy.Menu); the ":" anchor must match on the
+        // namespace and not be confused by the dots in the title.
+        XCTAssertTrue(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "codes.rambo.AirBuddyHelper", in: tracked)
+        )
+    }
 }

--- a/ThawTests/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/ProfileLayoutLogReplayTests.swift
@@ -445,3 +445,46 @@ extension ProfileLayoutLogReplay.Cycle {
         )
     }
 }
+
+/// Red→green guard for the relaunch-settling gate
+/// (MenuBarItemManager.tracksMenuBarItem). When a tracked app relaunches
+/// (e.g. an in-app update) Thaw must arm a settling period so the move pass
+/// waits out the churn; without it the bulk apply runs on the transient
+/// layout and sweeps hidden items into the visible section (the Free Download
+/// Manager update unhide). Equally it must NOT arm for ordinary launches, so
+/// users don't pay a deferral on every app start, and one bundle ID must not
+/// loosely prefix-match another app.
+final class RelaunchSettlingGateTests: XCTestCase {
+    private let tracked: Set<String> = [
+        "org.freedownloadmanager.fdm6:Item-0",
+        "codes.rambo.AirBuddyHelper:codes.rambo.AirBuddy.Menu",
+        "com.apple.controlcenter:WiFi",
+    ]
+
+    func testTrackedAppRelaunchArmsSettling() {
+        XCTAssertTrue(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "org.freedownloadmanager.fdm6", in: tracked)
+        )
+    }
+
+    func testUntrackedAppLaunchDoesNotArmSettling() {
+        XCTAssertFalse(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "com.apple.Safari", in: tracked)
+        )
+    }
+
+    func testBundleIDPrefixBoundaryDoesNotFalseMatch() {
+        // org.freedownloadmanager.fdm6 must not match a different app whose
+        // bundle id merely extends it; the ":" separator anchors the match.
+        let other: Set<String> = ["org.freedownloadmanager.fdm6x:Item-0"]
+        XCTAssertFalse(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "org.freedownloadmanager.fdm6", in: other)
+        )
+    }
+
+    func testEmptyKnownSetNeverArms() {
+        XCTAssertFalse(
+            MenuBarItemManager.tracksMenuBarItem(bundleID: "org.freedownloadmanager.fdm6", in: [])
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Stops previously-hidden menu bar items from jumping back onto the bar when an app with a status item relaunches (e.g. an in-app update like Free Download Manager). It arms a short settling period on a tracked app's relaunch so the layout move pass and the virtual-display provoke both wait until the item has re-paired, then plan against stable geometry.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

When an app with a menu bar item relaunches, its status item disappears and re-registers over a few seconds, during which the bar is in flux: the Thaw hidden control item (the wide boundary window) is briefly unresolved and its position slides hundreds of points between cycles. The `didLaunchApplicationNotification` handler refreshes the cache immediately, which dispatches a bulk apply, and the move pass runs against that transient geometry. The planner's section decision is actually correct (`crossSectionMoves=0, totalSectionMismatch=0` in the field log), but the within-section reorder moves resolve their anchors against the sliding control item and land previously-hidden items next to a visible Control Center item, so hidden icons jump back onto the bar. The same relaunch churn also fires the virtual-display provoke prematurely for the transient orphan.
Issue Number: #641

## What is the new behavior?

`isSettling` already makes both the move pass (`applyProfileLayout` awaits `waitForStartupSettlingToEnd`) and the provoke (guarded by `isSettling`) hold off while the bar is unstable, but it was only ever started for cold boot and Thaw-initiated relaunch waves, never for a spontaneous external relaunch. The launch handler now starts a settling period, but only when the launched bundle ID owns a menu bar item Thaw already tracks, so ordinary launches (apps with no status item) arm nothing and pay no deferral. The period uses expected-set mode keyed on that bundle ID, exiting the instant the item re-pairs with a resolved PID (median ~3s across field logs, p95 ~6s); the 8s `maxDuration` is only a backstop. One change covers both the bulk-apply unhide and the premature provoke. The tracked-app gate is extracted into `MenuBarItemManager.tracksMenuBarItem(bundleID:in:)` so it is unit-testable.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

The unhide is an execution-time effect (anchor resolution against transient geometry), not a planner-decision error, the planner logged `totalSectionMismatch=0` at the moment items unhid. That is why the fix defers the apply rather than changing the planner, and why the log-replay harness (which models the pure planner decision, correct in both transient and settled states) cannot reproduce this class; an FDM fixture there would pass with or without the fix, so none was added. `RelaunchSettlingGateTests` is a red/green guard on the gate condition (including the `org.x.fdm6` vs `org.x.fdm6x` boundary), which is the precise condition under which the unhide is prevented.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * More robust handling of app launches for tracked menu bar items: uses the launched app's bundle identifier to start a short, bundle-scoped startup settling period, reducing spurious refreshes.

* **Tests**
  * Added tests validating tracked vs untracked bundle identifiers, namespace/format edge cases, and empty-set behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->