### PR TITLE
fix(menubar): fall back from stale display ID in image cache

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -13,6 +13,67 @@ import os.lock
 /// Cache for menu bar item images.
 final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
     private static nonisolated let diagLog = DiagLog(category: "MenuBarItemImageCache")
+
+    struct DisplayResolution: Equatable {
+        let displayID: CGDirectDisplayID
+        let usedFallback: Bool
+    }
+
+    static func resolveDisplayID(
+        preferredDisplayID: CGDirectDisplayID?,
+        availableDisplayIDs: [CGDirectDisplayID],
+        activeMenuBarDisplayID: CGDirectDisplayID?,
+        mainDisplayID: CGDirectDisplayID
+    ) -> DisplayResolution? {
+        guard !availableDisplayIDs.isEmpty else {
+            return nil
+        }
+
+        if let preferredDisplayID, availableDisplayIDs.contains(preferredDisplayID) {
+            return DisplayResolution(displayID: preferredDisplayID, usedFallback: false)
+        }
+
+        if let activeMenuBarDisplayID, availableDisplayIDs.contains(activeMenuBarDisplayID) {
+            return DisplayResolution(
+                displayID: activeMenuBarDisplayID,
+                usedFallback: preferredDisplayID != nil
+            )
+        }
+
+        if availableDisplayIDs.contains(mainDisplayID) {
+            return DisplayResolution(
+                displayID: mainDisplayID,
+                usedFallback: preferredDisplayID != nil
+            )
+        }
+
+        return DisplayResolution(
+            displayID: availableDisplayIDs[0],
+            usedFallback: preferredDisplayID != nil
+        )
+    }
+
+    @MainActor
+    private static func resolveScreen(
+        preferredDisplayID: CGDirectDisplayID?,
+        screens: [NSScreen] = NSScreen.screens
+    ) -> (screen: NSScreen, usedFallback: Bool)? {
+        guard let resolution = resolveDisplayID(
+            preferredDisplayID: preferredDisplayID,
+            availableDisplayIDs: screens.map(\.displayID),
+            activeMenuBarDisplayID: Bridging.getActiveMenuBarDisplayID(),
+            mainDisplayID: CGMainDisplayID()
+        ) else {
+            return nil
+        }
+
+        guard let screen = screens.first(where: { $0.displayID == resolution.displayID }) else {
+            return nil
+        }
+
+        return (screen, resolution.usedFallback)
+    }
+
     /// A representation of a captured menu bar item image.
     struct CapturedImage: Hashable {
         /// The base image.
@@ -564,12 +625,16 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
 
             let nav = appState.navigationState
 
-            // Determine display
-            let displayID = appState.itemManager.itemCache.displayID
-                ?? Bridging.getActiveMenuBarDisplayID()
-                ?? CGMainDisplayID()
-            guard let screen = NSScreen.screens.first(where: { $0.displayID == displayID }) else {
+            let preferredDisplayID = appState.itemManager.itemCache.displayID
+            guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+                MenuBarItemImageCache.diagLog.warning("liveRefresh: no connected screens available, skipping")
                 continue
+            }
+            let screen = resolvedScreen.screen
+            if resolvedScreen.usedFallback, let preferredDisplayID {
+                MenuBarItemImageCache.diagLog.warning(
+                    "liveRefresh: cached displayID \(preferredDisplayID) is not connected; using displayID \(screen.displayID)"
+                )
             }
 
             // Determine which sections to refresh based on what's visible
@@ -1281,16 +1346,21 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
             return
         }
 
-        guard let displayID = appState.itemManager.itemCache.displayID else {
+        let preferredDisplayID = appState.itemManager.itemCache.displayID
+        guard preferredDisplayID != nil else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: itemCache.displayID is nil, aborting")
             return
         }
 
-        guard let screen = NSScreen.screens.first(where: {
-            $0.displayID == displayID
-        }) else {
-            MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: no screen found for displayID \(displayID)")
+        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+            MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: no connected screens available, aborting")
             return
+        }
+        let screen = resolvedScreen.screen
+        if resolvedScreen.usedFallback, let preferredDisplayID {
+            MenuBarItemImageCache.diagLog.warning(
+                "updateCacheWithoutChecks: cached displayID \(preferredDisplayID) is not connected; using displayID \(screen.displayID)"
+            )
         }
 
         let scale = screen.backingScaleFactor

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -1347,11 +1347,6 @@ final class MenuBarItemImageCache: ObservableObject, @unchecked Sendable {
         }
 
         let preferredDisplayID = appState.itemManager.itemCache.displayID
