### PR TITLE
fix(menubar): defer saved-layout apply/persist on unsettled or cross-display geometry and clear stuck profile flag

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -347,6 +347,40 @@ enum LayoutSolver {
         rightBoundary.isFinite && rightBoundary > notchMaxX
     }
 
+    /// Whether the given menu bar items currently occupy more than one display.
+    ///
+    /// Each center is matched to the screen frame that contains it. Frames and
+    /// centers are expected in the global CoreGraphics coordinate space
+    /// (top-left origin), so a secondary display above the main one has a
+    /// negative y origin. Centers that fall on no screen are intentionally
+    /// parked off-screen hidden items (the control item shoves them thousands
+    /// of points to the left) and are ignored. When the remaining on-screen
+    /// items resolve to more than one distinct screen the active menu bar is
+    /// relocating between displays: macOS migrates the status item windows
+    /// asynchronously, so for a window of time some items sit on the old screen
+    /// and some on the new one. A bulk apply dispatched then resolves each
+    /// move against a different display and cannot converge, leaving items
+    /// stranded where they read as un-hidden; a section order persisted then
+    /// bakes that transition artifact into the saved layout. Both callers defer
+    /// until the items collapse back onto a single display.
+    static nonisolated func itemsSpanMultipleDisplays(
+        itemCenters: [CGPoint],
+        screenFrames: [CGRect]
+    ) -> Bool {
+        guard screenFrames.count > 1 else { return false }
+        var hitScreens = Set<Int>()
+        for center in itemCenters {
+            guard let index = screenFrames.firstIndex(where: { $0.contains(center) }) else {
+                continue
+            }
+            hitScreens.insert(index)
+            if hitScreens.count > 1 {
+                return true
+            }
+        }
+        return false
+    }
+
     // MARK: - Notch overflow
 
     /// Decides which visible items must overflow into hidden to fit the

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -326,6 +326,27 @@ enum LayoutSolver {
         return .newHideableItem(candidate, identifierToMark: identifierToMark)
     }
 
