### PR TITLE
fix(window-info): don't warn on empty window identifier lists

### DIFF
--- a/Shared/Utilities/WindowInfo.swift
+++ b/Shared/Utilities/WindowInfo.swift
@@ -106,6 +106,15 @@ extension WindowInfo {
     ///
     /// - Parameter windowIDs: A list of window identifiers.
     static func createWindows(from windowIDs: [CGWindowID]) -> [WindowInfo] {
+        // An empty identifier list is a valid, expected input — there are
+        // simply no windows to describe. This happens routinely on macOS 26
+        // (Tahoe) and especially on macOS 27, where the per-item menu bar
+        // window list is frequently empty. `createCGWindowArray` returns nil
+        // by design for an empty list, so return early to avoid logging a
+        // misleading warning on every such call.
+        guard !windowIDs.isEmpty else {
+            return []
+        }
         guard let array = Bridging.createCGWindowArray(with: windowIDs) else {
             diagLog.warning("createWindows: createCGWindowArray returned nil for \(windowIDs.count) window IDs")
             return []

--- a/ThawTests/WindowInfoCreateWindowsTests.swift
+++ b/ThawTests/WindowInfoCreateWindowsTests.swift
@@ -1,0 +1,77 @@
+//
+//  WindowInfoCreateWindowsTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+/// Regression tests for `WindowInfo.createWindows(from:)` with an empty
+/// identifier list.
+///
+/// An empty list is a valid, expected input — there are simply no windows
+/// to describe. This happens routinely on macOS 26 and especially on
+/// macOS 27, where the per-item menu bar window list is frequently empty.
+/// `Bridging.createCGWindowArray(with:)` returns `nil` by design for an
+/// empty list, so `createWindows(from:)` must short-circuit instead of
+/// logging a misleading warning on every such call.
+final class WindowInfoCreateWindowsTests: XCTestCase {
+    private let emptyInputWarning = "createCGWindowArray returned nil"
+
+    func testEmptyWindowIDsReturnsEmpty() {
+        XCTAssertTrue(WindowInfo.createWindows(from: []).isEmpty)
+    }
+
+    func testEmptyWindowIDsDoesNotLogWarning() throws {
+        let logger = DiagnosticLogger.shared
+        let logFile = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("thaw-windowinfo-\(UUID().uuidString).log")
+
+        logger.attachToFile(at: logFile)
+        defer {
+            logger.isEnabled = false
+            try? FileManager.default.removeItem(at: logFile)
+        }
+
+        // Exercise the empty-input path that previously logged a warning.
+        _ = WindowInfo.createWindows(from: [])
+
+        // Emit a sentinel after the call. The logger's write queue is
+        // serial and FIFO, so once the sentinel is visible in the file
+        // any earlier write from createWindows has already been flushed.
+        let sentinel = "windowinfo-sentinel-\(UUID().uuidString)"
+        logger.log(level: .info, category: "Test", message: sentinel)
+
+        let contents = try pollForFileContents(at: logFile, containing: sentinel)
+        XCTAssertFalse(
+            contents.contains(emptyInputWarning),
+            "createWindows(from: []) must not log a warning for empty input"
+        )
+    }
+
+    // MARK: - Helpers
+
+    /// Polls the file at `url` until it contains `needle` or the timeout
+    /// elapses, then returns the file's contents. Used to wait for the
+    /// asynchronous diagnostic-log write queue to flush.
+    private func pollForFileContents(
+        at url: URL,
+        containing needle: String,
+        timeout: TimeInterval = 2
+    ) throws -> String {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let contents = try? String(contentsOf: url, encoding: .utf8),
+               contents.contains(needle)
+            {
+                return contents
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+        return (try? String(contentsOf: url, encoding: .utf8)) ?? ""
+    }
+}


### PR DESCRIPTION
## What does this PR do?

Stops `WindowInfo.createWindows(from:)` from logging a warning when it is
called with an empty window-identifier list. An empty list is a valid,
expected input — there are simply no windows to describe — so it should
return an empty array silently.

## PR Type

- [x] Bugfix

## Does this PR introduce a breaking change?

- [x] No

## What is the current behavior?

`Bridging.createCGWindowArray(with:)` returns `nil` by design for an empty
identifier list. `WindowInfo.createWindows(from:)` treats that `nil` as a
failure and logs:

```
createWindows: createCGWindowArray returned nil for 0 window IDs
```

On macOS 27 the per-item menu bar window list is frequently empty (Apple
unified all menu bar items into a single window owned by the new
`MenuBarAgent` process), so menu-bar enumeration paths repeatedly call
`createWindows(from: [])` and flood the diagnostic log with this warning
many times per minute. That noise makes the diagnostic logs maintainers
ask users to attach much harder to read.

Issue Number: #687

## What is the new behavior?

`createWindows(from:)` short-circuits on an empty input and returns an
empty array without logging. Genuine failures (a non-empty list that still
yields `nil`) keep their warning. A regression test covers both the return
value and the absence of the warning for empty input.

## PR Checklist

- [x] I’ve built and run the app locally
- [x] I’ve checked for console errors or crashes
- [x] I've run relevant tests and they pass
- [x] I've added or updated tests (if applicable)
- [ ] I've updated documentation as needed

## Other information

This is a small, self-contained noise-reduction fix scoped to log
hygiene. It does not attempt full macOS 27 menu bar management (tracked in
#687 and the maintainers' `feat/macos-27-experimental` branch); it only
keeps the diagnostic log readable on macOS 27 so that effort is easier to
debug.

### Notes for reviewers

The new test (`WindowInfoCreateWindowsTests`) enables the diagnostic
logger to a temporary file, calls `createWindows(from: [])`, then writes a
sentinel line and waits for it to flush (the logger's write queue is
serial/FIFO) before asserting the empty-input warning is absent. It fails
on the previous behavior and passes with this change.
