### PR TITLE
fix(resolution): keep Control-Center-hosted generic slots unresolved for marker-pair

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -347,6 +347,7 @@ final class SourcePIDCache {
             return state.apps
         }
 
+        let ccBundleID = "com.apple.controlcenter"
         var appsChecked = 0
         var appsWithBar = 0
         var totalChildrenChecked = 0
@@ -380,10 +381,27 @@ final class SourcePIDCache {
 
                     let childCenter = childFrame.center
 
-                    // Match this child to ANY window in our list.
+                    // Match this child to ANY window in our list, but skip
+                    // Control-Center-hosted generic slots. Control Center is the
+                    // CG owner for every CC-hosted NSStatusItem. When the matched
+                    // app is Control Center and the window title is a generic
+                    // Item-N slot, the spatial match only confirms the window is
+                    // CC-hosted; it does not identify the owning app. Writing
+                    // Control Center's PID would tag the item as a transient CC
+                    // widget (isTransientControlCenterItem true, canBeHidden
+                    // false), hiding it from profile management and the
+                    // virtual-display provoke's orphan scan. Leaving it
+                    // unresolved lets the marker-pair pass below supply the real
+                    // owner PID; named CC items (BentoBox-0, Clock, WiFi,
+                    // NowPlaying) carry non-generic titles and resolve to Control
+                    // Center normally.
                     if let matchedWindow = allWindows.first(where: {
                         $0.bounds.center.distance(to: childCenter) <= 1
-                    }) {
+                    }), !MarkerPairResolver.isCCHostedGenericSlot(
+                        appBundleID: app.bundleIdentifier,
+                        windowTitle: matchedWindow.title,
+                        ccBundleID: ccBundleID
+                    ) {
                         totalMatchesFound += 1
                         unresolvedWindows.remove(matchedWindow.windowID)
                         let pid = app.processIdentifier
@@ -473,7 +491,6 @@ final class SourcePIDCache {
         // never be attributed to a third-party widget.
         if !unresolvedWindows.isEmpty {
             let thawBundleID = "com.stonerl.Thaw"
-            let ccBundleID = "com.apple.controlcenter"
             let markers = MarkerPairResolver.extractMarkers(
                 from: allWindows.map { win in
                     (

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -162,6 +162,36 @@ enum MarkerPairResolver {
             )
         }
     }
+
+    /// True when a CG window title has the generic Item-N shape macOS assigns to
+    /// Control-Center-hosted items that publish no name of their own (Item-0,
+    /// Item-38, ...). The single source of truth for that shape, shared by
+    /// MenuBarItemTag.isControlCenterGenericItem and isCCHostedGenericSlot so the
+    /// two can never drift apart.
+    static func isGenericControlCenterTitle(_ title: String?) -> Bool {
+        guard let title else { return false }
+        return title.wholeMatch(of: /Item-\d+/) != nil
+    }
+
+    /// Returns true when a strict 1pt spatial match only confirms Control
+    /// Center hosting and does not identify the owning app. Control Center is
+    /// the CG owner of every CC-hosted NSStatusItem on macOS 26; when the
+    /// matched app IS Control Center and the window carries a generic Item-N
+    /// title, writing Control Center's PID would tag the item as a transient
+    /// CC widget (isTransientControlCenterItem true, canBeHidden false), hiding
+    /// it from profile management and the virtual-display provoke's orphan
+    /// scan. The window must be left unresolved so marker-pair can supply the
+    /// real owner PID. Named CC items (BentoBox-0, Clock, WiFi, NowPlaying, ...)
+    /// carry non-generic titles and are unaffected; a widget that publishes its
+    /// own extras-bar child (The Clock, com.fabriceleyne.theclock) matches via
+    /// that app, not Control Center, so it is never flagged here.
+    static func isCCHostedGenericSlot(
+        appBundleID: String?,
+        windowTitle: String?,
+        ccBundleID: String
+    ) -> Bool {
+        appBundleID == ccBundleID && isGenericControlCenterTitle(windowTitle)
+    }
 }
 
 /// Decides whether a Control-Center-hosted menu bar window's title

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -53,7 +53,7 @@ struct MenuBarItemTag: Hashable, CustomStringConvertible {
     /// dynamically-named Control Center item (Live Activities, etc.)
     /// with the pattern `controlCenter:Item-\d+`.
     var isControlCenterGenericItem: Bool {
-        namespace == .controlCenter && title.wholeMatch(of: /Item-\d+/) != nil
+        namespace == .controlCenter && MarkerPairResolver.isGenericControlCenterTitle(title)
     }
 
     /// A Boolean value that indicates whether the item identified

--- a/ThawTests/ControlCenterHostedMatchLogReplayTests.swift
+++ b/ThawTests/ControlCenterHostedMatchLogReplayTests.swift
@@ -1,0 +1,241 @@
+//
+//  ControlCenterHostedMatchLogReplayTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+/// Log-replay harness for the SourcePIDCache strict 1pt spatial pass, focused
+/// on the macOS 26 Control-Center-hosted resolution case that this area keeps
+/// regressing on.
+///
+/// macOS 26 hosts third-party status items under Control Center at the CG
+/// layer. Two shapes look identical from the outside but must resolve in
+/// opposite directions:
+///
+///   - Little Snitch publishes NO extras-bar child of its own, so the only AX
+///     child on its icon is Control Center's. Binding it to Control Center
+///     misattributes it and starves marker-pair / the provoke. It must stay
+///     unresolved.
+///   - The Clock publishes its OWN extras-bar child on the same icon, so it
+///     must resolve to com.fabriceleyne.theclock.
+///
+/// A fix for either case has repeatedly broken the other. These tests parse the
+/// real "diag unresolved" lines for both and drive the real
+/// ControlCenterHostedMatch gate, so a future change that re-breaks one is
+/// caught here. The named-module and Live-Activity gate guards keep the rest of
+/// the Control Center family from collateral damage.
+final class ControlCenterHostedMatchLogReplayTests: XCTestCase {
+    private let cc = "com.apple.controlcenter"
+
+    // MARK: - Parser characterization
+
+    func testParserRecoversLittleSnitchScenario() throws {
+        let scenario = try XCTUnwrap(
+            ControlCenterHostedResolutionReplay.parse(ControlCenterHostedResolutionLog.littleSnitch)
+        )
+        XCTAssertEqual(scenario.windowID, 355)
+        XCTAssertEqual(scenario.title, "Item-0")
+        XCTAssertEqual(scenario.cgOwnerBundleID, cc)
+        XCTAssertEqual(scenario.candidates.count, 3)
+        XCTAssertEqual(
+            scenario.candidates.first,
+            .init(appBundleID: cc, distance: 0, enabled: nil),
+            "the only child within 1pt is Control Center's own, at distance 0 with AXEnabled absent"
+        )
+    }
+
+    func testParserRecoversTheClockScenario() throws {
+        let scenario = try XCTUnwrap(
+            ControlCenterHostedResolutionReplay.parse(ControlCenterHostedResolutionLog.theClock)
+        )
+        XCTAssertEqual(scenario.windowID, 6475)
+        XCTAssertEqual(scenario.title, "Item-0")
+        XCTAssertEqual(scenario.cgOwnerBundleID, cc)
+        XCTAssertEqual(
+            scenario.candidates.first,
+            .init(appBundleID: "com.fabriceleyne.theclock", distance: 0, enabled: nil)
+        )
+        XCTAssertFalse(
+            scenario.candidates.contains { $0.appBundleID == cc },
+            "Control Center must not be a candidate for The Clock — its child is published by its own app"
+        )
+    }
+
+    // MARK: - Regression locks: the mutually-protective pair
+
+    /// RED before the gate, GREEN after. Little Snitch's icon must NOT bind to
+    /// Control Center; it has to stay unresolved so it remains an orphan that
+    /// reaches marker-pair resolution and the virtual-display provoke.
+    func testLittleSnitchIconDoesNotBindToControlCenter() throws {
+        let scenario = try XCTUnwrap(
+            ControlCenterHostedResolutionReplay.parse(ControlCenterHostedResolutionLog.littleSnitch)
+        )
+        XCTAssertNil(
+            ControlCenterHostedResolutionReplay.resolve(scenario),
+            "windowID 355 must stay unresolved, not bind to com.apple.controlcenter"
+        )
+    }
+
+    /// GREEN before and after the gate. The Clock must keep resolving to its
+    /// own app: the gate refuses only Control Center's self-match, never a
+    /// widget's own extras-bar child. This is the regression lock that protects
+    /// The Clock from a future Little Snitch fix.
+    func testTheClockResolvesToItsOwnApp() throws {
+        let scenario = try XCTUnwrap(
+            ControlCenterHostedResolutionReplay.parse(ControlCenterHostedResolutionLog.theClock)
+        )
+        XCTAssertEqual(
+            ControlCenterHostedResolutionReplay.resolve(scenario),
+            "com.fabriceleyne.theclock"
+        )
+    }
+
+    // MARK: - Gate guards: the rest of the Control Center family
+
+    /// Named Control Center modules carry descriptive titles, so the strict
+    /// match identifies a real owner and is NOT a bare CC-hosted slot: they keep
+    /// resolving to Control Center. System titles (TimeMachine) and nil/empty
+    /// likewise never count as generic slots. Confirmed present as managed
+    /// com.apple.controlcenter:<title> items in field logs.
+    func testNamedControlCenterTitlesAreNotGenericSlots() {
+        for title in [
+            "WiFi", "Battery", "Bluetooth", "NowPlaying", "Clock", "BentoBox-0",
+            "AudioVideoModule", "com.apple.menuextra.TimeMachine",
+        ] {
+            XCTAssertFalse(
+                MarkerPairResolver.isCCHostedGenericSlot(appBundleID: cc, windowTitle: title, ccBundleID: cc),
+                "named Control Center module \(title) must keep resolving to Control Center"
+            )
+        }
+        XCTAssertFalse(MarkerPairResolver.isCCHostedGenericSlot(appBundleID: cc, windowTitle: nil, ccBundleID: cc))
+        XCTAssertFalse(MarkerPairResolver.isCCHostedGenericSlot(appBundleID: cc, windowTitle: "", ccBundleID: cc))
+    }
+
+    /// A generic Item-N icon matched by Control Center itself (Little Snitch, or
+    /// a transient Live Activity) is a bare CC-hosted slot: it must be left
+    /// unresolved so it stays an orphan for marker-pair / the provoke.
+    func testGenericControlCenterHostedSlotDetected() {
+        for title in ["Item-0", "Item-5", "Item-38"] {
+            XCTAssertTrue(
+                MarkerPairResolver.isCCHostedGenericSlot(appBundleID: cc, windowTitle: title, ccBundleID: cc),
+                "generic Control-Center-hosted icon \(title) must not bind to Control Center"
+            )
+        }
+    }
+
+    /// The check only governs Control Center as the matcher: a generic Item-N
+    /// title attributed to any other app (a widget's own extras child like The
+    /// Clock, or Thaw's own items) — or to no known app at all — is never a bare
+    /// CC slot.
+    func testNonControlCenterMatcherIsNeverASlot() {
+        for matcher in ["com.fabriceleyne.theclock", "com.stonerl.Thaw"] {
+            XCTAssertFalse(
+                MarkerPairResolver.isCCHostedGenericSlot(appBundleID: matcher, windowTitle: "Item-0", ccBundleID: cc),
+                "\(matcher) matched its own child — must resolve to it, not be treated as a CC slot"
+            )
+        }
+        XCTAssertFalse(
+            MarkerPairResolver.isCCHostedGenericSlot(appBundleID: nil, windowTitle: "Item-0", ccBundleID: cc),
+            "a nil matched bundle ID cannot be Control Center"
+        )
+    }
+
+    /// The shared generic-title predicate, the single source of truth reused by
+    /// both isCCHostedGenericSlot and MenuBarItemTag.isControlCenterGenericItem.
+    func testGenericControlCenterTitlePredicate() {
+        XCTAssertTrue(MarkerPairResolver.isGenericControlCenterTitle("Item-0"))
+        XCTAssertTrue(MarkerPairResolver.isGenericControlCenterTitle("Item-1"))
+        XCTAssertTrue(MarkerPairResolver.isGenericControlCenterTitle("Item-38"))
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle("WiFi"))
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle("BentoBox-0"))
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle("com.apple.menuextra.TimeMachine"))
+        // Regex boundary: "Item-" without a trailing index must not match.
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle("Item-"))
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle(nil))
+        XCTAssertFalse(MarkerPairResolver.isGenericControlCenterTitle(""))
+    }
+}
+
+/// Parses one SourcePIDCache "diag unresolved" line into a replayable window
+/// scenario and drives the real strict-pass match decision. Test-only; models
+/// just enough of the strict 1pt pass to characterize which app an icon would
+/// bind to.
+enum ControlCenterHostedResolutionReplay {
+    /// One nearest-candidate AX child from the diag line's `nearest=[...]` list.
+    struct CandidateChild: Equatable {
+        let appBundleID: String
+        let distance: CGFloat
+        /// nil = AXEnabled attribute absent (treated as enabled post-#667);
+        /// true/false = explicit value.
+        let enabled: Bool?
+    }
+
+    /// One unresolved menu bar window reconstructed from a diag line.
+    struct WindowScenario: Equatable {
+        let windowID: CGWindowID
+        let title: String?
+        let cgOwnerBundleID: String?
+        let candidates: [CandidateChild]
+    }
+
+    static func parse(_ text: String) -> WindowScenario? {
+        let line = text.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        guard let widMatch = line.firstMatch(of: /windowID=(\d+)/),
+              let windowID = CGWindowID(widMatch.output.1)
+        else {
+            return nil
+        }
+        let title = line.firstMatch(of: /title=(\S+)/).map { String($0.output.1) }
+        let cgOwner = line.firstMatch(of: /cgOwner=([A-Za-z0-9._-]+):pid=/).map { String($0.output.1) }
+
+        var candidates = [CandidateChild]()
+        if let nearest = line.firstMatch(of: /nearest=\[(.*)\]/) {
+            for match in String(nearest.output.1)
+                .matches(of: /([A-Za-z0-9._-]+)@([0-9.]+)\(enabled=(nil|true|false)\)/)
+            {
+                let enabled: Bool? = match.output.3 == "nil" ? nil : (match.output.3 == "true")
+                candidates.append(CandidateChild(
+                    appBundleID: String(match.output.1),
+                    distance: Double(match.output.2).map { CGFloat($0) } ?? .greatestFiniteMagnitude,
+                    enabled: enabled
+                ))
+            }
+        }
+
+        return WindowScenario(windowID: windowID, title: title, cgOwnerBundleID: cgOwner, candidates: candidates)
+    }
+
+    /// Replays the strict 1pt spatial pass for one window through the real
+    /// MarkerPairResolver.isCCHostedGenericSlot check, returning the bundle ID
+    /// the icon would resolve to, or nil if it stays unresolved.
+    ///
+    /// Faithful reduction: within the 1pt tolerance the field logs show a
+    /// single candidate (the next is always >= 40pt away), so "nearest
+    /// qualifying candidate" equals the production pass's "first app whose child
+    /// is within 1pt". The enabled != false guard mirrors the post-#667 matcher,
+    /// where an absent AXEnabled attribute counts as enabled.
+    static func resolve(_ scenario: WindowScenario, ccBundleID: String = "com.apple.controlcenter") -> String? {
+        for candidate in scenario.candidates.sorted(by: { $0.distance < $1.distance }) {
+            guard candidate.distance <= 1 else { break }
+            guard candidate.enabled != false else { continue }
+            // A bare CC-hosted generic slot identifies no owner; leave it
+            // unresolved so marker-pair can supply the real owner PID.
+            if MarkerPairResolver.isCCHostedGenericSlot(
+                appBundleID: candidate.appBundleID,
+                windowTitle: scenario.title,
+                ccBundleID: ccBundleID
+            ) {
+                continue
+            }
+            return candidate.appBundleID
+        }
+        return nil
+    }
+}