+    // MARK: - Geometry readiness
+
+    /// Whether the menu bar geometry is settled enough to run a layout pass on
+    /// a notched display.
+    ///
+    /// `rightBoundary` is Control Center's left edge (or the screen's right edge
+    /// when Control Center is absent), the same value the notch-overflow budget
+    /// is derived from. A finite value to the right of the notch's right edge is
+    /// a valid layout anchor. A value at or left of the notch (or non-finite)
+    /// means Control Center was reported at a stale off-screen position, which
+    /// happens transiently during a display reconnect or Control Center widget
+    /// churn. Running the placement and move logic against that geometry
+    /// mis-positions the control items (the Thaw visible icon jumps to the far
+    /// left), so the pass must be deferred until the geometry settles.
+    static nonisolated func isMenuBarGeometryReady(
+        rightBoundary: CGFloat,
+        notchMaxX: CGFloat
+    ) -> Bool {
+        rightBoundary.isFinite && rightBoundary > notchMaxX
+    }
+
     // MARK: - Notch overflow
 
     /// Decides which visible items must overflow into hidden to fit the

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -303,7 +303,7 @@ final class MenuBarItemManager: ObservableObject {
     /// True while `applyProfileLayout` is executing. Suppresses the
     /// late-arrival detection in `cacheItemsRegardless` to prevent
     /// false re-sort triggers during an in-flight sort.
-    private var isApplyingProfileLayout = false
+    private(set) var isApplyingProfileLayout = false
 
     /// Persisted mapping of item tag identifiers to their original section name for
     /// temporarily shown items whose apps quit before they could be rehidden. When
@@ -5597,7 +5597,7 @@ extension MenuBarItemManager {
     /// Phase 7 with Task.isCancelled false). If a crash, SIGKILL, or
     /// mid-apply cancellation aborts before that point, disk reflects
     /// the previous profile rather than an unexecuted intent.
-    private func armProfileState(
+    func armProfileState(
         source: ApplySource,
         pinnedHidden: Set<String>,
         pinnedAlwaysHidden: Set<String>,
@@ -5686,6 +5686,19 @@ extension MenuBarItemManager {
         updateProfileSortedSnapshot(source: source, items: items)
         guard case .profile = source else { return }
         isApplyingProfileLayout = false
+    }
+
+    /// Cleanup for a profile apply that needed no item moves: the bar was
+    /// already in the target arrangement, so the move loop is skipped and the
+    /// normal Phase 7 exit (which clears the in-flight flag) is never reached.
+    /// This early exit must run the same profile-only teardown as Phase 7,
+    /// otherwise a no-moves apply (common on a display reconnect, where the
+    /// active-display profile is re-applied onto an already-correct bar) leaks
+    /// isApplyingProfileLayout = true and permanently blocks applySavedLayout
+    /// for the rest of the session.
+    func concludeProfileApplyWithoutMoves(source: ApplySource, items: [MenuBarItem]) {
+        persistProfileStateOnSuccess(source: source)
+        clearProfileState(source: source, items: items)
     }
 
     /// Schedules the post-apply refresh sequence on a detached Task:
@@ -6521,8 +6534,7 @@ extension MenuBarItemManager {
                 } else {
                     MenuBarItemManager.diagLog.info("Profile layout: all items already in correct positions")
                 }
-                updateProfileSortedSnapshot(source: source, items: items)
-                persistProfileStateOnSuccess(source: source)
+                concludeProfileApplyWithoutMoves(source: source, items: items)
                 scheduleDeferredCacheRefresh()
                 return
             }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -6777,6 +6777,29 @@ extension MenuBarItemManager {
             return false
         }
 
+        // Geometry-readiness gate. On a notched display, if Control Center is
+        // reported at or left of the notch's right edge the menu bar geometry
+        // has not settled: a stale off-screen position reported transiently
+        // during a display reconnect or Control Center widget churn. Dispatching
+        // the bulk apply now runs the control-item placement against that
+        // geometry and mis-positions the Thaw visible icon to the far left (the
+        // notch-overflow budget guard alone only suppresses the eject, not the
+        // moves). Skip; the cache cycle falls through to a plain recache and a
+        // later tick retries once the geometry settles.
+        if let screen = NSScreen.screenWithActiveMenuBar ?? NSScreen.main,
+           screen.hasNotch,
+           let notch = screen.frameOfNotch
+        {
+            let rightBoundary = items.first(where: { $0.tag == .controlCenter })?.bounds.minX
+                ?? screen.frame.maxX
+            guard LayoutSolver.isMenuBarGeometryReady(rightBoundary: rightBoundary, notchMaxX: notch.maxX) else {
+                MenuBarItemManager.diagLog.debug(
+                    "applySavedLayout: skipping, menu bar geometry not settled (rightBoundary=\(rightBoundary), notch.maxX=\(notch.maxX))"
+                )
+                return false
+            }
+        }
+
         // Saved-tags intersection: skip if none of the saved items are
         // currently present. Matches the legacy restore's guard;
         // protects against running the bulk apply on a menu bar that

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -1820,12 +1820,30 @@ extension MenuBarItemManager {
                     return bounds.origin.x == -1
                 }
             }
-            if !hasBlockedItems {
-                saveSectionOrder(from: context.cache)
-            } else {
+            // Don't persist while the items straddle two displays. A cross-display
+            // cache is a menu bar relocation caught mid-flight, not a settled
+            // layout: macOS un-hides items as it moves them to the new screen, so
+            // capturing the section order now would bake those un-hidden items
+            // into the saved layout as if the user wanted them visible. Wait for
+            // the items to collapse back onto a single display.
+            let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+            let itemCenters = MenuBarSection.Name.allCases.flatMap { section in
+                context.cache[section].map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) }
+            }
+            let spansDisplays = LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: itemCenters,
+                screenFrames: screenFrames
+            )
+            if hasBlockedItems {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping saveSectionOrder; blocked items detected (x=-1), will retry on next cache tick"
                 )
+            } else if spansDisplays {
+                MenuBarItemManager.diagLog.debug(
+                    "Skipping saveSectionOrder; menu bar items span multiple displays (relocation in progress)"
+                )
+            } else {
+                saveSectionOrder(from: context.cache)
             }
         }
         MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
