### PR TITLE
fix(menubar): don't re-sort the saved layout on an active-display switch

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2242,7 +2242,9 @@ extension MenuBarItemManager {
             let didApplySavedLayout = await applySavedLayout(
                 items: items,
                 previousWindowIDs: previousWindowIDs,
-                controlItems: controlItems
+                controlItems: controlItems,
+                previousDisplayID: itemCache.displayID,
+                currentDisplayID: displayID
             )
             if didApplySavedLayout {
                 backgroundCacheContinuation?.resume()
@@ -6668,10 +6670,44 @@ extension MenuBarItemManager {
         return false
     }
 
+    /// Decides whether a windowID-set difference between two cache cycles is a
+    /// genuine change that should trigger a saved-layout re-apply, or merely an
+    /// artifact of the active menu bar display switching to another screen.
+    ///
+    /// With "Displays have separate Spaces" enabled the menu bar follows the
+    /// active display, so on a switch the previous display's item windows leave
+    /// the active-space window list and read as "missing" even though the same
+    /// logical items are still present on the other screen. Treating that as an
+    /// item quit fires a full bulk re-sort on every cross-screen focus change,
+    /// which on a notched display drifts items into always-hidden. A display
+    /// switch is not a layout edit, so it must not advance the gate; the
+    /// divergence check still runs and catches genuine section drift.
+    nonisolated static func windowIDsChanged(
+        previous: Set<CGWindowID>,
+        current: Set<CGWindowID>,
+        previousDisplayID: CGDirectDisplayID?,
+        currentDisplayID: CGDirectDisplayID?
+    ) -> Bool {
+        // First cycle: no prior frame to diff against.
+        guard !previous.isEmpty else { return false }
+        // The active menu bar display moved to another screen. With separate
+        // Spaces the prior display's windows are no longer on the active space,
+        // so they read as missing even though the same logical items are still
+        // present elsewhere. Not an item quit; do not advance the gate. Only
+        // suppress when both displays are known and genuinely differ, so an
+        // unknown display falls back to the plain disappearance signal.
+        if let previousDisplayID, let currentDisplayID, previousDisplayID != currentDisplayID {
+            return false
+        }
+        return !previous.isSubset(of: current)
+    }
+
     func applySavedLayout(
         items: [MenuBarItem],
         previousWindowIDs: [CGWindowID],
-        controlItems: ControlItemPair
+        controlItems: ControlItemPair,
+        previousDisplayID: CGDirectDisplayID? = nil,
+        currentDisplayID: CGDirectDisplayID? = nil
     ) async -> Bool {
         // Each guard logs a distinct reason so a "Thaw stopped
         // restoring my layout" bug report can be diagnosed from the
@@ -6727,8 +6763,12 @@ extension MenuBarItemManager {
         // happy path on app quit/relaunch pays nothing.
         let currentWindowIDSet = Set(items.map(\.windowID))
         let previousWindowIDSet = Set(previousWindowIDs)
-        let windowIDsChanged = !previousWindowIDSet.isEmpty &&
-            !previousWindowIDSet.isSubset(of: currentWindowIDSet)
+        let windowIDsChanged = Self.windowIDsChanged(
+            previous: previousWindowIDSet,
+            current: currentWindowIDSet,
+            previousDisplayID: previousDisplayID,
+            currentDisplayID: currentDisplayID
+        )
         let layoutDiverged = windowIDsChanged
             ? false
             : currentLayoutDivergesFromSaved(items: items, controlItems: controlItems)

--- a/ThawTests/WindowIDsChangedGateTests.swift
+++ b/ThawTests/WindowIDsChangedGateTests.swift
@@ -1,0 +1,100 @@
+//
+//  WindowIDsChangedGateTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+/// Characterizes the windowID-change gate that decides whether a cache cycle
+/// should dispatch a saved-layout re-apply.
+///
+/// The gate fires when a previously-seen window has disappeared (an item quit
+/// or relaunched). The bug: with "Displays have separate Spaces" enabled, when
+/// the menu bar follows the user's focus to another display the previous
+/// display's item windows leave the active-space window list, so they read as
+/// "missing" and the gate fires a full bulk re-sort on every cross-screen
+/// focus change. That re-sort is what thrashed the control items and drifted
+/// items into always-hidden on the notched display. A pure display switch must
+/// not advance the gate.
+final class WindowIDsChangedGateTests: XCTestCase {
+    private let d1: CGDirectDisplayID = 1
+    private let d2: CGDirectDisplayID = 2
+
+    /// Same display, a previously-seen window is gone: a real change (item quit
+    /// / relaunch). Must fire.
+    func testSameDisplayMissingWindowFires() {
+        XCTAssertTrue(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11, 12],
+                current: [10, 11], // 12 disappeared
+                previousDisplayID: d1,
+                currentDisplayID: d1
+            )
+        )
+    }
+
+    /// Same display, every previous window still present (pure additions are
+    /// owned by another path): must not fire.
+    func testSameDisplayNoMissingWindowDoesNotFire() {
+        XCTAssertFalse(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11],
+                current: [10, 11, 13], // only an addition
+                previousDisplayID: d1,
+                currentDisplayID: d1
+            )
+        )
+    }
+
+    /// The active menu bar display switched to another screen: the previous
+    /// display's windows are gone from the active-space set, but this is not an
+    /// item quit. Must NOT fire. This is the fix; it is red against the stub.
+    func testActiveDisplaySwitchDoesNotFire() {
+        XCTAssertFalse(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11, 12], // display 1's windows
+                current: [20, 21, 22], // display 2's windows
+                previousDisplayID: d1,
+                currentDisplayID: d2
+            )
+        )
+    }
+
+    /// First cycle (no previous frame to diff against): must not fire.
+    func testEmptyPreviousDoesNotFire() {
+        XCTAssertFalse(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [],
+                current: [10, 11],
+                previousDisplayID: d1,
+                currentDisplayID: d1
+            )
+        )
+    }
+
+    /// Unknown display on either side (nil): fall back to the plain
+    /// windowID-disappearance signal rather than suppressing a real change.
+    func testNilDisplayFallsBackToWindowIDSignal() {
+        XCTAssertTrue(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11, 12],
+                current: [10, 11],
+                previousDisplayID: nil,
+                currentDisplayID: d1
+            )
+        )
+        XCTAssertTrue(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11, 12],
+                current: [10, 11],
+                previousDisplayID: d1,
+                currentDisplayID: nil
+            )
+        )
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Stops Thaw from re-sorting the saved menu bar layout when the active menu bar display switches to another screen. On multi-display setups that re-sort thrashed the control items across displays and drifted items into the always-hidden section.

