### PR TITLE
fix(onboarding): make full button area tappable, not just the label

### DIFF
--- a/Thaw/Onboarding/OnboardingMockups.swift
+++ b/Thaw/Onboarding/OnboardingMockups.swift
@@ -285,9 +285,10 @@ struct ManagementScreen: View {
                     Color.clear.frame(width: 22, height: 24)
                     MenuBarDividerDot(tint: tint.label.opacity(0.85))
                 }
+                .padding(.horizontal, 2)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .padding(.horizontal, 2)
 
             MenuBarClockGroup(tint: tint.label.opacity(0.9))
                 .padding(.trailing, 8)
@@ -450,16 +451,19 @@ struct AppearanceHUD: View {
         ControlHUD {
             HStack(spacing: 0) {
                 ForEach(Array(AppearanceMockupModel.styleLabels.enumerated()), id: \.offset) { i, label in
-                    Button(label) {
+                    Button {
                         model.selectStyle(i)
+                    } label: {
+                        Text(label)
+                            .font(.system(size: 11, weight: model.styleIndex == i ? .semibold : .regular))
+                            .foregroundStyle(model.styleIndex == i ? Color.white : Color.white.opacity(0.5))
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 3)
+                            .background(model.styleIndex == i ? Color.white.opacity(0.15) : Color.clear)
+                            .clipShape(Capsule())
+                            .contentShape(Capsule())
                     }
                     .buttonStyle(.plain)
-                    .font(.system(size: 11, weight: model.styleIndex == i ? .semibold : .regular))
-                    .foregroundStyle(model.styleIndex == i ? Color.white : Color.white.opacity(0.5))
-                    .padding(.horizontal, 10)
-                    .padding(.vertical, 3)
-                    .background(model.styleIndex == i ? Color.white.opacity(0.15) : Color.clear)
-                    .clipShape(Capsule())
                 }
             }
         }

--- a/Thaw/Onboarding/OnboardingSheet.swift
+++ b/Thaw/Onboarding/OnboardingSheet.swift
@@ -344,17 +344,20 @@ struct OnboardingSheet: View {
                 .frame(maxWidth: 440)
             }
 
-            Button(isLast ? "Get Started" : "Continue") {
+            Button {
                 if isLast { finishOnboarding() } else { advance() }
+            } label: {
+                Text(isLast ? "Get Started" : "Continue")
+                    .font(.body.bold())
+                    .foregroundStyle(.white)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 44)
+                    .background(Color.accentColor)
+                    .clipShape(Capsule())
+                    .contentShape(Capsule())
             }
             .keyboardShortcut(.defaultAction)
             .buttonStyle(.plain)
-            .font(.body.bold())
-            .foregroundStyle(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 44)
-            .background(Color.accentColor)
-            .clipShape(Capsule())
         }
     }
 


### PR DESCRIPTION
# Summary

In the onboarding tour, Continue / Get Started looked like a full-width capsule but only the label text was clickable. Layout/appearance modifiers are moved into the button `label:` and `.contentShape(...)` is applied so the whole capsule is tappable. Same pattern applied to `AppearanceHUD` style chips and the `ManagementScreen` divider-dot toggle.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

The full visual area of onboarding primary buttons and the listed mockup controls responds to taps, not only the text/label bounds.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [ ] I've updated documentation as needed

## Other information

Verified locally that edges of the Continue / Get Started capsule are tappable on every onboarding slide.