@@ -6798,6 +6816,24 @@ extension MenuBarItemManager {
                 )
                 return false
             }
+        }
+
+        // Display-spread gate. While the active menu bar is relocating to
+        // another display macOS migrates the status item windows between
+        // screens asynchronously, so the items transiently straddle two
+        // displays. A bulk apply dispatched now resolves each item's move
+        // against whichever display its window currently occupies and cannot
+        // converge, stranding items on the wrong screen where they read as
+        // un-hidden. Skip; a later tick retries once the items collapse back
+        // onto the active display. Frames come from CGDisplayBounds so they
+        // share the top-left origin coordinate space of the item bounds.
+        let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+        let itemCenters = items.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) }
+        if LayoutSolver.itemsSpanMultipleDisplays(itemCenters: itemCenters, screenFrames: screenFrames) {
+            MenuBarItemManager.diagLog.debug(
+                "applySavedLayout: skipping, menu bar items span multiple displays (relocation in progress)"
+            )
+            return false
         }
 
         // Saved-tags intersection: skip if none of the saved items are

--- a/ThawTests/DisplaySpreadGateTests.swift
+++ b/ThawTests/DisplaySpreadGateTests.swift
@@ -1,0 +1,117 @@
+//
+//  DisplaySpreadGateTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+/// Characterizes the display-spread predicate that both the saved-layout apply
+/// and the section-order persist consult before acting.
+///
+/// When the active menu bar relocates to another display macOS migrates the
+/// status item windows between screens asynchronously. For a window of time
+/// the managed items straddle two displays: some still on the old screen,
+/// some already on the new one. A bulk apply dispatched in that window
+/// resolves each item's move against whichever display its window currently
+/// occupies, so the moves cannot converge and leave items stranded on the
+/// wrong screen, where they read as un-hidden. Persisting the section order in
+/// that window bakes the transition artifact into the saved layout. Both
+/// callers defer until the items collapse back onto a single display.
+///
+/// Frames are expressed in the global CoreGraphics coordinate space
+/// (top-left origin), the same space the menu bar item bounds use, so a
+/// secondary display positioned above the main one has a negative y origin.
+final class DisplaySpreadGateTests: XCTestCase {
+    private let main = CGRect(x: 0, y: 0, width: 1728, height: 1117)
+    private let above = CGRect(x: 0, y: -1440, width: 2560, height: 1440)
+
+    /// A single connected display can never spread; the predicate must short
+    /// circuit so single-display users never defer.
+    func testSingleScreenNeverSpreads() {
+        XCTAssertFalse(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [CGPoint(x: 800, y: 10), CGPoint(x: 1200, y: 10)],
+                screenFrames: [main]
+            )
+        )
+    }
+
+    /// Two displays connected, but every item resolves to the same screen: a
+    /// settled layout. Must not defer.
+    func testAllItemsOnOneOfTwoScreensDoesNotSpread() {
+        XCTAssertFalse(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [CGPoint(x: 800, y: 10), CGPoint(x: 1200, y: 10)],
+                screenFrames: [main, above]
+            )
+        )
+    }
+
+    /// Items straddle both displays: the relocation-in-progress state from the
+    /// field log. This is the condition both gates must catch. Red against the
+    /// missing predicate.
+    func testItemsSplitAcrossTwoScreensSpreads() {
+        XCTAssertTrue(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [CGPoint(x: 800, y: 10), CGPoint(x: 1000, y: -1065)],
+                screenFrames: [main, above]
+            )
+        )
+    }
+
+    /// Items on one screen plus intentionally off-screen parked hidden items
+    /// (the control item shoves them ~10000px left, onto no display). The
+    /// parked points must be ignored so a normal hidden layout does not read
+    /// as spread.
+    func testOffScreenParkedItemsAreIgnored() {
+        XCTAssertFalse(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [
+                    CGPoint(x: 800, y: 10),
+                    CGPoint(x: 1200, y: 10),
+                    CGPoint(x: -7535, y: -1065), // parked hidden control item
+                    CGPoint(x: -10071, y: -1065), // parked hidden item
+                ],
+                screenFrames: [main, above]
+            )
+        )
+    }
+
+    /// Only parked off-screen items resolve to no display at all: not a spread.
+    func testOnlyOffScreenItemsDoesNotSpread() {
+        XCTAssertFalse(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [CGPoint(x: -7535, y: -1065), CGPoint(x: -10071, y: -1065)],
+                screenFrames: [main, above]
+            )
+        )
+    }
+
+    /// Two real on-screen items, one per display, mixed with parked items:
+    /// still a spread (the parked items neither add nor mask the split).
+    func testSplitWithParkedItemsStillSpreads() {
+        XCTAssertTrue(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [
+                    CGPoint(x: 800, y: 10), // display 1
+                    CGPoint(x: 1000, y: -1065), // display 2
+                    CGPoint(x: -7535, y: -1065), // parked
+                ],
+                screenFrames: [main, above]
+            )
+        )
+    }
+
+    /// No items at all: nothing to spread.
+    func testEmptyItemsDoesNotSpread() {
+        XCTAssertFalse(
+            LayoutSolver.itemsSpanMultipleDisplays(itemCenters: [], screenFrames: [main, above])
+        )
+    }
+}

