### PR TITLE
fix(profiles): re-arm layout cache when the active profile is updated

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -277,8 +277,10 @@ final class MenuBarItemManager: ObservableObject {
     private var pinnedAlwaysHiddenBundleIDs = Set<String>()
 
     /// Cached layout parameters from the last profile apply, used to re-sort
-    /// when profile-listed items appear after the initial apply.
-    private var activeProfileLayout: (
+    /// when profile-listed items appear after the initial apply. Read access
+    /// is internal so tests can verify the re-arm path refreshes it; writes
+    /// remain confined to this file (armProfileState and rearmActiveProfileLayout).
+    private(set) var activeProfileLayout: (
         pinnedHidden: Set<String>,
         pinnedAlwaysHidden: Set<String>,
         sectionOrder: [String: [String]],
@@ -288,7 +290,7 @@ final class MenuBarItemManager: ObservableObject {
 
     /// Flattened set of item identifiers from the active profile's itemOrder,
     /// for O(1) lookup when detecting late-arriving profile items.
-    private var activeProfileItemIdentifiers = Set<String>()
+    private(set) var activeProfileItemIdentifiers = Set<String>()
 
     /// Set of item identifiers that were present when the profile layout was
     /// last applied (or re-applied). Used to detect genuinely new arrivals.
@@ -5563,6 +5565,40 @@ extension MenuBarItemManager {
             itemOrder: itemOrder
         )
         activeProfileItemIdentifiers = Set(itemOrder.values.flatMap(\.self))
+    }
+
+    /// Refreshes the cached active-profile spec to match a freshly saved
+    /// layout, without performing any moves. Called when the user updates the
+    /// currently-active profile (Update Layout / Update All): the saved layout
+    /// is captured from the live savedSectionOrder, so the bar is already in
+    /// the target arrangement and only the in-memory spec that drives
+    /// late-arrival re-sorts needs to catch up. armProfileState runs only on
+    /// apply, so without this an update leaves activeProfileLayout pointing at
+    /// the pre-update spec and the next late-arrival re-sort reverts the bar
+    /// until the profile is re-applied.
+    ///
+    /// Unlike armProfileState this performs a pure cache refresh: it does not
+    /// touch savedSectionOrder or the live pinning sets (the snapshot already
+    /// equals them), does not arm isApplyingProfileLayout, and does not cancel
+    /// an in-flight re-sort.
+    func rearmActiveProfileLayout(
+        pinnedHidden: Set<String>,
+        pinnedAlwaysHidden: Set<String>,
+        sectionOrder: [String: [String]],
+        itemSectionMap: [String: String],
+        itemOrder: [String: [String]]
+    ) {
+        activeProfileLayout = (
+            pinnedHidden: pinnedHidden,
+            pinnedAlwaysHidden: pinnedAlwaysHidden,
+            sectionOrder: sectionOrder,
+            itemSectionMap: itemSectionMap,
+            itemOrder: itemOrder
+        )
+        activeProfileItemIdentifiers = Set(itemOrder.values.flatMap(\.self))
+        MenuBarItemManager.diagLog.debug(
+            "rearmActiveProfileLayout: refreshed cached profile spec after active-profile update (\(self.activeProfileItemIdentifiers.count) item identifiers)"
+        )
     }
 
     /// Persists the profile's pinning sets and saved section order to

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -42,7 +42,11 @@ final class ProfileManager: ObservableObject {
     /// Observers for profile hotkey changes.
     private var profileHotkeyCancellables = Set<AnyCancellable>()
 
-    init() {
+    /// - Parameter profilesDirectory: Where profile JSON and the manifest
+    ///   live. Defaults to Application Support in production; tests pass a
+    ///   temporary directory to exercise the real load/save paths in isolation
+    ///   without touching the user's profiles.
+    init(profilesDirectory: URL? = nil) {
         let enc = JSONEncoder()
         enc.dateEncodingStrategy = .iso8601
         enc.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -52,15 +56,19 @@ final class ProfileManager: ObservableObject {
         dec.dateDecodingStrategy = .iso8601
         decoder = dec
 
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
-            fatalError("Application Support directory not found")
+        if let profilesDirectory {
+            self.profilesDirectory = profilesDirectory
+        } else {
+            guard let appSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                fatalError("Application Support directory not found")
+            }
+            self.profilesDirectory = appSupport
+                .appendingPathComponent("Thaw/Profiles", isDirectory: true)
         }
-        profilesDirectory = appSupport
-            .appendingPathComponent("Thaw/Profiles", isDirectory: true)
-        manifestURL = profilesDirectory
+        manifestURL = self.profilesDirectory
             .appendingPathComponent("profiles.json")
 
         ensureDirectoryExists()
@@ -208,7 +216,7 @@ final class ProfileManager: ObservableObject {
                 displayConfigurations: appState.settings.displaySettings.configurations,
                 globalDisplayConfiguration: appState.settings.displaySettings.globalConfiguration,
                 appearanceConfiguration: appState.appearanceManager.configuration,
-                menuBarLayout: captureCurrentLayout(from: appState)
+                menuBarLayout: captureCurrentLayout(from: appState.itemManager)
             )
         )
 
@@ -564,12 +572,25 @@ final class ProfileManager: ObservableObject {
             profiles[index].modifiedAt = updated.modifiedAt
         }
         saveManifest()
+
+        // The live arrangement is unchanged by this save, so re-capturing it
+        // yields the same layout that was just persisted. Re-arm the cache from
+        // it when this is the active profile so a later late-arrival re-sort
+        // honours the update instead of reverting to the pre-update spec.
+        rearmActiveLayoutIfNeeded(
+            updatedID: id,
+            scope: .all,
+            layout: captureCurrentLayout(from: appState.itemManager),
+            itemManager: appState.itemManager
+        )
     }
 
     // MARK: - Capture Helpers
 
-    /// Captures the current menu bar layout from the app state.
-    private func captureCurrentLayout(from appState: AppState) -> MenuBarLayoutSnapshot {
+    /// Captures the current menu bar layout. Depends only on the item manager
+    /// (and UserDefaults), not the full app state, so the capture and re-arm
+    /// paths can be exercised in tests without standing up an AppState.
+    private func captureCurrentLayout(from itemManager: MenuBarItemManager) -> MenuBarLayoutSnapshot {
         let savedSectionOrder = UserDefaults.standard.dictionary(
             forKey: "MenuBarItemManager.savedSectionOrder"
         ) as? [String: [String]] ?? [:]
@@ -600,8 +621,8 @@ final class ProfileManager: ObservableObject {
         // MenuBarItemManager.computeSectionOrder runs the same filter
         // and closed-app preservation, so the profile's itemOrder is
         // a curated snapshot consistent with savedSectionOrder.
-        let itemOrder = appState.itemManager.computeSectionOrder(
-            from: appState.itemManager.itemCache
+        let itemOrder = itemManager.computeSectionOrder(
+            from: itemManager.itemCache
         )
         var itemSectionMap = [String: String]()
         for (sectionKey, uids) in itemOrder {
@@ -617,7 +638,7 @@ final class ProfileManager: ObservableObject {
             customNames: customNames,
             itemSectionMap: itemSectionMap,
             itemOrder: itemOrder,
-            newItemsPlacement: appState.itemManager.newItemsPlacement,
+            newItemsPlacement: itemManager.newItemsPlacement,
             itemHotkeys: itemHotkeys
         )
     }
@@ -656,24 +677,79 @@ final class ProfileManager: ObservableObject {
         case configurationOnly
     }
 
+    /// Decides whether updating profile updatedID under scope should
+    /// refresh MenuBarItemManager's in-memory active-profile layout cache.
+    /// True only when the updated profile is the currently-active one and the
+    /// update captured a fresh layout (.all or .layoutOnly): a
+    /// configuration-only update changes no layout, and updating an inactive
+    /// profile must never touch live state. Without re-arming, an update writes
+    /// the new layout to disk but leaves the cache pointing at the pre-update
+    /// spec, so the next late-arrival re-sort reverts the bar until the profile
+    /// is manually re-applied.
+    nonisolated static func shouldRearmActiveLayout(
+        updatedID: UUID,
+        activeID: UUID?,
+        scope: ProfileUpdateScope
+    ) -> Bool {
+        guard updatedID == activeID else { return false }
+        switch scope {
+        case .all, .layoutOnly:
+            return true
+        case .configurationOnly:
+            return false
+        }
+    }
+
     /// Updates a profile with only the specified scope of current state.
     func updateProfile(id: UUID, scope: ProfileUpdateScope, appState: AppState) throws {
         switch scope {
         case .all:
             try updateProfileWithCurrentState(id: id, appState: appState)
         case .layoutOnly:
-            try updateProfileLayout(id: id, appState: appState)
+            try updateProfileLayout(id: id, itemManager: appState.itemManager)
         case .configurationOnly:
             try updateProfileConfiguration(id: id, appState: appState)
         }
     }
 
-    /// Updates only the menu bar layout of an existing profile.
-    private func updateProfileLayout(id: UUID, appState: AppState) throws {
+    /// Updates only the menu bar layout of an existing profile. Takes the item
+    /// manager rather than the full app state: layout capture and re-arm need
+    /// nothing else, and the narrower dependency lets this be exercised in
+    /// tests without an AppState. Internal so the integration test can drive it
+    /// directly through the injected profiles directory.
+    func updateProfileLayout(id: UUID, itemManager: MenuBarItemManager) throws {
         var profile = try loadProfile(id: id)
-        profile.menuBarLayout = captureCurrentLayout(from: appState)
+        let layout = captureCurrentLayout(from: itemManager)
+        profile.menuBarLayout = layout
         profile.modifiedAt = Date()
         try saveProfileAndUpdateManifest(profile)
+        rearmActiveLayoutIfNeeded(updatedID: id, scope: .layoutOnly, layout: layout, itemManager: itemManager)
+    }
+
+    /// Refreshes MenuBarItemManager's cached active-profile layout after an
+    /// update that captured a fresh layout, so a later late-arrival re-sort
+    /// honours the new layout without a manual re-apply. No-op unless the
+    /// updated profile is the active one (see shouldRearmActiveLayout). The
+    /// captured layout already matches the live arrangement, so this only syncs
+    /// the in-memory spec and moves nothing.
+    private func rearmActiveLayoutIfNeeded(
+        updatedID: UUID,
+        scope: ProfileUpdateScope,
+        layout: MenuBarLayoutSnapshot,
+        itemManager: MenuBarItemManager
+    ) {
+        guard Self.shouldRearmActiveLayout(
+            updatedID: updatedID,
+            activeID: activeProfileID,
+            scope: scope
+        ) else { return }
+        itemManager.rearmActiveProfileLayout(
+            pinnedHidden: Set(layout.pinnedHiddenBundleIDs),
+            pinnedAlwaysHidden: Set(layout.pinnedAlwaysHiddenBundleIDs),
+            sectionOrder: layout.savedSectionOrder,
+            itemSectionMap: layout.itemSectionMap ?? [:],
+            itemOrder: layout.itemOrder ?? [:]
+        )
     }
 
     /// Updates only the configuration (settings, hotkeys, appearance) of an existing profile.

--- a/ThawTests/MenuBarItemManagerRearmTests.swift
+++ b/ThawTests/MenuBarItemManagerRearmTests.swift
@@ -1,0 +1,92 @@
+//
+//  MenuBarItemManagerRearmTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Verifies the cache-refresh contract of rearmActiveProfileLayout, the half
+/// of the fix that lives in MenuBarItemManager.
+///
+/// The late-arrival re-sort reads activeProfileLayout (its sectionOrder /
+/// itemSectionMap) and activeProfileItemIdentifiers. When the user updates the
+/// active profile, re-arming must refresh both so the next re-sort targets the
+/// updated layout instead of the spec frozen at the last apply. This is exactly
+/// the reversion that dragged items back into Always-Hidden in the field logs.
+@MainActor
+final class MenuBarItemManagerRearmTests: XCTestCase {
+    /// Re-arming on a fresh manager refreshes both the cached layout and the
+    /// flattened identifier set the late-arrival detector consults.
+    func testRearmRefreshesCachedLayoutAndIdentifiers() {
+        let manager = MenuBarItemManager()
+        XCTAssertNil(manager.activeProfileLayout, "Nothing should be armed before a profile is applied or updated")
+
+        let sectionOrder = [
+            "hidden": ["com.example.a:Item-0", "com.example.b:Item-0"],
+            "alwaysHidden": [String](),
+        ]
+        let itemSectionMap = [
+            "com.example.a:Item-0": "hidden",
+            "com.example.b:Item-0": "hidden",
+        ]
+
+        manager.rearmActiveProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: sectionOrder,
+            itemSectionMap: itemSectionMap,
+            itemOrder: sectionOrder
+        )
+
+        XCTAssertEqual(manager.activeProfileLayout?.sectionOrder, sectionOrder)
+        XCTAssertEqual(manager.activeProfileLayout?.itemSectionMap, itemSectionMap)
+        XCTAssertEqual(
+            manager.activeProfileItemIdentifiers,
+            ["com.example.a:Item-0", "com.example.b:Item-0"]
+        )
+    }
+
+    /// Reproduces the field reversion at the cache level: a profile is applied
+    /// with an item in Always-Hidden, the user moves it to Hidden and updates
+    /// the profile, and re-arming must move the cached section to Hidden. With
+    /// the pre-fix no-op, the cache would stay on the Always-Hidden spec and the
+    /// next late-arrival re-sort would drag the item back into Always-Hidden.
+    func testRearmMovesCachedItemFromAlwaysHiddenToHidden() {
+        let manager = MenuBarItemManager()
+        let uid = "com.if.Amphetamine:Amphetamine"
+
+        // State A: as applied — item lives in Always-Hidden.
+        manager.rearmActiveProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: ["alwaysHidden": [uid]],
+            itemSectionMap: [uid: "alwaysHidden"],
+            itemOrder: ["alwaysHidden": [uid]]
+        )
+        XCTAssertEqual(
+            manager.activeProfileLayout?.itemSectionMap[uid],
+            "alwaysHidden",
+            "Precondition: the applied spec has the item in Always-Hidden"
+        )
+
+        // State B: user moved it to Hidden and updated the active profile.
+        manager.rearmActiveProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: ["hidden": [uid]],
+            itemSectionMap: [uid: "hidden"],
+            itemOrder: ["hidden": [uid]]
+        )
+
+        XCTAssertEqual(
+            manager.activeProfileLayout?.itemSectionMap[uid],
+            "hidden",
+            "Re-arm must refresh the cached section so the late-arrival re-sort targets the updated layout, not the pre-update spec"
+        )
+        XCTAssertEqual(manager.activeProfileItemIdentifiers, [uid])
+    }
+}

--- a/ThawTests/ProfileManagerRearmGateTests.swift
+++ b/ThawTests/ProfileManagerRearmGateTests.swift
@@ -1,0 +1,68 @@
+//
+//  ProfileManagerRearmGateTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Characterizes the gate that decides whether updating a profile should
+/// re-arm MenuBarItemManager's in-memory active-profile layout cache.
+///
+/// The bug: updating the currently-applied profile (Update Layout / Update
+/// All) writes the new layout to disk but never refreshes the cache, so a
+/// later late-arrival re-sort reverts the bar to the pre-update spec. The fix
+/// re-arms the cache, but only for the active profile and only when the update
+/// captured a fresh layout. These tests pin that decision matrix down.
+final class ProfileManagerRearmGateTests: XCTestCase {
+    /// Updating the active profile's layout must re-arm the cache.
+    func testActiveProfileLayoutOnlyUpdateRearms() {
+        let id = UUID()
+        XCTAssertTrue(
+            ProfileManager.shouldRearmActiveLayout(updatedID: id, activeID: id, scope: .layoutOnly)
+        )
+    }
+
+    /// An "Update All" on the active profile also captures the layout, so it
+    /// must re-arm.
+    func testActiveProfileAllUpdateRearms() {
+        let id = UUID()
+        XCTAssertTrue(
+            ProfileManager.shouldRearmActiveLayout(updatedID: id, activeID: id, scope: .all)
+        )
+    }
+
+    /// A configuration-only update changes no layout, so it must not touch the
+    /// layout cache.
+    func testActiveProfileConfigurationOnlyDoesNotRearm() {
+        let id = UUID()
+        XCTAssertFalse(
+            ProfileManager.shouldRearmActiveLayout(updatedID: id, activeID: id, scope: .configurationOnly)
+        )
+    }
+
+    /// Updating a profile that is not the active one must never touch live
+    /// state, regardless of scope.
+    func testInactiveProfileUpdateDoesNotRearm() {
+        XCTAssertFalse(
+            ProfileManager.shouldRearmActiveLayout(updatedID: UUID(), activeID: UUID(), scope: .layoutOnly)
+        )
+        XCTAssertFalse(
+            ProfileManager.shouldRearmActiveLayout(updatedID: UUID(), activeID: UUID(), scope: .all)
+        )
+    }
+
+    /// With no active profile there is nothing to re-arm.
+    func testNoActiveProfileDoesNotRearm() {
+        let id = UUID()
+        XCTAssertFalse(
+            ProfileManager.shouldRearmActiveLayout(updatedID: id, activeID: nil, scope: .layoutOnly)
+        )
+        XCTAssertFalse(
+            ProfileManager.shouldRearmActiveLayout(updatedID: id, activeID: nil, scope: .all)
+        )
+    }
+}

--- a/ThawTests/ProfileManagerUpdateRearmIntegrationTests.swift
+++ b/ThawTests/ProfileManagerUpdateRearmIntegrationTests.swift
@@ -1,0 +1,178 @@
+//
+//  ProfileManagerUpdateRearmIntegrationTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// End-to-end regression lock for the update-re-arms-cache wiring.
+///
+/// Drives the real ProfileManager.updateProfileLayout path against an injected
+/// temporary profiles directory and a standalone MenuBarItemManager: it loads
+/// the profile from disk, captures the live layout, writes the update back, and
+/// re-arms the in-memory cache. This is the integration the gate test and the
+/// MenuBarItemManager cache test could not reach on their own. It fails if the
+/// rearm wiring is removed from updateProfileLayout.
+@MainActor
+final class ProfileManagerUpdateRearmIntegrationTests: XCTestCase {
+    private let savedSectionOrderKey = "MenuBarItemManager.savedSectionOrder"
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: savedSectionOrderKey)
+        super.tearDown()
+    }
+
+    /// A profile is active with an item in Always-Hidden, the user moves it to
+    /// Hidden (updating the live savedSectionOrder), then updates the active
+    /// profile's layout. The item manager's cached spec must follow to Hidden,
+    /// so a later late-arrival re-sort no longer drags the item back into
+    /// Always-Hidden. Without the re-arm wiring the cache stays on the
+    /// Always-Hidden spec and this fails.
+    func testUpdatingActiveProfileLayoutRearmsCacheEndToEnd() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let profileManager = ProfileManager(profilesDirectory: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let itemManager = MenuBarItemManager()
+        let uid = "com.example.app:Item-0"
+
+        // A profile exists on disk and is the active one.
+        let profile = makeProfile(savedSectionOrder: ["alwaysHidden": [uid]])
+        try writeProfile(profile, into: tmp)
+        profileManager.activeProfileID = profile.id
+
+        // Cache armed as if the profile were applied: item in Always-Hidden.
+        itemManager.rearmActiveProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: ["alwaysHidden": [uid]],
+            itemSectionMap: [uid: "alwaysHidden"],
+            itemOrder: ["alwaysHidden": [uid]]
+        )
+        XCTAssertEqual(
+            itemManager.activeProfileLayout?.sectionOrder,
+            ["alwaysHidden": [uid]],
+            "Precondition: cache reflects the applied (Always-Hidden) spec"
+        )
+
+        // The user dragged the item to Hidden: the live layout is now B.
+        UserDefaults.standard.set(["hidden": [uid]], forKey: savedSectionOrderKey)
+
+        // The user updates the active profile's layout.
+        try profileManager.updateProfileLayout(id: profile.id, itemManager: itemManager)
+
+        // The cache now reflects Hidden, so the next late-arrival re-sort
+        // targets the updated layout instead of reverting to Always-Hidden.
+        XCTAssertEqual(
+            itemManager.activeProfileLayout?.sectionOrder,
+            ["hidden": [uid]],
+            "Updating the active profile must re-arm the cache to the new layout"
+        )
+    }
+
+    /// Updating a profile that is not the active one must not touch the cache,
+    /// even end-to-end: the disk write happens but the in-memory spec is left
+    /// pointing at the active profile's layout.
+    func testUpdatingInactiveProfileDoesNotRearmCache() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let profileManager = ProfileManager(profilesDirectory: tmp)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let itemManager = MenuBarItemManager()
+        let uid = "com.example.app:Item-0"
+
+        let inactiveProfile = makeProfile(savedSectionOrder: ["alwaysHidden": [uid]])
+        try writeProfile(inactiveProfile, into: tmp)
+        // A different profile is the active one.
+        profileManager.activeProfileID = UUID()
+
+        itemManager.rearmActiveProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: ["alwaysHidden": [uid]],
+            itemSectionMap: [uid: "alwaysHidden"],
+            itemOrder: ["alwaysHidden": [uid]]
+        )
+
+        UserDefaults.standard.set(["hidden": [uid]], forKey: savedSectionOrderKey)
+        try profileManager.updateProfileLayout(id: inactiveProfile.id, itemManager: itemManager)
+
+        XCTAssertEqual(
+            itemManager.activeProfileLayout?.sectionOrder,
+            ["alwaysHidden": [uid]],
+            "Updating a non-active profile must leave the active cache untouched"
+        )
+    }
+
+    // MARK: - Helpers
+
+    private func makeProfile(savedSectionOrder: [String: [String]]) -> Profile {
+        let content = ProfileContent(
+            generalSettings: GeneralSettingsSnapshot(
+                showIceIcon: true,
+                iceIcon: .defaultIceIcon,
+                lastCustomIceIcon: nil,
+                customIceIconIsTemplate: true,
+                useIceBar: false,
+                useIceBarOnlyOnNotchedDisplay: false,
+                iceBarLocation: .dynamic,
+                iceBarLocationOnHotkey: false,
+                showOnClick: true,
+                showOnDoubleClick: false,
+                showOnHover: false,
+                showOnScroll: false,
+                autoRehide: true,
+                rehideStrategyRawValue: 0,
+                rehideInterval: 15
+            ),
+            advancedSettings: AdvancedSettingsSnapshot(
+                enableAlwaysHiddenSection: true,
+                showAllSectionsOnUserDrag: true,
+                sectionDividerStyle: 0,
+                hideApplicationMenus: false,
+                enableSecondaryContextMenu: true,
+                enableSecondaryContextMenuQuit: false,
+                showOnHoverDelay: 0.2,
+                tooltipDelay: 1.0,
+                showMenuBarTooltips: true,
+                iconRefreshInterval: 3.0,
+                enableDiagnosticLogging: false,
+                useDoubleClickToShowAlwaysHiddenSection: false,
+                useOptionClickToShowAlwaysHiddenSection: false,
+                useLCSSortingOnNotchedDisplays: false,
+                enableMenuBarItemOverflow: false,
+                searchSectionOrder: ["visible", "hidden", "alwaysHidden"],
+                searchIncludeVisible: true,
+                searchIncludeHidden: true,
+                searchIncludeAlwaysHidden: true
+            ),
+            hotkeys: [:],
+            displayConfigurations: [:],
+            appearanceConfiguration: .defaultConfiguration,
+            menuBarLayout: MenuBarLayoutSnapshot(
+                savedSectionOrder: savedSectionOrder,
+                pinnedHiddenBundleIDs: [],
+                pinnedAlwaysHiddenBundleIDs: [],
+                customNames: [:]
+            )
+        )
+        return Profile(name: "Integration Test", content: content)
+    }
+
+    private func writeProfile(_ profile: Profile, into directory: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(profile)
+        try data.write(
+            to: directory.appendingPathComponent("\(profile.id.uuidString).json"),
+            options: .atomic
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Re-arms `MenuBarItemManager`'s in-memory active-profile layout cache when the user updates the currently-applied profile, so a subsequent late-arrival re-sort honours the updated layout instead of reverting the menu bar to the spec frozen at the last apply.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [x] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

`MenuBarItemManager.activeProfileLayout` (the cached spec the late-arrival re-sort consults) is written only by `armProfileState`, which runs only on a profile apply (`applyProfileLayout(source: .profile)`). Updating the currently-applied profile via Update Layout or Update All writes the new layout to disk but leaves the in-memory cache pointing at the pre-update spec, so the next late-arrival re-sort (triggered by an app relaunch) reverts the menu bar to the old layout until the user manually re-applies the profile.
Issue Number: Refs #666 (one of several contributing fixes; does not fully close the issue)

## What is the new behavior?

`ProfileManager` now re-arms the cache after an update that captured a fresh layout: `updateProfileLayout` and `updateProfileWithCurrentState` call the new `MenuBarItemManager.rearmActiveProfileLayout`, gated by the pure `shouldRearmActiveLayout` so it fires only when the updated profile is the active one and the scope is `.all` or `.layoutOnly`; configuration-only updates and updates to inactive profiles leave live state untouched. The re-arm is a pure cache refresh that moves no items, since the captured layout already matches the live arrangement. As supporting refactors, `captureCurrentLayout` and `updateProfileLayout` are narrowed from `AppState` to `MenuBarItemManager` (their only real dependency), and `ProfileManager.init` accepts an injectable `profilesDirectory` so the update path can be tested without standing up an `AppState`.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom profile storage location configuration, with fallback to the default Application Support directory.

* **Bug Fixes**
  * Improved profile layout caching and refresh mechanisms for more reliable profile state management during updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->