-        guard preferredDisplayID != nil else {
-            MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: itemCache.displayID is nil, aborting")
-            return
-        }
-
         guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: no connected screens available, aborting")
             return

--- a/ThawTests/MenuBarItemImageCacheDisplayResolutionTests.swift
+++ b/ThawTests/MenuBarItemImageCacheDisplayResolutionTests.swift
@@ -33,6 +33,17 @@ final class ImageCacheDisplayResolutionTests: XCTestCase {
         XCTAssertEqual(resolution, .init(displayID: 300, usedFallback: true))
     }
 
+    func testNilPreferredDisplayFallsBackToActiveWithoutStaleDisplayFallback() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: nil,
+            availableDisplayIDs: [100, 200, 300],
+            activeMenuBarDisplayID: 300,
+            mainDisplayID: 100
+        )
+
+        XCTAssertEqual(resolution, .init(displayID: 300, usedFallback: false))
+    }
+
     func testFallsBackToMainDisplayWhenPreferredAndActiveAreStale() {
         let resolution = MenuBarItemImageCache.resolveDisplayID(
             preferredDisplayID: 999,

--- a/ThawTests/MenuBarItemImageCacheDisplayResolutionTests.swift
+++ b/ThawTests/MenuBarItemImageCacheDisplayResolutionTests.swift
@@ -1,0 +1,68 @@
+//
+//  MenuBarItemImageCacheDisplayResolutionTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+@testable import Thaw
+import XCTest
+
+final class ImageCacheDisplayResolutionTests: XCTestCase {
+    func testUsesPreferredDisplayWhenConnected() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: 200,
+            availableDisplayIDs: [100, 200, 300],
+            activeMenuBarDisplayID: 300,
+            mainDisplayID: 100
+        )
+
+        XCTAssertEqual(resolution, .init(displayID: 200, usedFallback: false))
+    }
+
+    func testCachedDisplayIDFromDisconnectedMonitorShouldNotAbortImageCaching() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: 999,
+            availableDisplayIDs: [100, 200, 300],
+            activeMenuBarDisplayID: 300,
+            mainDisplayID: 100
+        )
+
+        XCTAssertEqual(resolution, .init(displayID: 300, usedFallback: true))
+    }
+
+    func testFallsBackToMainDisplayWhenPreferredAndActiveAreStale() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: 999,
+            availableDisplayIDs: [100, 200, 300],
+            activeMenuBarDisplayID: 888,
+            mainDisplayID: 200
+        )
+
+        XCTAssertEqual(resolution, .init(displayID: 200, usedFallback: true))
+    }
+
+    func testFallsBackToFirstScreenWhenNoPreferredActiveOrMainMatchExists() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: 999,
+            availableDisplayIDs: [100, 200, 300],
+            activeMenuBarDisplayID: 888,
+            mainDisplayID: 777
+        )
+
+        XCTAssertEqual(resolution, .init(displayID: 100, usedFallback: true))
+    }
+
+    func testReturnsNilForEmptyScreenList() {
+        let resolution = MenuBarItemImageCache.resolveDisplayID(
+            preferredDisplayID: 999,
+            availableDisplayIDs: [],
+            activeMenuBarDisplayID: 888,
+            mainDisplayID: 777
+        )
+
+        XCTAssertNil(resolution)
+    }
+}


### PR DESCRIPTION
# Summary

After monitor changes, a stale cached menu bar `displayID` could leave image capture with no screen. Falls back to active menu bar display → main display → first connected screen.

**Scope:** Display-ID fallback chain for menu bar image cache refresh after monitor disconnect/change.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Image cache refresh no longer aborts solely because a preferred/cached display ID is disconnected or transient; it resolves a usable screen via the fallback chain and continues capture.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test -only-testing:ThawTests/ImageCacheDisplayResolutionTests` (CODE_SIGNING_ALLOWED=NO)

## Known limitations / follow-ups

- (none)

## Other information

Validated with SwiftFormat/SwiftLint on touched files.