--- a/ThawTests/ProfileApplyInFlightFlagTests.swift
+++ b/ThawTests/ProfileApplyInFlightFlagTests.swift
@@ -1,0 +1,63 @@
+//
+//  ProfileApplyInFlightFlagTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+@testable import Thaw
+import XCTest
+
+/// Characterizes the in-flight profile flag teardown on the no-moves exit of a
+/// profile apply.
+///
+/// A profile apply arms isApplyingProfileLayout so a concurrent saved-layout
+/// apply cannot fight it. The normal exit clears the flag. The no-moves exit
+/// (taken when the bar is already in the target arrangement, which is the
+/// common case on a display reconnect that re-applies the active-display
+/// profile) is a separate code path: if it does not run the same teardown the
+/// flag leaks true and every later applySavedLayout is skipped with "profile
+/// apply in flight", so the saved layout can never be restored for the rest of
+/// the session. The field log showed this stick at a display reconnect and
+/// disable re-hide while the menu bar churned across three displays.
+@MainActor
+final class ProfileApplyInFlightFlagTests: XCTestCase {
+    private func makeOrder() -> [String: [String]] {
+        ["visible": [], "hidden": [], "alwaysHidden": []]
+    }
+
+    /// A profile apply that needs no moves must leave the in-flight flag clear.
+    /// Red against the pre-fix no-moves exit, which never cleared it.
+    func testNoMovesProfileApplyClearsInFlightFlag() {
+        let manager = MenuBarItemManager()
+        manager.armProfileState(
+            source: .profile,
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: makeOrder(),
+            itemSectionMap: [:],
+            itemOrder: makeOrder()
+        )
+        XCTAssertTrue(manager.isApplyingProfileLayout, "Arming a profile apply must set the in-flight flag")
+
+        manager.concludeProfileApplyWithoutMoves(source: .profile, items: [])
+
+        XCTAssertFalse(
+            manager.isApplyingProfileLayout,
+            "A profile apply that needs no item moves must clear the in-flight flag"
+        )
+    }
+
+    /// A .savedOrder apply never arms the profile flag, and the no-moves
+    /// conclusion must not toggle it on.
+    func testNoMovesSavedOrderApplyLeavesFlagUntouched() {
+        let manager = MenuBarItemManager()
+        XCTAssertFalse(manager.isApplyingProfileLayout)
+
+        manager.concludeProfileApplyWithoutMoves(source: .savedOrder, items: [])
+
+        XCTAssertFalse(manager.isApplyingProfileLayout)
+    }
+}

--- a/ThawTests/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/ProfileLayoutLogReplayTests.swift
@@ -268,6 +268,72 @@ final class ProfileLayoutLogReplayTests: XCTestCase {
         )
         XCTAssertEqual(result.updatedDesiredFiltered, desiredFiltered)
     }