--- a/ThawTests/Fixtures/ControlCenterHostedResolutionLog.swift
+++ b/ThawTests/Fixtures/ControlCenterHostedResolutionLog.swift
@@ -1,0 +1,45 @@
+//
+//  ControlCenterHostedResolutionLog.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+/// Verbatim SourcePIDCache "diag unresolved" lines captured from the field,
+/// used by the strict-spatial-pass log-replay harness. Each line records, for
+/// one menu bar window that was unresolved at the moment of capture, the CG
+/// owner and the nearest AXExtrasMenuBar children (app, distance, enabled), so
+/// the harness can replay which app the strict 1pt pass would bind the icon
+/// to.
+///
+/// The two fixtures are the mutually-protective pair this area keeps
+/// regressing on: Little Snitch (must NOT bind to Control Center, so it stays
+/// an orphan for marker-pair) and The Clock (must bind to its own app). A fix
+/// for either one has repeatedly broken the other, so both are pinned here.
+enum ControlCenterHostedResolutionLog {
+    /// Little Snitch agent icon, from thaw_2026-06-08_20-54-21.log (beta.15,
+    /// commit 9a003611, macOS 26.5.1), line 3051. The icon (windowID 355,
+    /// generic title Item-0, 116pt wide) is hosted by Control Center at the CG
+    /// layer. The ONLY AX child within the strict 1pt tolerance is Control
+    /// Center's OWN (distance 0.0, AXEnabled absent); the next candidate is
+    /// 74pt away. Little Snitch publishes no extras-bar child of its own, so
+    /// accepting Control Center's self-match misattributes it to
+    /// com.apple.controlcenter and starves the marker-pair / provoke path.
+    static let littleSnitch = """
+    2026-06-08 20:57:54.289 [DEBUG] [SourcePIDCache] SourcePIDCache diag unresolved: windowID=355 title=Item-0 bounds=(889.0, 0.0, 116.0, 33.0) center=(947.0, 16.5) | cgOwner=com.apple.controlcenter:pid=648 ownerName=Control Center | closestAXFrame=(889.0, 0.0, 116.0, 33.0) in app=com.apple.controlcenter distance=0.0 closestAXEnabled=nil | nearest=[com.apple.controlcenter@0.0(enabled=nil), com.shortery-app.Shortery@74.0(enabled=true), org.languagetool.desktop@77.0(enabled=true)]
+    """
+
+    /// The Clock (com.fabriceleyne.theclock), from
+    /// thaw_2026-06-03_09-44-18.copy.log (beta.14 diagnostic build 37dfb6a),
+    /// line for windowID 6475. The icon also carries the generic title Item-0
+    /// and is hosted by Control Center at the CG layer, but the matching
+    /// distance-0 child is published by The Clock's OWN app (AXEnabled absent),
+    /// so it must resolve to com.fabriceleyne.theclock. Crucially, Control
+    /// Center publishes no competing child here: the nearest candidate after
+    /// The Clock is 40pt away, and com.apple.controlcenter never appears in the
+    /// candidate list.
+    static let theClock = """
+    2026-06-03 09:44:46.106 [DEBUG] [SourcePIDCache] SourcePIDCache diag unresolved: windowID=6475 title=Item-0 bounds=(-3725.0, 0.0, 46.0, 34.0) center=(-3702.0, 17.0) | cgOwner=com.apple.controlcenter:pid=701 ownerName=Control Center | closestAXFrame=(-3717.0, 6.0, 30.0, 22.0) in app=com.fabriceleyne.theclock distance=0.0 closestAXEnabled=nil | nearest=[com.fabriceleyne.theclock@0.0(enabled=nil), com.muesli.app@40.0(enabled=true), com.antiless.cleanclip.mac@74.0(enabled=true)]
+    """
+}


