### PR TITLE
feat(displays): warn before spacing relaunches, save choice per profile

### DIFF
--- a/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
+++ b/Thaw/MenuBar/Spacing/MenuBarItemSpacingManager.swift
@@ -228,6 +228,18 @@ final class MenuBarItemSpacingManager {
         return value ?? key.defaultValue
     }
 
+    /// Returns true when applying the given offset would rewrite the on-disk
+    /// spacing or padding, and therefore fire a relaunch wave. Mirrors the
+    /// no-op guard in applyOffsetLocked so callers can decide whether to
+    /// prompt the user before a relaunch without performing the apply.
+    func willRelaunch(forOffset offset: Int) -> Bool {
+        let targetSpacing = Key.spacing.defaultValue + offset
+        let targetPadding = Key.padding.defaultValue + offset
+        let onDiskSpacing = currentlyAppliedValue(forKey: .spacing)
+        let onDiskPadding = currentlyAppliedValue(forKey: .padding)
+        return onDiskSpacing != targetSpacing || onDiskPadding != targetPadding
+    }
+
     /// Applies the current ``offset``.
     ///
     /// Returns true if a relaunch wave was actually fired, or false if

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -1,6 +1,30 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Active profile" : {
+      "comment" : "Picker option: save spacing changes to the active profile only when relaunch confirmations are disabled."
+    },
+    "All profiles" : {
+      "comment" : "Picker option: save spacing changes to every profile when relaunch confirmations are disabled."
+    },
+    "Apply menu bar spacing change?" : {
+      "comment" : "Title of the just-in-time confirmation shown before a display transition relaunches menu bar apps to apply new spacing."
+    },
+    "Before a display change or spacing edit relaunches your menu bar apps, Thaw asks you to confirm. Turn this off to apply spacing changes and relaunch apps without confirmation." : {
+      "comment" : "Annotation for the Confirm before relaunching apps toggle in the Displays pane."
+    },
+    "Confirm before relaunching apps" : {
+      "comment" : "Toggle in the Displays pane controlling whether spacing changes ask for confirmation before relaunching menu bar apps."
+    },
+    "Don't ask again" : {
+      "comment" : "Suppression checkbox on the spacing relaunch confirmation; disables future confirmations."
+    },
+    "When a profile is active, choose whether spacing changes save to just the active profile or to every profile." : {
+      "comment" : "Annotation for the profile-target picker shown when relaunch confirmations are disabled."
+    },
+    "Without confirmation, save spacing to" : {
+      "comment" : "Label for the picker choosing which profiles receive a spacing change when relaunch confirmations are disabled."
+    },
     "(no script selected)" : {
       "comment" : "A placeholder displayed in the \"Path\" column of a hook row when no script is selected.",
       "localizations" : {
@@ -5763,7 +5787,7 @@
         }
       }
     },
-    "Applying this spacing change will briefly relaunch all apps with menu bar items." : {
+    "Applying this spacing change will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
       "comment" : "Alert message variant shown when applying a spacing change for the active menu bar display and no profile is active.",
       "localizations" : {
         "cs" : {
@@ -5882,7 +5906,7 @@
         }
       }
     },
-    "Applying this spacing change will briefly relaunch all apps with menu bar items. Save the new spacing to the active profile \"%@\", or save it to every profile." : {
+    "Applying this spacing change will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost. Save the new spacing to the active profile \"%@\", or save it to every profile." : {
       "comment" : "Alert message variant shown when applying a spacing change for the active menu bar display while a profile is active. %@ is the active profile name.",
       "localizations" : {
         "cs" : {
@@ -11732,13 +11756,13 @@
         }
       }
     },
-    "Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches." : {
-      "comment" : "A warning that mismatched per-display spacing causes a menu bar app relaunch wave when a display is connected.",
+    "When a display transition requires Thaw to apply a different menu bar spacing, Thaw relaunches apps with menu bar items. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
+      "comment" : "A warning that a display transition requiring a different menu bar spacing relaunches menu bar apps, which can lose unsaved state.",
       "localizations" : {
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches."
+            "value" : "When a display transition requires Thaw to apply a different menu bar spacing, Thaw relaunches apps with menu bar items. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
           }
         }
       }