+
+    // MARK: Regression lock for the unsettled-geometry layout pass
+
+    /// Replays a real field cycle (thaw_2026-06-11_09-11-10.log, 11:31:05) on
+    /// the patched build where the notch-overflow guard is already present:
+    /// Control Center was reported at rightBoundary=672, left of the notch's
+    /// right edge (956), giving a negative budget. The overflow guard correctly
+    /// skipped the eject, but the pass still ran its control-item placement on
+    /// that stale geometry and moved the Thaw visible icon to the far left. The
+    /// geometry-readiness gate must report this cycle as not ready so the whole
+    /// pass is deferred. Red before the gate (the stub reports ready).
+    func testUnsettledGeometryFieldCycleIsNotReady() throws {
+        let log = """
+        2026-06-11 11:31:05.750 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 1 items: ["leits.MeetingBar:Item-0"]
+        2026-06-11 11:31:05.750 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 0 items: []
+        2026-06-11 11:31:05.750 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 0 items: []
+        2026-06-11 11:31:05.751 [DEBUG] [MenuBarItemManager] Notch overflow budget: screen.maxX=1728.0 notch=[771.0…956.0] rightBoundary=672.0 availableWidth=-308.0 userSpacing=0.0 visibleUIDs.count=14 nonProfileCount=0 nonProfileFootprint=0.0 chevronFootprint=0.0 nonProfileBreakdown=[]
+        """
+        let parsed = ProfileLayoutLogReplay.parse(log)
+        let cycle = try XCTUnwrap(parsed.cycles.first)
+
+        XCTAssertEqual(cycle.notchRightBoundary, 672)
+        XCTAssertEqual(cycle.notchMaxX, 956)
+
+        XCTAssertFalse(
+            LayoutSolver.isMenuBarGeometryReady(
+                rightBoundary: try XCTUnwrap(cycle.notchRightBoundary),
+                notchMaxX: try XCTUnwrap(cycle.notchMaxX)
+            ),
+            "Control Center reported left of the notch (672 <= 956) is unsettled geometry; the pass must defer"
+        )
+    }
+
+    /// A settled field cycle (rightBoundary 1562, right of the notch 956) is
+    /// ready and must not be deferred. Guards against a gate that blocks valid
+    /// layouts.
+    func testSettledGeometryFieldCycleIsReady() throws {
+        let log = """
+        2026-06-11 13:13:58.558 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 1 items: ["leits.MeetingBar:Item-0"]
+        2026-06-11 13:13:58.558 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 0 items: []
+        2026-06-11 13:13:58.558 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 0 items: []
+        2026-06-11 13:13:58.559 [DEBUG] [MenuBarItemManager] Notch overflow budget: screen.maxX=1728.0 notch=[771.0…956.0] rightBoundary=1562.0 availableWidth=565.0 userSpacing=0.0 visibleUIDs.count=14 nonProfileCount=0 nonProfileFootprint=0.0 chevronFootprint=17.0 nonProfileBreakdown=[]
+        """
+        let parsed = ProfileLayoutLogReplay.parse(log)
+        let cycle = try XCTUnwrap(parsed.cycles.first)
+
+        XCTAssertEqual(cycle.notchRightBoundary, 1562)
+        XCTAssertEqual(cycle.notchMaxX, 956)
+
+        XCTAssertTrue(
+            LayoutSolver.isMenuBarGeometryReady(
+                rightBoundary: try XCTUnwrap(cycle.notchRightBoundary),
+                notchMaxX: try XCTUnwrap(cycle.notchMaxX)
+            )
+        )
+    }
+
+    /// Boundary cases for the pure gate: strictly right of the notch is ready;
+    /// at the edge, left of it, or non-finite is not.
+    func testGeometryReadyBoundaries() {
+        XCTAssertTrue(LayoutSolver.isMenuBarGeometryReady(rightBoundary: 957, notchMaxX: 956))
+        XCTAssertFalse(LayoutSolver.isMenuBarGeometryReady(rightBoundary: 956, notchMaxX: 956))
+        XCTAssertFalse(LayoutSolver.isMenuBarGeometryReady(rightBoundary: -222, notchMaxX: 956))
+        XCTAssertFalse(LayoutSolver.isMenuBarGeometryReady(rightBoundary: .infinity, notchMaxX: 956))
+        XCTAssertFalse(LayoutSolver.isMenuBarGeometryReady(rightBoundary: .nan, notchMaxX: 956))
+    }
 }
 
 /// Parses Thaw profile-layout log text into replayable cycles and drives the