### PR DESCRIPTION
## What does this PR do?

Stops macOS 26 Control-Center-hosted third-party menu bar items (Little Snitch's agent observed in the wild) from being mis-resolved to Control Center in `SourcePIDCache`'s strict AX spatial pass, so they stay unresolved and reach marker-pair resolution instead. This is the `SourcePIDCache` half of the fix and closes #689; it deliberately omits that PR's `VirtualDisplayProvoker` one-strike-to-retry change (a separate trade-off against the #661 display-arrangement churn).

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

On macOS 26 Control Center is the CG owner of every hosted `NSStatusItem`, and Control Center's own `AXExtrasMenuBar` publishes a child sitting exactly on each hosted icon. Since `#667` relaxed the strict spatial pass to treat an absent `AXEnabled` attribute as enabled, that self-match now succeeds for third-party widgets, so `SourcePIDCache` writes `com.apple.controlcenter`'s PID into the cache. That tags the icon as a transient Control Center widget (`isTransientControlCenterItem` true, `canBeHidden` false), which hides it from profile management and drops it from the orphan set `VirtualDisplayProvoker` scans, so its bundle-ID marker window is never provoked and marker-pair never runs.
Issue Number: N/A

## What is the new behavior?

`MarkerPairResolver.isCCHostedGenericSlot(appBundleID:windowTitle:ccBundleID:)` returns true only when the matched app is Control Center and the window carries a generic `Item-N` title, and the strict pass in `SourcePIDCache.pidBody` now skips writing the PID for those windows, leaving them in `unresolvedWindows` so marker-pair supplies the real owner. Named Control Center modules (`BentoBox-0`, `Clock`, `WiFi`, `NowPlaying`, ...) carry descriptive titles and still resolve to Control Center, and a widget that publishes its own extras-bar child (The Clock, `com.fabriceleyne.theclock`) matches via that app and is unaffected. The generic `Item-N` title test is extracted into `MarkerPairResolver.isGenericControlCenterTitle(_:)` as a single source of truth, and `MenuBarItemTag.isControlCenterGenericItem` is routed through it so the two definitions cannot drift apart.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

A log-replay harness (`ControlCenterHostedMatchLogReplayTests`, `ControlCenterHostedResolutionLog`) parses the real `diag unresolved` lines for Little Snitch (windowID 355) and The Clock (windowID 6475) and replays the strict-pass decision, locking in that Little Snitch stays unresolved while The Clock resolves to `com.fabriceleyne.theclock`. These two cases are mutually protective: a future fix for either must keep the other green. Runtime verification on macOS 26 hardware with Little Snitch installed is still recommended, since the local checks are build + test only.

Closes #689


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of app identification for menu bar icons hosted in Control Center, including better handling of generically-named Control Center slots so icons are attributed to their real owning apps.

* **Tests**
  * Added regression tests and log-replay fixtures to validate Control Center–hosted menu bar item resolution and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->