### PR TITLE
Fix docs and helper version metadata

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Regardless of the type of contribution, you'll need a GitHub account and a fork 
    git checkout -b your-branch-name
    ```
 
-5. When ready, open a pull request against `stonerl/Thaw:main`
+5. When ready, open a pull request against `stonerl/Thaw:development`
 
 ## Non-technical contributions
 
@@ -105,4 +105,4 @@ Open a pull request via the [Thaw pull requests page][pr] and select the [approp
 [fq]: ../FREQUENT_ISSUES.md
 [it]: https://github.com/stonerl/Thaw/issues
 [pr]: https://github.com/stonerl/Thaw/pulls
-[prt]: https://github.com/stonerl/Thaw/blob/main/.github/pull_request_template.md
+[prt]: https://github.com/stonerl/Thaw/blob/development/.github/pull_request_template.md

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thaw is a powerful menu bar management tool for macOS 26. While its primary func
 
 ### Manual Installation
 
-Download the `Thaw_1.x.x.zip` file from the [latest release](https://github.com/stonerl/Thaw/releases/latest) and move the unzipped app into your `Applications` folder.
+Download the `Thaw_<version>.zip` file from the [latest release](https://github.com/stonerl/Thaw/releases/latest) and move the unzipped app into your `Applications` folder.
 
 ### Homebrew
 

--- a/Thaw.xcodeproj/project.pbxproj
+++ b/Thaw.xcodeproj/project.pbxproj
@@ -644,7 +644,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Toni Förster\nCopyright © 2023–2025 Jordan Baird (Ice) ";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = "2.0.0-beta.16";
+				MARKETING_VERSION = "2.0.0-beta.15";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stonerl.Thaw.MenuBarItemService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -674,7 +674,7 @@
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 Toni Förster\nCopyright © 2023–2025 Jordan Baird (Ice) ";
 				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
 				MACOSX_DEPLOYMENT_TARGET = 26.0;
-				MARKETING_VERSION = "2.0.0-beta.16";
+				MARKETING_VERSION = "2.0.0-beta.15";
 				PRODUCT_BUNDLE_IDENTIFIER = com.stonerl.Thaw.MenuBarItemService;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## Summary
- Update contributing guidance to target the repository's default `development` branch and fix the PR template link.
- Generalize the manual download filename in the README so it is not tied to 1.x releases.
- Align the `MenuBarItemService` marketing version with the main Thaw app target for build 46 / `2.0.0-beta.15`.

## Testing
- `xcodebuild -list -project Thaw.xcodeproj`
- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributing guidelines to reference the development branch for pull requests.
  * Improved manual installation instructions with dynamic version naming.

* **Chores**
  * Updated application version to 2.0.0-beta.15.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->