### PR TITLE
fix(menubar): guard notch overflow against unsettled display geometry

### DIFF
--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -298,6 +298,17 @@ final class AppState: ObservableObject {
                     self.diagLog.info("Display disconnected: refresh item cache + cleanup image cache")
                     Task { @MainActor [weak self] in
                         guard let self else { return }
+                        // A display change relocates items to the remaining
+                        // display and leaves the menu bar geometry (Control
+                        // Center position, item bounds) unsettled for a short
+                        // window. Open a settling period so saved-layout restores
+                        // defer until the bar restabilizes and then run once on
+                        // settled geometry. Without this, a restore could fire
+                        // against transient off-screen geometry: Control Center's
+                        // stale left edge produces a negative notch-overflow
+                        // budget that collapses the hidden section into visible
+                        // and is then persisted into the saved order.
+                        self.itemManager.startSettlingPeriod(reason: "displayDisconnect")
                         // Force item cache rebuild so displayID reflects current
                         // display geometry (items moved to remaining display).
                         await self.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
@@ -311,6 +322,10 @@ final class AppState: ObservableObject {
                     self.diagLog.info("Display connected: refresh item cache")
                     Task { @MainActor [weak self] in
                         guard let self else { return }
+                        // Defer the saved-layout restore until the menu bar
+                        // geometry settles after the new display attaches; see
+                        // the disconnect branch above for the rationale.
+                        self.itemManager.startSettlingPeriod(reason: "displayConnect")
                         // Items keep their windowIDs when moving to new display.
                         // Item cache rebuild picks up new items on the added display.
                         await self.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -351,6 +351,23 @@ enum LayoutSolver {
         uidWidths: [String: CGFloat],
         availableWidth: CGFloat
     ) -> NotchOverflowResult {
+        // Guard against invalid / not-yet-settled geometry. A non-positive or
+        // non-finite budget means the menu bar layout could not be measured:
+        // during a display disconnect/reconnect Control Center transiently
+        // reports a stale off-screen left edge, which drives rightBoundary and
+        // therefore availableWidth negative. On such a budget the eject logic
+        // below would treat every visible item as overflow and dump the whole
+        // section into hidden, corrupting the layout (and the persisted saved
+        // order). Never act on a budget we cannot trust: return no overflow and
+        // leave the layout untouched until the geometry settles.
+        guard availableWidth > 0, availableWidth.isFinite else {
+            return NotchOverflowResult(
+                overflowUIDs: [],
+                updatedDesiredFiltered: desiredFiltered,
+                updatedSectionMap: sectionMap
+            )
+        }
+
         // Visible-section UIDs in profile order (left-to-right).
         let visibleUIDs = Array(desiredFiltered.prefix(while: { $0 != controlUIDs.hidden }))
         let chevronWidth = controlUIDs.visible.flatMap { uidWidths[$0] } ?? 0

--- a/ThawTests/PlanNotchOverflowTests.swift
+++ b/ThawTests/PlanNotchOverflowTests.swift
@@ -310,4 +310,113 @@ final class PlanNotchOverflowTests: XCTestCase {
         XCTAssertEqual(result.overflowUIDs, [],
                        "no item should overflow when widths sum to exactly the budget — spacing must not be double-counted")
     }
+
+    // MARK: - Invalid / unsettled geometry guard (issue #666, display reconnect)
+
+    /// A negative availableWidth means the budget was computed from invalid,
+    /// not-yet-settled geometry: during a display reconnect Control Center
+    /// reported a stale off-screen left edge, so rightBoundary went negative
+    /// and availableWidth came out at -1202 in the field log. The planner must
+    /// not eject items on a budget it cannot trust. Without the guard the
+    /// "profile alone exceeds budget" branch ejects every visible item, which
+    /// is the exact corruption observed (availableWidth=-1202 -> 13 items
+    /// ejected from visible, collapsing the hidden section into visible).
+    func testNegativeAvailableWidthYieldsNoOverflow() {
+        let desired = makeSequence(
+            chevron: chevron,
+            visible: ["a", "b", "c", "d"],
+            hiddenCtrl: hiddenCtrl,
+            ahCtrl: ahCtrl
+        )
+        let widths: [String: CGFloat] = [chevron: 24, "a": 24, "b": 24, "c": 24, "d": 24]
+        let sectionMap = ["a": "visible", "b": "visible", "c": "visible", "d": "visible"]
+
+        let result = LayoutSolver.planNotchOverflow(
+            desiredFiltered: desired,
+            unmanagedUIDs: [],
+            controlUIDs: ControlUIDs(visible: chevron, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+            sectionMap: sectionMap,
+            uidWidths: widths,
+            availableWidth: -1202 // exact value from the field log (display reconnect)
+        )
+
+        XCTAssertEqual(result.overflowUIDs, [], "must not eject items on a negative (invalid) budget")
+        XCTAssertEqual(result.updatedDesiredFiltered, desired)
+        XCTAssertEqual(result.updatedSectionMap, sectionMap)
+    }
+
+    /// A zero budget is equally untrustworthy (Control Center left edge at or
+    /// inside the notch boundary) and must not trigger overflow.
+    func testZeroAvailableWidthYieldsNoOverflow() {
+        let desired = makeSequence(
+            chevron: chevron,
+            visible: ["a", "b"],
+            hiddenCtrl: hiddenCtrl,
+            ahCtrl: ahCtrl
+        )
+        let widths: [String: CGFloat] = [chevron: 24, "a": 24, "b": 24]
+        let sectionMap = ["a": "visible", "b": "visible"]
+
+        let result = LayoutSolver.planNotchOverflow(
+            desiredFiltered: desired,
+            unmanagedUIDs: [],
+            controlUIDs: ControlUIDs(visible: chevron, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+            sectionMap: sectionMap,
+            uidWidths: widths,
+            availableWidth: 0
+        )
+
+        XCTAssertEqual(result.overflowUIDs, [], "must not eject items on a zero budget")
+    }
+
+    /// A non-finite budget (degenerate screen frame / missing geometry) must
+    /// not eject either.
+    func testNonFiniteAvailableWidthYieldsNoOverflow() {
+        let desired = makeSequence(
+            chevron: chevron,
+            visible: ["a", "b"],
+            hiddenCtrl: hiddenCtrl,
+            ahCtrl: ahCtrl
+        )
+        let widths: [String: CGFloat] = [chevron: 24, "a": 24, "b": 24]
+        let sectionMap = ["a": "visible", "b": "visible"]
+
+        for badBudget in [CGFloat.infinity, -.infinity, .nan] {
+            let result = LayoutSolver.planNotchOverflow(
+                desiredFiltered: desired,
+                unmanagedUIDs: [],
+                controlUIDs: ControlUIDs(visible: chevron, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+                sectionMap: sectionMap,
+                uidWidths: widths,
+                availableWidth: badBudget
+            )
+            XCTAssertEqual(result.overflowUIDs, [], "must not eject items on a non-finite budget (\(badBudget))")
+        }
+    }
+
+    /// Guard rail: a small but POSITIVE budget still overflows legitimately, so
+    /// the invalid-budget guard does not suppress real overflow on a genuinely
+    /// full bar.
+    func testSmallPositiveBudgetStillOverflows() {
+        // chevron(24) + a + b + c + d (24 each) = 120; budget 60 fits chevron + 1.
+        let desired = makeSequence(
+            chevron: chevron,
+            visible: ["a", "b", "c", "d"],
+            hiddenCtrl: hiddenCtrl,
+            ahCtrl: ahCtrl
+        )
+        let widths: [String: CGFloat] = [chevron: 24, "a": 24, "b": 24, "c": 24, "d": 24]
+        let sectionMap = ["a": "visible", "b": "visible", "c": "visible", "d": "visible"]
+
+        let result = LayoutSolver.planNotchOverflow(
+            desiredFiltered: desired,
+            unmanagedUIDs: [],
+            controlUIDs: ControlUIDs(visible: chevron, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+            sectionMap: sectionMap,
+            uidWidths: widths,
+            availableWidth: 60
+        )
+
+        XCTAssertFalse(result.overflowUIDs.isEmpty, "a genuinely full bar (positive budget) must still overflow")
+    }
 }

--- a/ThawTests/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/ProfileLayoutLogReplayTests.swift
@@ -207,6 +207,67 @@ final class ProfileLayoutLogReplayTests: XCTestCase {
         XCTAssertEqual(result, ["com.example.extra:Item-0"])
         XCTAssertEqual(result, cycle.loggedUnmanagedUIDs)
     }
+
+    // MARK: Regression lock for the display-reconnect overflow corruption (#666)
+
+    /// Replays a real field cycle (thaw_2026-06-07_09-48-52.log, 11:44:42)
+    /// where a display disconnect/reconnect left the menu bar geometry
+    /// unsettled: Control Center reported a stale off-screen edge, so the
+    /// overflow budget came out negative (availableWidth=-1202) and the buggy
+    /// build ejected all 13 visible items into hidden, collapsing the hidden
+    /// section into visible. Driving the live planNotchOverflow with that exact
+    /// budget must yield no overflow once the invalid-budget guard is in place.
+    /// Red before the guard (every visible item ejected), green after.
+    func testDisplayReconnectNegativeBudgetYieldsNoOverflow() throws {
+        let log = """
+        2026-06-07 11:44:42.027 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 4 items: ["leits.MeetingBar:Item-0", "eu.exelban.Stats:CPU_bar_chart", "com.stonerl.Thaw:Thaw.ControlItem.Visible", "com.apple.TextInputMenuAgent:Item-0"]
+        2026-06-07 11:44:42.027 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 3 items: ["com.electron.dockerdesktop:Item-0", "com.apple.controlcenter:WiFi", "com.kaspersky.kav_agent:Item-0"]
+        2026-06-07 11:44:42.027 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 2 items: ["ru.keepcoder.Telegram:Item-0", "com.apple.controlcenter:Battery"]
+        2026-06-07 11:44:42.028 [DEBUG] [MenuBarItemManager] Notch overflow budget: screen.maxX=1728.0 notch=[771.0…956.0] rightBoundary=-222.0 availableWidth=-1202.0 userSpacing=0.0 visibleUIDs.count=14 nonProfileCount=0 nonProfileFootprint=0.0 chevronFootprint=0.0 nonProfileBreakdown=[]
+        2026-06-07 11:44:42.028 [INFO] [MenuBarItemManager] Profile layout: notch overflow; 13 item(s) moved from visible to hidden
+        """
+
+        let parsed = ProfileLayoutLogReplay.parse(log)
+        let cycle = try XCTUnwrap(parsed.cycles.first)
+
+        // Field characterization: the reconnect produced an invalid (negative)
+        // budget, and the buggy build ejected 13 items from visible.
+        XCTAssertEqual(cycle.notchAvailableWidth, -1202)
+        XCTAssertEqual(cycle.loggedOverflowCount, 13)
+
+        // Reconstruct a desiredFiltered flat order from the cycle and drive the
+        // live planner with the real (negative) budget. Widths are any positive
+        // value; the guard must short-circuit before widths matter.
+        let visibleCtrl = MenuBarItemTag.visibleControlItem.tagIdentifier
+        let hiddenCtrl = MenuBarItemTag.hiddenControlItem.tagIdentifier
+        let ahCtrl = MenuBarItemTag.alwaysHiddenControlItem.tagIdentifier
+
+        var desiredFiltered = cycle.currentVisible
+        desiredFiltered.append(hiddenCtrl)
+        desiredFiltered.append(contentsOf: cycle.currentHidden)
+        desiredFiltered.append(ahCtrl)
+        desiredFiltered.append(contentsOf: cycle.currentAlwaysHidden)
+
+        var uidWidths = [String: CGFloat]()
+        for uid in desiredFiltered {
+            uidWidths[uid] = 24
+        }
+
+        let result = LayoutSolver.planNotchOverflow(
+            desiredFiltered: desiredFiltered,
+            unmanagedUIDs: [],
+            controlUIDs: ControlUIDs(visible: visibleCtrl, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+            sectionMap: [:],
+            uidWidths: uidWidths,
+            availableWidth: try XCTUnwrap(cycle.notchAvailableWidth)
+        )
+
+        XCTAssertTrue(
+            result.overflowUIDs.isEmpty,
+            "Negative field budget (-1202) must not eject any item once guarded; the buggy build ejected \(cycle.loggedOverflowCount ?? -1)"
+        )
+        XCTAssertEqual(result.updatedDesiredFiltered, desiredFiltered)
+    }
 }
 
 /// Parses Thaw profile-layout log text into replayable cycles and drives the
@@ -228,6 +289,14 @@ enum ProfileLayoutLogReplay {
         /// UIDs the log actually routed through planUnmanagedPlacement this
         /// cycle (the field verdict the harness characterizes against).
         var loggedUnmanagedUIDs: [String] = []
+        /// The notch-overflow budget the cycle logged, when present. A
+        /// non-positive value means the menu bar geometry had not settled
+        /// (Control Center reporting a stale off-screen edge), which the
+        /// overflow planner must not act on.
+        var notchAvailableWidth: CGFloat?
+        /// How many items the cycle logged as overflowing visible -> hidden
+        /// (the field verdict for the overflow planner).
+        var loggedOverflowCount: Int?
     }
 
     /// The parsed result: the ordered cycles plus the set of menu bar items
@@ -311,6 +380,16 @@ enum ProfileLayoutLogReplay {
 
             if let match = line.firstMatch(of: /Profile layout: planUnmanagedPlacement (\S+) ->/) {
                 current?.loggedUnmanagedUIDs.append(String(match.output.1))
+                continue
+            }
+
+            if let match = line.firstMatch(of: /Notch overflow budget:.*availableWidth=(-?[0-9.]+)/) {
+                current?.notchAvailableWidth = Double(match.output.1).map { CGFloat($0) }
+                continue
+            }
+
+            if let match = line.firstMatch(of: /notch overflow; (\d+) item\(s\) moved from visible to hidden/) {
+                current?.loggedOverflowCount = Int(match.output.1)
                 continue
             }
         }


### PR DESCRIPTION
## What does this PR do?

Guards the menu bar notch-overflow planner against invalid, not-yet-settled display geometry, and adds a settling period on display connect/disconnect, so a display reconnect no longer collapses the hidden section into the visible section and reorders the control items.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

On a notched display with menu bar item overflow enabled, a display disconnect/reconnect can run a layout pass before the menu bar geometry settles. Control Center transiently reports a stale off-screen left edge, so the overflow budget (`rightBoundary = ccItem.bounds.minX`; `availableWidth = rightBoundary - (notch.maxX + notchGap)`) comes out negative (`availableWidth = -1202` was observed in a field log). `LayoutSolver.planNotchOverflow` then takes its "profile alone exceeds budget" branch and ejects every visible item into hidden, which collapses the hidden section into visible, reorders the Thaw control item, and is written back into the saved section order so the corruption persists until the profile is manually re-applied.
Issue Number: Refs #666

## What is the new behavior?

Two complementary fixes. First, `LayoutSolver.planNotchOverflow` returns no overflow when `availableWidth` is non-positive or non-finite, leaving the layout untouched until the geometry can be measured; a zero or negative budget is never a legitimate eject signal, so this alone prevents the corruption because the pass already finds no section mismatch. Second, `AppState` now opens a settling period via `startSettlingPeriod` on display connect and disconnect, so saved-layout restores defer until the menu bar restabilizes and then run once against settled geometry instead of transient off-screen bounds.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when displays connect or disconnect by deferring menu bar layout restoration until geometry stabilizes, preventing corrupt layouts caused by unreliable measurements during display transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->