### PR TITLE
fix(menubar): fall back to Thaw Bar when hiding app menus under fullscreen

### DIFF
--- a/Thaw/MenuBar/MenuBarSection.swift
+++ b/Thaw/MenuBar/MenuBarSection.swift
@@ -324,11 +324,26 @@ final class MenuBarSection {
         // Determine whether we should use the Thaw Bar based on settings.
         let shouldUseIceBarBasedOnSettings = useIceBar
 
-        let preferredPresentationMode: PresentationMode
+        var preferredPresentationMode: PresentationMode
         if shouldUseIceBarBasedOnSettings {
             preferredPresentationMode = .iceBar
         } else if let screen = screenForIceBar {
             preferredPresentationMode = presentationMode(on: screen)
+            // Avoid hiding application menus while a fullscreen space is
+            // active. Hiding the application menus activates Thaw
+            // (NSApp.activate), and activating inside a fullscreen space
+            // makes macOS immediately hide the menu bar (FB13544993). Fall
+            // back to the Thaw Bar instead: its panel is shown via
+            // orderFrontRegardless() without activating. This mirrors the
+            // fullscreen guard already present in the reactive sink in
+            // MenuBarManager.
+            if
+                preferredPresentationMode == .inlineHidingApplicationMenus,
+                appState?.activeSpace.isFullscreen == true
+            {
+                diagLog.info("Fullscreen space active; falling back to Thaw Bar instead of hiding application menus")
+                preferredPresentationMode = .iceBar
+            }
             switch preferredPresentationMode {
             case .inline:
                 break


### PR DESCRIPTION
# Summary

Adds a fullscreen guard on the synchronous “hide application menus” path in `MenuBarSection.show()`, matching the reactive sink in `MenuBarManager`. When a fullscreen space is active and presentation would be `.inlineHidingApplicationMenus`, it falls back to `.iceBar` (Thaw Bar) so activating Thaw does not hide the menu bar (Apple Feedback FB13544993).

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #740

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Clicking the control item under a fullscreen app shows the hidden section via Thaw Bar instead of hiding application menus (which activates the app and can dismiss the menu bar). Non-fullscreen behavior is unchanged.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [ ] I've updated documentation as needed

## Other information

Reproduced on unpatched build (menu bar hides under fullscreen with default `hideApplicationMenus`); patched build keeps the menu bar and expands via Thaw Bar. No existing unit fixture for this path found.