@@ -297,6 +363,12 @@ enum ProfileLayoutLogReplay {
         /// How many items the cycle logged as overflowing visible -> hidden
         /// (the field verdict for the overflow planner).
         var loggedOverflowCount: Int?
+        /// The notch's right edge (notch.maxX) from the budget line.
+        var notchMaxX: CGFloat?
+        /// The rightBoundary the cycle logged: Control Center's left edge, or
+        /// the screen's right edge when Control Center is absent. The
+        /// geometry-readiness gate compares this against notchMaxX.
+        var notchRightBoundary: CGFloat?
     }
 
     /// The parsed result: the ordered cycles plus the set of menu bar items
@@ -383,8 +455,12 @@ enum ProfileLayoutLogReplay {
                 continue
             }
 
-            if let match = line.firstMatch(of: /Notch overflow budget:.*availableWidth=(-?[0-9.]+)/) {
-                current?.notchAvailableWidth = Double(match.output.1).map { CGFloat($0) }
+            if let match = line.firstMatch(
+                of: /Notch overflow budget:.*notch=\[[0-9.]+…([0-9.]+)\] rightBoundary=(-?[0-9.]+) availableWidth=(-?[0-9.]+)/
+            ) {
+                current?.notchMaxX = Double(match.output.1).map { CGFloat($0) }
+                current?.notchRightBoundary = Double(match.output.2).map { CGFloat($0) }
+                current?.notchAvailableWidth = Double(match.output.3).map { CGFloat($0) }
                 continue
             }
 


### PR DESCRIPTION
# Summary

Three independent, targeted fixes for menu bar layout corruption on multi-display and notched-display setups, each diagnosed from user-submitted diagnostic logs and implemented test-first. They stop the saved layout from being applied or persisted against transient or invalid geometry, and stop a profile apply from permanently disabling saved-layout restoration.

Closes: #702

## PR Type

- [x] Bugfix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

1. Defer the saved-layout apply on unsettled menu bar geometry (`5a0f454b`). On a notched display, `applySavedLayout` now consults `LayoutSolver.isMenuBarGeometryReady(rightBoundary:notchMaxX:)` and skips the bulk apply when Control Center is reported at or left of the notch's right edge, a stale off-screen position seen transiently during a display reconnect or Control Center widget churn. Previously the apply ran against that geometry and mis-positioned the visible control item.

2. Defer the apply and the persist while items span multiple displays (`3149de4f`). A new pure predicate `LayoutSolver.itemsSpanMultipleDisplays(itemCenters:screenFrames:)`, built from `CGDisplayBounds` so it shares the top-left origin coordinate space of the item bounds, detects a menu bar relocation in progress. `applySavedLayout` defers when the managed items straddle two displays, and the persist path in `uncheckedCacheItems` skips `saveSectionOrder` under the same condition. Previously a windowID-change-triggered apply could run mid-relocation, fail to converge across displays, and then bake the failed state into `savedSectionOrder`, permanently corrupting the saved layout.

3. Clear the in-flight profile flag on the no-moves apply exit (`1f1531ce`). `applyProfileLayout`'s early return, taken when the bar is already in the target arrangement (the common case on a display reconnect that re-applies the active-display profile), now runs the same teardown as the normal exit via `concludeProfileApplyWithoutMoves`, which persists on success and clears `isApplyingProfileLayout`. Previously that exit left the flag set, so every later `applySavedLayout` was skipped with "profile apply in flight" and the saved layout could never be restored for the rest of the session.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

All three fixes are covered by unit tests written red then green: `DisplaySpreadGateTests` (display-spread predicate), `ProfileApplyInFlightFlagTests` (no-moves exit clears the flag), and geometry-readiness additions in `ProfileLayoutLogReplayTests`. The full `ThawTests` suite passes and `swiftlint` reports zero violations.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar item placement on notched displays by waiting for display geometry to stabilize before applying layout changes.
  * Prevented menu bar items from being misplaced during macOS display transitions when items temporarily span multiple screens.

* **Tests**
  * Added comprehensive tests for multi-display item detection and profile apply lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->