### PR TITLE
fix(menubar): make pre-move input-pause threshold configurable

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2423,10 +2423,17 @@ extension MenuBarItemManager {
 
     /// Waits asynchronously for the user to pause input.
     private nonisolated func waitForUserToPauseInput() async throws {
+        // The pre-move input-pause window is configurable so users hit by repeated cursor
+        // "kidnapping" during menu-bar reordering can widen it. Reordering warps the real cursor,
+        // and a very short window lets warps slip through the micro-gaps between a user's own mouse
+        // moves when a churny app keeps changing its menu-bar items (see #750, #723, #736). The
+        // default preserves the previous 50 ms behaviour; override with:
+        //   defaults write com.stonerl.Thaw inputPauseThresholdMs -int <milliseconds>
+        let pauseMs = max(0, (UserDefaults.standard.object(forKey: "inputPauseThresholdMs") as? Int) ?? 50)
         let waitTask = Task {
             while true {
                 try Task.checkCancellation()
-                if hasUserPausedInput(for: .milliseconds(50)) {
+                if hasUserPausedInput(for: .milliseconds(pauseMs)) {
                     break
                 }
                 try await Task.sleep(for: .milliseconds(50))


### PR DESCRIPTION
# Summary

Makes the pre-move input-pause threshold in `waitForUserToPauseInput()` configurable via the `inputPauseThresholdMs` UserDefaults key, so users who hit cursor “kidnapping” during menu-bar reordering can widen the idle window. Default remains 50 ms (unchanged unless the key is set).

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #750 (also related: #723, #736)

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Before a move/reorder, Thaw waits for `inputPauseThresholdMs` milliseconds of no input (default 50). Affected users can raise it, e.g.:

```
defaults write com.stonerl.Thaw inputPauseThresholdMs -int 400
```

This is an opt-in mitigation complementary to cursor-free reorder work; unset behavior matches prior releases.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [ ] I've updated documentation as needed

## Other information

Built and run locally on macOS 26.2 with Xcode 26.6; with a raised threshold, the cursor is no longer warped while moving, and reordering resumes when idle.