### PR TITLE
docs(readme): reflect macOS 27 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <img src="Resources/headers/Header_Light.svg" width="400" alt="Thaw Header" />
   </picture>
 </p>
-Thaw is a powerful menu bar management tool for macOS 26. While its primary function is hiding and showing menu bar items, it aims to cover a wide variety of additional features to make it one of the most versatile menu bar tools available.
+Thaw is a powerful menu bar management tool for macOS 26 and macOS 27. While its primary function is hiding and showing menu bar items, it aims to cover a wide variety of additional features to make it one of the most versatile menu bar tools available.
 
 <br>
 
@@ -105,6 +105,8 @@ If a language you'd like to help to translate is not listed here, let us know an
 <details>
 <summary>Click to view the full features list</summary>
 
+- macOS 27 (Golden Gate) support
+
 ### Menu bar item management
 
 - Hide menu bar items
@@ -146,7 +148,6 @@ If a language you'd like to help to translate is not listed here, let us know an
 
 <br>
 
-- **macOS 27 support** — compatibility with the next macOS release.
 - **Menu bar item management** — individual spacer items; menu bar item groups; show menu bar items when trigger conditions are met
 - **Menu bar appearance** — rounded screen corners
 - **Hotkeys** — enable/disable auto rehide; temporarily show individual menu bar items


### PR DESCRIPTION
# Summary

Cherry-picks the README update from `feat/macos-27-experimental` onto `integration/sanitize-dev`. Complements the existing issue #687 status banner on `development` by updating the tagline and features list.

Closes: N/A

## PR Type

- [ ] Bugfix
- [ ] CI/CD
- [x] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Tagline now reads "macOS 26 and macOS 27"
- macOS 27 (Golden Gate) support added to the shipped features list
- macOS 27 removed from the roadmap section (now reflected as shipped)

Docs-only — no runtime or build changes.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

Part of the `feat/macos-27-experimental` → `integration/sanitize-dev` extraction plan (PR B). Standalone README PR, kept separate from build/CI changes in #761.