### PR TITLE
Update contribution and install docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ Regardless of the type of contribution, you'll need a GitHub account and a fork 
    git checkout -b your-branch-name
    ```
 
-5. When ready, open a pull request against `stonerl/Thaw:main`
+5. When ready, open a pull request against `stonerl/Thaw:development`
 
 ## Non-technical contributions
 
@@ -105,4 +105,4 @@ Open a pull request via the [Thaw pull requests page][pr] and select the [approp
 [fq]: ../FREQUENT_ISSUES.md
 [it]: https://github.com/stonerl/Thaw/issues
 [pr]: https://github.com/stonerl/Thaw/pulls
-[prt]: https://github.com/stonerl/Thaw/blob/main/.github/pull_request_template.md
+[prt]: https://github.com/stonerl/Thaw/blob/development/.github/pull_request_template.md

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Thaw is a powerful menu bar management tool for macOS 26. While its primary func
 
 ### Manual Installation
 
-Download the `Thaw_1.x.x.zip` file from the [latest release](https://github.com/stonerl/Thaw/releases/latest) and move the unzipped app into your `Applications` folder.
+Download the `Thaw_<version>.zip` file from the [latest release](https://github.com/stonerl/Thaw/releases/latest) and move the unzipped app into your `Applications` folder.
 
 ### Homebrew
 


### PR DESCRIPTION
## What does this PR do?

Updates two documentation references:

- Changes the contribution guide PR target from `main` to `development`.
- Updates the PR template link to point at the `development` branch.
- Generalizes the manual download filename in the README so it is not tied to `1.x.x` releases.

This is a docs-only follow-up to #713 and intentionally does not modify `Thaw.xcodeproj`.

## PR Type

- [ ] Bugfix
- [ ] CI/CD related changes
- [ ] Code style update (formatting, renaming)
- [x] Documentation
- [ ] Feature
- [ ] Refactor
- [ ] Performance improvement
- [ ] Test addition or update
- [ ] Other (please describe):

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If yes, please describe the impact and migration path:

N/A

## What is the current behavior?

The contribution guide still points contributors at `stonerl/Thaw:main` and links the PR template on `main`. The README manual install instructions also use a `Thaw_1.x.x.zip` filename example.

Issue Number: N/A

## What is the new behavior?

The contribution guide points contributors at `stonerl/Thaw:development`, the PR template link uses `development`, and the README uses a generic `Thaw_<version>.zip` filename placeholder.

## PR Checklist

- [ ] I’ve built and run the app locally
- [ ] I’ve checked for console errors or crashes
- [ ] I've run relevant tests and they pass
- [ ] I've added or updated tests (if applicable)
- [x] I've updated documentation as needed

## Other information

Docs-only change; no app code or Xcode project files are modified.

### Notes for reviewers

This intentionally excludes the `Thaw.xcodeproj` version metadata change from #713 per maintainer feedback.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contribution guidelines to direct pull requests to the development branch.
  * Updated manual installation instructions to reference the latest release version instead of a specific version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->