@@ -41425,7 +41449,7 @@
         }
       }
     },
-    "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items." : {
+    "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
       "comment" : "A confirmation message that appears when the user is prompted to apply a global template. The first argument is the number of displays that will be affected. The second argument is the name of the active profile.",
       "localizations" : {
         "cs" : {
@@ -41482,13 +41506,13 @@
               "one" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
+                  "value" : "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
                 }
               },
               "other" : {
                 "stringUnit" : {
                   "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
+                  "value" : "This will overwrite the settings of %lld displays with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
                 }
               }
             }

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -41450,7 +41450,7 @@
       }
     },
     "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
-      "comment" : "A confirmation message that appears when the user is prompted to apply a global template. The first argument is the number of displays that will be affected. The second argument is the name of the active profile.",
+      "comment" : "A confirmation message that appears when the user is prompted to apply a global template. The argument is the number of displays that will be affected.",
       "localizations" : {
         "cs" : {
           "variations" : {

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -34,6 +34,17 @@ final class DisplaySettingsManager: ObservableObject {
     /// re-connect the display first.
     @Published var knownDisplays: [String: KnownDisplay] = [:]
 
+    /// Whether Thaw asks for confirmation before a spacing change relaunches
+    /// menu bar apps. When true, the automatic display-transition path shows
+    /// a just-in-time prompt and the Displays pane shows its Apply/global
+    /// confirmation alerts. When false, both apply without asking.
+    @Published var confirmSpacingRelaunch = Defaults.DefaultValue.confirmSpacingRelaunch
+
+    /// When confirmSpacingRelaunch is off and a profile is active, selects
+    /// whether an applied spacing change is saved to the active profile only
+    /// or to every profile.
+    @Published var unconfirmedSpacingProfileScope = Defaults.DefaultValue.unconfirmedSpacingProfileScope
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -168,6 +179,12 @@ final class DisplaySettingsManager: ObservableObject {
             } catch {
                 diagLog.error("Failed to decode known display cache: \(error)")
             }
+        }
+        Defaults.ifPresent(key: .confirmSpacingRelaunch, assign: &confirmSpacingRelaunch)
+        if let raw = Defaults.string(forKey: .unconfirmedSpacingProfileScope),
+           let scope = SpacingProfileSaveScope(rawValue: raw)
+        {
+            unconfirmedSpacingProfileScope = scope
         }
     }
 
@@ -338,6 +355,13 @@ final class DisplaySettingsManager: ObservableObject {
             }
             .store(in: &c)
 
+        $confirmSpacingRelaunch.persistToDefaults(key: .confirmSpacingRelaunch, in: &c)
+        $unconfirmedSpacingProfileScope.persistToDefaults(
+            key: .unconfirmedSpacingProfileScope,
+            transform: \.rawValue,
+            in: &c
+        )
+
         cancellables = c
     }
 
@@ -366,8 +390,23 @@ final class DisplaySettingsManager: ObservableObject {
     /// moving them.
     private func applyActiveDisplaySpacing(reason: String) {
         guard let appState else { return }
-        lastAppliedActiveDisplayUUID = Bridging.getActiveMenuBarDisplayUUID()
         let desired = Int(configurationForActiveDisplay().itemSpacingOffset.rounded())
+        // A display transition can fire the relaunch wave with no warning.
+        // When confirmations are enabled and this apply would actually
+        // relaunch apps, ask the user first. Declining keeps the current
+        // on-disk spacing and leaves lastAppliedActiveDisplayUUID untouched
+        // so the next genuine transition re-prompts. The in-pane Apply and
+        // global broadcast carry their own confirmations, so only the
+        // automatic path is gated here.
+        if reason == "screenParametersChanged",
+           confirmSpacingRelaunch,
+           appState.spacingManager.willRelaunch(forOffset: desired),
+           !presentSpacingRelaunchConfirmation()
+        {
+            diagLog.info("User declined the spacing relaunch confirmation for a display transition; skipping apply")
+            return
+        }
+        lastAppliedActiveDisplayUUID = Bridging.getActiveMenuBarDisplayUUID()
         appState.spacingManager.offset = desired
         Task { [weak self] in
             guard let self else { return }
@@ -401,6 +440,27 @@ final class DisplaySettingsManager: ObservableObject {
                 diagLog.error("applyActiveDisplaySpacing(\(reason)) failed: \(error)")
             }
         }
+    }
+
+    /// Presents an app-modal confirmation before a display transition fires
+    /// the relaunch wave. Returns true when the user approves the relaunch,
+    /// false when they cancel. Runs modally so it surfaces even with the
+    /// Settings window closed; ticking the suppression checkbox turns
+    /// confirmSpacingRelaunch off so future transitions apply silently.
+    private func presentSpacingRelaunchConfirmation() -> Bool {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Apply menu bar spacing change?")
+        alert.informativeText = String(localized: "When a display transition requires Thaw to apply a different menu bar spacing, Thaw relaunches apps with menu bar items. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
+        alert.addButton(withTitle: String(localized: "Apply"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = String(localized: "Don't ask again")
+        let response = alert.runModal()
+        if alert.suppressionButton?.state == .on {
+            confirmSpacingRelaunch = false
+        }
+        return response == .alertFirstButtonReturn
     }
 
     /// Handles per-display settings changed externally via Settings URI scheme.
@@ -835,4 +895,11 @@ final class DisplaySettingsManager: ObservableObject {
 struct KnownDisplay: Codable, Equatable {
     let name: String
     let hasNotch: Bool
+}
+
+/// Destination for an applied spacing change when the relaunch confirmation
+/// is disabled and a profile is active.
+enum SpacingProfileSaveScope: String, CaseIterable, Codable {
+    case activeProfile
+    case allProfiles
 }

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -445,8 +445,9 @@ final class DisplaySettingsManager: ObservableObject {
     /// Presents an app-modal confirmation before a display transition fires
     /// the relaunch wave. Returns true when the user approves the relaunch,
     /// false when they cancel. Runs modally so it surfaces even with the
-    /// Settings window closed; ticking the suppression checkbox turns
-    /// confirmSpacingRelaunch off so future transitions apply silently.
+    /// Settings window closed; ticking the suppression checkbox while pressing
+    /// Apply turns confirmSpacingRelaunch off so future transitions apply
+    /// silently. Cancelling never changes that setting.
     private func presentSpacingRelaunchConfirmation() -> Bool {
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
@@ -456,11 +457,11 @@ final class DisplaySettingsManager: ObservableObject {
         alert.addButton(withTitle: String(localized: "Cancel"))
         alert.showsSuppressionButton = true
         alert.suppressionButton?.title = String(localized: "Don't ask again")
-        let response = alert.runModal()
-        if alert.suppressionButton?.state == .on {
+        let apply = alert.runModal() == .alertFirstButtonReturn
+        if apply, alert.suppressionButton?.state == .on {
             confirmSpacingRelaunch = false
         }
-        return response == .alertFirstButtonReturn
+        return apply
     }
 
     /// Handles per-display settings changed externally via Settings URI scheme.

--- a/Thaw/Settings/Models/Profile.swift
+++ b/Thaw/Settings/Models/Profile.swift
@@ -324,6 +324,8 @@ struct ProfileContent {
     var hotkeys: [String: Data]
     var displayConfigurations: [String: DisplayIceBarConfiguration]
     var globalDisplayConfiguration: DisplayIceBarConfiguration
+    var confirmSpacingRelaunch: Bool
+    var unconfirmedSpacingProfileScope: SpacingProfileSaveScope
     var appearanceConfiguration: MenuBarAppearanceConfigurationV2
     var menuBarLayout: MenuBarLayoutSnapshot
     var automation: ProfileAutomation?
@@ -334,6 +336,8 @@ struct ProfileContent {
         hotkeys: [String: Data],
         displayConfigurations: [String: DisplayIceBarConfiguration],
         globalDisplayConfiguration: DisplayIceBarConfiguration = Defaults.DefaultValue.globalDisplayConfiguration,
+        confirmSpacingRelaunch: Bool = Defaults.DefaultValue.confirmSpacingRelaunch,
+        unconfirmedSpacingProfileScope: SpacingProfileSaveScope = Defaults.DefaultValue.unconfirmedSpacingProfileScope,
         appearanceConfiguration: MenuBarAppearanceConfigurationV2,
         menuBarLayout: MenuBarLayoutSnapshot,
         automation: ProfileAutomation? = nil
@@ -343,6 +347,8 @@ struct ProfileContent {
         self.hotkeys = hotkeys
         self.displayConfigurations = displayConfigurations
         self.globalDisplayConfiguration = globalDisplayConfiguration
+        self.confirmSpacingRelaunch = confirmSpacingRelaunch
+        self.unconfirmedSpacingProfileScope = unconfirmedSpacingProfileScope
         self.appearanceConfiguration = appearanceConfiguration
         self.menuBarLayout = menuBarLayout
         self.automation = automation
@@ -362,6 +368,8 @@ struct Profile: Codable, Identifiable {
     var hotkeys: [String: Data]
     var displayConfigurations: [String: DisplayIceBarConfiguration]
     var globalDisplayConfiguration: DisplayIceBarConfiguration
+    var confirmSpacingRelaunch: Bool
+    var unconfirmedSpacingProfileScope: SpacingProfileSaveScope
     var appearanceConfiguration: MenuBarAppearanceConfigurationV2
     var menuBarLayout: MenuBarLayoutSnapshot
     var automation: ProfileAutomation?
@@ -384,6 +392,8 @@ struct Profile: Codable, Identifiable {
             hotkeys: hotkeys,
             displayConfigurations: displayConfigurations,
             globalDisplayConfiguration: globalDisplayConfiguration,
+            confirmSpacingRelaunch: confirmSpacingRelaunch,
+            unconfirmedSpacingProfileScope: unconfirmedSpacingProfileScope,
             appearanceConfiguration: appearanceConfiguration,
             menuBarLayout: menuBarLayout,
             automation: automation
@@ -402,6 +412,8 @@ struct Profile: Codable, Identifiable {
         case hotkeys
         case displayConfigurations
         case globalDisplayConfiguration
+        case confirmSpacingRelaunch
+        case unconfirmedSpacingProfileScope
         case appearanceConfiguration
         case menuBarLayout
         case automation
@@ -423,6 +435,8 @@ struct Profile: Codable, Identifiable {
         self.hotkeys = content.hotkeys
         self.displayConfigurations = content.displayConfigurations
         self.globalDisplayConfiguration = content.globalDisplayConfiguration
+        self.confirmSpacingRelaunch = content.confirmSpacingRelaunch
+        self.unconfirmedSpacingProfileScope = content.unconfirmedSpacingProfileScope
         self.appearanceConfiguration = content.appearanceConfiguration
         self.menuBarLayout = content.menuBarLayout
         self.automation = content.automation
@@ -496,6 +510,16 @@ struct Profile: Codable, Identifiable {
             DisplayIceBarConfiguration.self,
             forKey: .globalDisplayConfiguration
         ) ?? Defaults.DefaultValue.globalDisplayConfiguration
+
+        confirmSpacingRelaunch = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .confirmSpacingRelaunch
+        ) ?? Defaults.DefaultValue.confirmSpacingRelaunch
+
+        unconfirmedSpacingProfileScope = try container.decodeIfPresent(
+            SpacingProfileSaveScope.self,
+            forKey: .unconfirmedSpacingProfileScope
+        ) ?? Defaults.DefaultValue.unconfirmedSpacingProfileScope
 
         appearanceConfiguration = try container.decodeIfPresent(
             MenuBarAppearanceConfigurationV2.self,

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -215,6 +215,8 @@ final class ProfileManager: ObservableObject {
                 hotkeys: Defaults.dictionary(forKey: .hotkeys) as? [String: Data] ?? [:],
                 displayConfigurations: appState.settings.displaySettings.configurations,
                 globalDisplayConfiguration: appState.settings.displaySettings.globalConfiguration,
+                confirmSpacingRelaunch: appState.settings.displaySettings.confirmSpacingRelaunch,
+                unconfirmedSpacingProfileScope: appState.settings.displaySettings.unconfirmedSpacingProfileScope,
                 appearanceConfiguration: appState.appearanceManager.configuration,
                 menuBarLayout: captureCurrentLayout(from: appState.itemManager)
             )
@@ -450,6 +452,10 @@ final class ProfileManager: ObservableObject {
         // Apply global display configuration template
         appState.settings.displaySettings.globalConfiguration = profile.globalDisplayConfiguration
 
+        // Apply the spacing-relaunch confirmation preferences
+        appState.settings.displaySettings.confirmSpacingRelaunch = profile.confirmSpacingRelaunch
+        appState.settings.displaySettings.unconfirmedSpacingProfileScope = profile.unconfirmedSpacingProfileScope
+
         // Apply appearance configuration
         appState.appearanceManager.configuration = profile.appearanceConfiguration
 
@@ -654,6 +660,8 @@ final class ProfileManager: ObservableObject {
         profile.hotkeys = Defaults.dictionary(forKey: .hotkeys) as? [String: Data] ?? [:]
         profile.displayConfigurations = appState.settings.displaySettings.configurations
         profile.globalDisplayConfiguration = appState.settings.displaySettings.globalConfiguration
+        profile.confirmSpacingRelaunch = appState.settings.displaySettings.confirmSpacingRelaunch
+        profile.unconfirmedSpacingProfileScope = appState.settings.displaySettings.unconfirmedSpacingProfileScope
         profile.appearanceConfiguration = appState.appearanceManager.configuration
     }
 

--- a/Thaw/Settings/Models/SettingsResetter.swift
+++ b/Thaw/Settings/Models/SettingsResetter.swift
@@ -78,5 +78,7 @@ extension AppSettings {
     func resetDisplay() {
         displaySettings.configurations = Defaults.DefaultValue.displayIceBarConfigurations
         displaySettings.globalConfiguration = Defaults.DefaultValue.globalDisplayConfiguration
+        displaySettings.confirmSpacingRelaunch = Defaults.DefaultValue.confirmSpacingRelaunch
+        displaySettings.unconfirmedSpacingProfileScope = Defaults.DefaultValue.unconfirmedSpacingProfileScope
     }
 }

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -56,8 +56,11 @@ struct DisplaySettingsPane: View {
             IceSection {
                 globalSection()
             }
+            IceSection {
+                confirmSpacingRelaunchControls
+            }
             CalloutBox(systemImage: "exclamationmark.triangle.fill", font: .callout, foregroundStyle: Color.warning) {
-                Text("Connecting a display whose spacing differs from the current spacing relaunches every menu bar app. Keep spacing consistent across displays to avoid relaunches.")
+                Text("When a display transition requires Thaw to apply a different menu bar spacing, Thaw relaunches apps with menu bar items. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
             }
             ForEach(displaySettings.allDisplays()) { display in
                 IceSection {
@@ -89,6 +92,23 @@ struct DisplaySettingsPane: View {
             Button("OK") { errorMessage = nil }
         } message: {
             if let errorMessage { Text(errorMessage) }
+        }
+    }
+
+    @ViewBuilder
+    private var confirmSpacingRelaunchControls: some View {
+        Toggle("Confirm before relaunching apps", isOn: $displaySettings.confirmSpacingRelaunch)
+            .annotation("Before a display change or spacing edit relaunches your menu bar apps, Thaw asks you to confirm. Turn this off to apply spacing changes and relaunch apps without confirmation.")
+
+        if !displaySettings.confirmSpacingRelaunch {
+            IcePicker(
+                "Without confirmation, save spacing to",
+                selection: $displaySettings.unconfirmedSpacingProfileScope
+            ) {
+                Text("Active profile").tag(SpacingProfileSaveScope.activeProfile)
+                Text("All profiles").tag(SpacingProfileSaveScope.allProfiles)
+            }
+            .annotation("When a profile is active, choose whether spacing changes save to just the active profile or to every profile.")
         }
     }
 
@@ -315,6 +335,17 @@ struct DisplaySettingsPane: View {
             return
         }
 
+        // Confirmations disabled: apply directly, saving to the profile
+        // target the user picked instead of staging the alert.
+        if !displaySettings.confirmSpacingRelaunch {
+            commitSpacingWithoutConfirmation(
+                displayID: display.id,
+                offset: offset,
+                activeProfileID: activeID
+            )
+            return
+        }
+
         let activeName = activeID.flatMap { id in
             appState.profileManager.profiles.first(where: { $0.id == id })?.name
         }
@@ -337,6 +368,39 @@ struct DisplaySettingsPane: View {
         draftSpacing[displayID] = CGFloat(offset)
         displaySettings.updateConfiguration(forDisplayUUID: displayID) { config in
             config.withItemSpacingOffset(offset)
+        }
+    }
+
+    /// Commits the spacing and, when a profile is active, persists it to the
+    /// profile target chosen by unconfirmedSpacingProfileScope. Used when
+    /// confirmations are disabled; mirrors the spacingConfirmationButtons
+    /// actions including the rollback on a failed profile save.
+    private func commitSpacingWithoutConfirmation(
+        displayID: String,
+        offset: Double,
+        activeProfileID: UUID?
+    ) {
+        let previousOffset = displaySettings.configuration(forUUID: displayID).itemSpacingOffset
+        commitSpacing(displayID: displayID, offset: offset)
+        guard let id = activeProfileID else { return }
+        do {
+            switch displaySettings.unconfirmedSpacingProfileScope {
+            case .activeProfile:
+                try appState.profileManager.updateProfile(
+                    id: id,
+                    scope: .configurationOnly,
+                    appState: appState
+                )
+            case .allProfiles:
+                try appState.profileManager.updateAllProfilesItemSpacingOffset(
+                    displayUUID: displayID,
+                    offset: offset
+                )
+            }
+        } catch {
+            commitSpacing(displayID: displayID, offset: previousOffset)
+            errorMessage = error.localizedDescription
+            showingError = true
         }
     }
 
@@ -408,7 +472,7 @@ struct DisplaySettingsPane: View {
         switch (pending.isActiveDisplay, pending.activeProfileID != nil) {
         case (true, true):
             return String(
-                format: String(localized: "Applying this spacing change will briefly relaunch all apps with menu bar items. Save the new spacing to the active profile \"%@\", or save it to every profile."),
+                format: String(localized: "Applying this spacing change will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost. Save the new spacing to the active profile \"%@\", or save it to every profile."),
                 profileName
             )
         case (false, true):
@@ -417,7 +481,7 @@ struct DisplaySettingsPane: View {
                 profileName
             )
         case (true, false):
-            return String(localized: "Applying this spacing change will briefly relaunch all apps with menu bar items.")
+            return String(localized: "Applying this spacing change will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
         case (false, false):
             return ""
         }
@@ -616,6 +680,14 @@ struct DisplaySettingsPane: View {
     private func requestGlobalApply() {
         let displayCount = displaySettings.allDisplays().count
         let activeID = appState.profileManager.activeProfileID
+
+        // Confirmations disabled: broadcast directly, saving to the chosen
+        // profile target instead of staging the alert.
+        if !displaySettings.confirmSpacingRelaunch {
+            commitGlobalApplyWithoutConfirmation(activeProfileID: activeID)
+            return
+        }
+
         let activeName = activeID.flatMap { id in
             appState.profileManager.profiles.first(where: { $0.id == id })?.name
         }
@@ -632,6 +704,35 @@ struct DisplaySettingsPane: View {
     /// for the active display on the next main-queue dispatch.
     private func commitGlobalApply() {
         displaySettings.applyGlobalToAllKnownDisplays()
+    }
+
+    /// Broadcasts the global template and, when a profile is active,
+    /// persists it to the profile target chosen by
+    /// unconfirmedSpacingProfileScope. Used when confirmations are disabled;
+    /// mirrors the globalConfirmationButtons actions including rollback.
+    private func commitGlobalApplyWithoutConfirmation(activeProfileID: UUID?) {
+        let previousConfigurations = displaySettings.configurations
+        commitGlobalApply()
+        guard let id = activeProfileID else { return }
+        do {
+            switch displaySettings.unconfirmedSpacingProfileScope {
+            case .activeProfile:
+                try appState.profileManager.updateProfile(
+                    id: id,
+                    scope: .configurationOnly,
+                    appState: appState
+                )
+            case .allProfiles:
+                try appState.profileManager.updateAllProfilesGlobalConfiguration(
+                    displaySettings.globalConfiguration,
+                    propagateToDisplays: true
+                )
+            }
+        } catch {
+            displaySettings.configurations = previousConfigurations
+            errorMessage = error.localizedDescription
+            showingError = true
+        }
     }
 
     @ViewBuilder
@@ -685,7 +786,7 @@ struct DisplaySettingsPane: View {
 
     private func globalConfirmationMessage(for pending: PendingGlobalApply) -> String {
         let profileName = pending.activeProfileName ?? ""
-        let displayMessage = String(localized: "This will overwrite the settings of \(pending.displayCount) display with the global template and may briefly relaunch apps with menu bar items.")
+        let displayMessage = String(localized: "This will overwrite the settings of \(pending.displayCount) display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
         if pending.activeProfileID != nil {
             let profileInstruction = String(localized: "Save the global template to the active profile \"\(profileName)\", or save it to every profile.")
             return "\(displayMessage) \(profileInstruction)"

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -202,6 +202,8 @@ extension Defaults {
 
         static let displayIceBarConfigurations: [String: DisplayIceBarConfiguration] = [:]
         static let globalDisplayConfiguration: DisplayIceBarConfiguration = .defaultConfiguration
+        static let confirmSpacingRelaunch = true
+        static let unconfirmedSpacingProfileScope: SpacingProfileSaveScope = .activeProfile
     }
 }
 
@@ -226,6 +228,8 @@ extension Defaults {
         case displayIceBarConfigurations = "DisplayIceBarConfigurations"
         case globalDisplayConfiguration = "GlobalDisplayConfiguration"
         case knownDisplays = "KnownDisplays"
+        case confirmSpacingRelaunch = "ConfirmSpacingRelaunch"
+        case unconfirmedSpacingProfileScope = "UnconfirmedSpacingProfileScope"
 
         // MARK: Hotkeys Settings
 


### PR DESCRIPTION
## What does this PR do?

Adds a just-in-time confirmation before menu bar spacing changes relaunch your apps, an override toggle to disable it, and persists the new confirmation settings per profile. Also rewords the existing relaunch warnings to state the data-loss risk plainly.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [x] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

Profiles saved before this change decode with backward-compatible defaults (`decodeIfPresent`), so existing profiles load unchanged.

## What is the current behavior?

Changing menu bar item spacing relaunches every app that owns a menu bar item, which can lose unsaved input, in-progress work, or transient app state. The automatic display-transition path applies a different spacing and fires this relaunch wave with no warning at all, and the in-pane Apply and global-broadcast confirmations describe the relaunch as a brief, harmless event.
Issue Number: #685, #686

## What is the new behavior?

When a display transition would actually rewrite the on-disk spacing, `DisplaySettingsManager.applyActiveDisplaySpacing` now presents an app-modal `NSAlert` before relaunching, so it surfaces even with the Settings window closed. The prompt is gated by a new `MenuBarItemSpacingManager.willRelaunch(forOffset:)` predicate that mirrors the existing no-op guard, so it never appears for a no-op; declining keeps the current on-disk spacing and leaves `lastAppliedActiveDisplayUUID` untouched so the next genuine transition re-prompts.
A new `confirmSpacingRelaunch` toggle (default on) in the Displays pane governs all spacing confirmations: when off, the automatic path applies silently and the in-pane Apply and global-broadcast paths bypass their alerts. A companion `unconfirmedSpacingProfileScope` picker chooses whether an unconfirmed apply saves spacing to the active profile only or to every profile when a profile is active, and the alert carries a "Don't ask again" suppression checkbox wired to the toggle.
Both new settings are full profile state: captured in `saveProfile` and `applyCurrentConfiguration`, restored in `applySnapshot`, threaded through `Profile`/`ProfileContent`, and reset in `resetDisplay`, so each profile can carry its own confirmation behaviour. The three existing relaunch warning strings are reworded to state the data-loss risk plainly, and the new UI strings are added to the catalog.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

Closes #685, Closes #686


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Confirmation dialog when spacing changes would relaunch apps
  * Toggle to disable relaunch confirmations for faster workflow
  * Option to choose where unconfirmed spacing edits are saved (active profile or all profiles)

* **Improvements**
  * Clearer warning text about per-app relaunch and possible loss of unsaved/transient state
  * UI flows now respect the confirmation setting when applying or broadcasting spacing changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->