### PR TITLE
fix(menubar): keep the visible control item in place during notch overflow

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -455,13 +455,16 @@ enum LayoutSolver {
             .filter { !controlSet.contains($0) }
 
         let overflowSet = Set(overflowUIDs)
-        let remainingNonChevron = nonChevronUIDs.filter { !overflowSet.contains($0) }
+        // Keep the visible items in their saved order and drop only the
+        // overflowed ones. The visible control item is never in overflowSet, so
+        // filtering preserves its saved position instead of forcing it to the
+        // front of the visible section. Prepending the chevron relocated the
+        // always-visible Thaw icon to the leftmost slot on every overflow even
+        // though it was never the item that overflowed.
+        let remainingVisible = visibleUIDs.filter { !overflowSet.contains($0) }
 
         var rebuilt = [String]()
-        if let chevron = controlUIDs.visible {
-            rebuilt.append(chevron)
-        }
-        rebuilt.append(contentsOf: remainingNonChevron)
+        rebuilt.append(contentsOf: remainingVisible)
         rebuilt.append(controlUIDs.hidden)
         rebuilt.append(contentsOf: existingHidden)
         rebuilt.append(contentsOf: overflowUIDs)

--- a/ThawTests/PlanNotchOverflowTests.swift
+++ b/ThawTests/PlanNotchOverflowTests.swift
@@ -419,4 +419,40 @@ final class PlanNotchOverflowTests: XCTestCase {
 
         XCTAssertFalse(result.overflowUIDs.isEmpty, "a genuinely full bar (positive budget) must still overflow")
     }
+
+    /// The visible control item is never ejected, but it must also keep its
+    /// saved position when an overflow rebuild runs. The field layout puts the
+    /// Thaw icon near the end of the visible section (items after it), not at
+    /// the front. Here the chevron sits mid-section; when a profile item
+    /// overflows, the chevron must stay between its neighbours rather than jump
+    /// to index 0. Red before the fix, which prepended the chevron.
+    func testChevronKeepsSavedPositionAcrossOverflow() {
+        // visible order left-to-right: a, b, chevron, c (chevron mid-list).
+        let desired = makeSequence(
+            chevron: nil,
+            visible: ["a", "b", chevron, "c"],
+            hiddenCtrl: hiddenCtrl,
+            ahCtrl: ahCtrl
+        )
+        let widths: [String: CGFloat] = [chevron: 24, "a": 24, "b": 24, "c": 24]
+        let sectionMap = ["a": "visible", "b": "visible", "c": "visible"]
+
+        // profileBaseline = chevron + a + b + c = 96 > 80, so one item overflows.
+        let result = LayoutSolver.planNotchOverflow(
+            desiredFiltered: desired,
+            unmanagedUIDs: [],
+            controlUIDs: ControlUIDs(visible: chevron, hidden: hiddenCtrl, alwaysHidden: ahCtrl),
+            sectionMap: sectionMap,
+            uidWidths: widths,
+            availableWidth: 80
+        )
+
+        XCTAssertEqual(result.overflowUIDs, ["a"], "leftmost profile item overflows first")
+        XCTAssertEqual(
+            result.updatedDesiredFiltered,
+            ["b", chevron, "c", hiddenCtrl, "a", ahCtrl],
+            "the chevron must stay between b and c, not be relocated to the front"
+        )
+        XCTAssertEqual(result.updatedSectionMap["a"], "hidden")
+    }
 }


### PR DESCRIPTION
# Summary

Fixes a notch-overflow regression where the always-visible Thaw control item (the chevron) was relocated to the leftmost slot of the visible section whenever an overflow fired, even though it was never the item that overflowed.

Refs: #666, #702

## PR Type

- [x] Bugfix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

`planNotchOverflow` already excludes the visible control item from the set of items eligible to overflow into hidden, so it is never ejected. However, the rebuild that runs after an ejection prepended the chevron to the front of the visible section instead of leaving it where it was, so any notch overflow forced the Thaw icon to the leftmost slot.

This rebuilds the visible section by filtering the overflowed items out of the saved visible order (`visibleUIDs`) rather than extracting the chevron and re-prepending it. Because the chevron is never in the overflow set, filtering preserves its saved position while still ejecting the overflowing items. Layouts whose chevron was already leftmost are unaffected.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

Adds `PlanNotchOverflowTests.swift` covering the regression: confirms the visible control item keeps its saved position through an overflow, and that an already-leftmost chevron is unaffected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed menu bar overflow handling to maintain the control element's relative position within the visible section during layout adjustments, rather than moving it to the front.

* **Tests**
  * Added test coverage for control element positioning during menu bar overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->