## PR Type

- [x] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [ ] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [x] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

## What is the current behavior?

With "Displays have separate Spaces" enabled the menu bar follows the user's focus to whichever display is active. On each switch the previous display's item windows leave the active-space window list returned by `getMenuBarWindowList(.activeSpace)`, so `applySavedLayout`'s `windowIDsChanged` gate (a previously-seen windowID is no longer present) read the switch as an item quitting and dispatched a full bulk re-sort. On a multi-display setup this fired on every cross-screen focus change, thrashing the `ControlItem.Visible/Hidden/AlwaysHidden` dividers across displays and drifting items into always-hidden, which then persisted to the saved order.
Issue Number: Refs #666, Refs #675

## What is the new behavior?

The gate now compares the previous cache's display against the current active menu bar display: when both are known and differ, the windowID-set difference is attributed to the display switch and does not advance the gate. App quit/relaunch detection is unchanged (same display, a window genuinely disappears), and the `currentLayoutDivergesFromSaved` check still runs to catch real section drift. The decision is extracted into the pure `MenuBarItemManager.windowIDsChanged(previous:current:previousDisplayID:currentDisplayID:)` and `applySavedLayout` is threaded the previous (`itemCache.displayID`) and current display IDs.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved saved-layout restoration when the menu bar switches displays to avoid treating cross-display moves as window quits, preventing incorrect restore gating and spurious state changes.
* **Tests**
  * Added unit tests covering window-ID change detection across display switches and edge cases (initial cycle and unknown display identifiers).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->