### PR TITLE
feat(layout): reset target picker with legacy section moves

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
@@ -202,7 +202,7 @@ extension MenuBarItemManager {
                 do {
                     try await move(
                         item: item,
-                        to: .rightOfItem(alwaysHiddenControl),
+                        to: .leftOfItem(alwaysHiddenControl),
                         skipInputPause: true,
                         watchdogTimeout: Self.layoutWatchdogTimeout
                     )

--- a/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
@@ -84,7 +84,6 @@ extension MenuBarItemManager {
         }
 
         return try await layoutResetMoveItemsToAlwaysHidden(
-            controlItems: controlItems,
             alwaysHiddenControl: alwaysHiddenControl,
             items: items
         )
@@ -166,7 +165,6 @@ extension MenuBarItemManager {
     }
 
     private func layoutResetMoveItemsToAlwaysHidden(
-        controlItems: ControlItemPair,
         alwaysHiddenControl: MenuBarItem,
         items: [MenuBarItem]
     ) async throws -> Int {

--- a/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
@@ -181,8 +181,6 @@ extension MenuBarItemManager {
             appState.hidEventManager.startAll()
         }
 
-        let hiddenControlBounds = Bridging.getWindowBounds(for: controlItems.hidden.windowID)
-            ?? controlItems.hidden.bounds
         let alwaysHiddenControlBounds = Bridging.getWindowBounds(for: alwaysHiddenControl.windowID)
             ?? alwaysHiddenControl.bounds
 
@@ -194,9 +192,7 @@ extension MenuBarItemManager {
                     return false
                 }
                 let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
-                let inAlwaysHiddenBand = bounds.minX >= alwaysHiddenControlBounds.maxX
-                    && bounds.maxX <= hiddenControlBounds.minX
-                return !inAlwaysHiddenBand
+                return bounds.maxX > alwaysHiddenControlBounds.minX
             }
         }
 
@@ -227,8 +223,6 @@ extension MenuBarItemManager {
             let refreshedControls = layoutResetControlItemPair(from: &refreshedItems),
             let refreshedAlwaysHidden = refreshedControls.alwaysHidden
         {
-            let refreshedHiddenBounds = Bridging.getWindowBounds(for: refreshedControls.hidden.windowID)
-                ?? refreshedControls.hidden.bounds
             let refreshedAlwaysHiddenBounds = Bridging.getWindowBounds(for: refreshedAlwaysHidden.windowID)
                 ?? refreshedAlwaysHidden.bounds
             let notYetInAlwaysHidden = refreshedItems.filter { item in
@@ -238,9 +232,7 @@ extension MenuBarItemManager {
                     return false
                 }
                 let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
-                let inAlwaysHiddenBand = bounds.minX >= refreshedAlwaysHiddenBounds.maxX
-                    && bounds.maxX <= refreshedHiddenBounds.minX
-                return !inAlwaysHiddenBand
+                return bounds.maxX > refreshedAlwaysHiddenBounds.minX
             }
             if !notYetInAlwaysHidden.isEmpty {
                 MenuBarItemManager.diagLog.debug("Reset-to-always-hidden pass 2: \(notYetInAlwaysHidden.count) items not yet in always-hidden section")

--- a/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
@@ -1,0 +1,254 @@
+//
+//  LayoutResetLegacy.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+
+// MARK: - LayoutResetTarget
+
+/// Destination section for a user-initiated layout reset from Settings.
+enum LayoutResetTarget {
+    case visible
+    case hidden
+    case alwaysHidden
+}
+
+// MARK: - LayoutResetLegacy
+
+extension MenuBarItemManager {
+    /// Resets layout to the given section using legacy control-item moves.
+    func resetLayout(to target: LayoutResetTarget) async throws -> Int {
+        switch target {
+        case .hidden:
+            try await resetLayoutToFreshState()
+        case .visible:
+            try await resetLayoutToVisible()
+        case .alwaysHidden:
+            try await resetLayoutToAlwaysHidden()
+        }
+    }
+
+    /// Moves every movable, hideable item to the visible section.
+    func resetLayoutToVisible() async throws -> Int {
+        MenuBarItemManager.diagLog.info("Resetting menu bar layout to visible")
+
+        layoutResetBeginUserOperation()
+        defer { layoutResetEndUserOperation() }
+
+        guard appState != nil else {
+            throw LayoutResetError.missingAppState
+        }
+
+        layoutResetClearPinnedSectionPreferences()
+
+        var items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+
+        guard let controlItems = layoutResetControlItemPair(from: &items) else {
+            throw LayoutResetError.missingControlItems
+        }
+
+        return try await layoutResetMoveItemsToVisible(
+            controlItems: controlItems,
+            items: items
+        )
+    }
+
+    /// Moves every movable, hideable item to the always-hidden section.
+    func resetLayoutToAlwaysHidden() async throws -> Int {
+        MenuBarItemManager.diagLog.info("Resetting menu bar layout to always-hidden")
+
+        layoutResetBeginUserOperation()
+        defer { layoutResetEndUserOperation() }
+
+        guard let appState else {
+            throw LayoutResetError.missingAppState
+        }
+
+        guard appState.settings.advanced.enableAlwaysHiddenSection else {
+            throw LayoutResetError.alwaysHiddenSectionDisabled
+        }
+
+        layoutResetClearPinnedSectionPreferences()
+
+        var items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+
+        guard
+            let controlItems = layoutResetControlItemPair(from: &items),
+            let alwaysHiddenControl = controlItems.alwaysHidden
+        else {
+            throw LayoutResetError.missingControlItems
+        }
+
+        return try await layoutResetMoveItemsToAlwaysHidden(
+            controlItems: controlItems,
+            alwaysHiddenControl: alwaysHiddenControl,
+            items: items
+        )
+    }
+
+    private func layoutResetMoveItemsToVisible(
+        controlItems: ControlItemPair,
+        items: [MenuBarItem]
+    ) async throws -> Int {
+        guard let appState else {
+            throw LayoutResetError.missingAppState
+        }
+
+        appState.menuBarManager.iceBarPanel.close()
+
+        appState.hidEventManager.stopAll()
+        defer {
+            appState.hidEventManager.startAll()
+        }
+
+        let hiddenControlBounds = Bridging.getWindowBounds(for: controlItems.hidden.windowID)
+            ?? controlItems.hidden.bounds
+
+        func itemsNotInVisible(_ items: [MenuBarItem]) -> [MenuBarItem] {
+            items.filter { item in
+                guard item.isMovable, item.canBeHidden, !item.isControlItem,
+                      item.tag != .visibleControlItem
+                else {
+                    return false
+                }
+                let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
+                return bounds.minX < hiddenControlBounds.maxX
+            }
+        }
+
+        func movePass(_ items: [MenuBarItem]) async -> Int {
+            var failed = 0
+            for item in items {
+                do {
+                    try await move(
+                        item: item,
+                        to: .rightOfItem(controlItems.hidden),
+                        skipInputPause: true,
+                        watchdogTimeout: Self.layoutWatchdogTimeout
+                    )
+                } catch {
+                    failed += 1
+                    MenuBarItemManager.diagLog.error("Failed to move \(item.logString) during reset-to-visible: \(error)")
+                }
+            }
+            return failed
+        }
+
+        var failedMoves = await movePass(itemsNotInVisible(items))
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        var refreshedItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        if let refreshedControls = layoutResetControlItemPair(from: &refreshedItems) {
+            let refreshedHiddenBounds = Bridging.getWindowBounds(for: refreshedControls.hidden.windowID)
+                ?? refreshedControls.hidden.bounds
+            let notYetInVisible = refreshedItems.filter { item in
+                guard item.isMovable, item.canBeHidden, !item.isControlItem,
+                      item.tag != .visibleControlItem
+                else {
+                    return false
+                }
+                let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
+                return bounds.minX < refreshedHiddenBounds.maxX
+            }
+            if !notYetInVisible.isEmpty {
+                MenuBarItemManager.diagLog.debug("Reset-to-visible pass 2: \(notYetInVisible.count) items not yet in visible section")
+                failedMoves += await movePass(notYetInVisible)
+            }
+        }
+
+        await layoutResetRefreshCachesAfterSectionMoves()
+        return failedMoves
+    }
+
+    private func layoutResetMoveItemsToAlwaysHidden(
+        controlItems: ControlItemPair,
+        alwaysHiddenControl: MenuBarItem,
+        items: [MenuBarItem]
+    ) async throws -> Int {
+        guard let appState else {
+            throw LayoutResetError.missingAppState
+        }
+
+        appState.menuBarManager.iceBarPanel.close()
+
+        appState.hidEventManager.stopAll()
+        defer {
+            appState.hidEventManager.startAll()
+        }
+
+        let hiddenControlBounds = Bridging.getWindowBounds(for: controlItems.hidden.windowID)
+            ?? controlItems.hidden.bounds
+        let alwaysHiddenControlBounds = Bridging.getWindowBounds(for: alwaysHiddenControl.windowID)
+            ?? alwaysHiddenControl.bounds
+
+        func itemsNotInAlwaysHidden(_ items: [MenuBarItem]) -> [MenuBarItem] {
+            items.filter { item in
+                guard item.isMovable, item.canBeHidden, !item.isControlItem,
+                      item.tag != .visibleControlItem
+                else {
+                    return false
+                }
+                let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
+                let inAlwaysHiddenBand = bounds.minX >= alwaysHiddenControlBounds.maxX
+                    && bounds.maxX <= hiddenControlBounds.minX
+                return !inAlwaysHiddenBand
+            }
+        }
+
+        func movePass(_ items: [MenuBarItem]) async -> Int {
+            var failed = 0
+            for item in items {
+                do {
+                    try await move(
+                        item: item,
+                        to: .rightOfItem(alwaysHiddenControl),
+                        skipInputPause: true,
+                        watchdogTimeout: Self.layoutWatchdogTimeout
+                    )
+                } catch {
+                    failed += 1
+                    MenuBarItemManager.diagLog.error("Failed to move \(item.logString) during reset-to-always-hidden: \(error)")
+                }
+            }
+            return failed
+        }
+
+        var failedMoves = await movePass(itemsNotInAlwaysHidden(items))
+
+        try? await Task.sleep(for: .milliseconds(200))
+
+        var refreshedItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        if
+            let refreshedControls = layoutResetControlItemPair(from: &refreshedItems),
+            let refreshedAlwaysHidden = refreshedControls.alwaysHidden
+        {
+            let refreshedHiddenBounds = Bridging.getWindowBounds(for: refreshedControls.hidden.windowID)
+                ?? refreshedControls.hidden.bounds
+            let refreshedAlwaysHiddenBounds = Bridging.getWindowBounds(for: refreshedAlwaysHidden.windowID)
+                ?? refreshedAlwaysHidden.bounds
+            let notYetInAlwaysHidden = refreshedItems.filter { item in
+                guard item.isMovable, item.canBeHidden, !item.isControlItem,
+                      item.tag != .visibleControlItem
+                else {
+                    return false
+                }
+                let bounds = Bridging.getWindowBounds(for: item.windowID) ?? item.bounds
+                let inAlwaysHiddenBand = bounds.minX >= refreshedAlwaysHiddenBounds.maxX
+                    && bounds.maxX <= refreshedHiddenBounds.minX
+                return !inAlwaysHiddenBand
+            }
+            if !notYetInAlwaysHidden.isEmpty {
+                MenuBarItemManager.diagLog.debug("Reset-to-always-hidden pass 2: \(notYetInAlwaysHidden.count) items not yet in always-hidden section")
+                failedMoves += await movePass(notYetInAlwaysHidden)
+            }
+        }
+
+        await layoutResetRefreshCachesAfterSectionMoves()
+        return failedMoves
+    }
+}

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -126,7 +126,7 @@ final class MenuBarItemManager: ObservableObject {
     @Published private(set) var areControlItemsMissing = false
 
     /// Diagnostic logger for the menu bar item manager.
-    fileprivate static nonisolated let diagLog = DiagLog(category: "MenuBarItemManager")
+    static nonisolated let diagLog = DiagLog(category: "MenuBarItemManager")
 
     /// Semaphore to prevent overlapping event operations.
     private let eventSemaphore = SimpleSemaphore(value: 1)
@@ -5207,6 +5207,7 @@ extension MenuBarItemManager {
     enum LayoutResetError: LocalizedError {
         case missingAppState
         case missingControlItems
+        case alwaysHiddenSectionDisabled
 
         var errorDescription: String? {
             switch self {
@@ -5214,6 +5215,8 @@ extension MenuBarItemManager {
                 "Unable to access app state"
             case .missingControlItems:
                 "Couldn't find section dividers in the menu bar"
+            case .alwaysHiddenSectionDisabled:
+                "The always-hidden section is disabled"
             }
         }
 
@@ -5446,6 +5449,82 @@ extension MenuBarItemManager {
         NSScreen.invalidateMenuBarHeightCache()
 
         return failedMoves
+    }
+
+    // MARK: Layout reset helpers (LayoutResetLegacy.swift)
+
+    func layoutResetBeginUserOperation() {
+        startupSettlingTask?.cancel()
+        isInStartupSettling = false
+        settlingDeadline = nil
+        settlingExpectedBundleIDs.removeAll()
+        settlingKind = nil
+        isResettingLayout = true
+    }
+
+    func layoutResetEndUserOperation() {
+        isResettingLayout = false
+    }
+
+    func layoutResetClearPinnedSectionPreferences() {
+        pinnedHiddenBundleIDs.removeAll()
+        pinnedAlwaysHiddenBundleIDs.removeAll()
+        persistPinnedBundleIDs()
+        savedSectionOrder.removeAll()
+        persistSavedSectionOrder()
+        temporarilyShownItemContexts.removeAll()
+    }
+
+    func layoutResetControlItemPair(from items: inout [MenuBarItem]) -> ControlItemPair? {
+        guard let appState else {
+            return nil
+        }
+
+        let hiddenWID: CGWindowID? = appState.menuBarManager
+            .controlItem(withName: .hidden)?.window
+            .flatMap { CGWindowID(exactly: $0.windowNumber) }
+        let alwaysHiddenWID: CGWindowID? = appState.menuBarManager
+            .controlItem(withName: .alwaysHidden)?.window
+            .flatMap { CGWindowID(exactly: $0.windowNumber) }
+
+        return ControlItemPair(
+            items: &items,
+            hiddenControlItemWindowID: hiddenWID,
+            alwaysHiddenControlItemWindowID: alwaysHiddenWID
+        )
+    }
+
+    func layoutResetRefreshCachesAfterSectionMoves() async {
+        guard let appState else {
+            return
+        }
+
+        cacheActor.clearCachedItemWindowIDs()
+        itemCache = ItemCache(displayID: nil)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            self.backgroundCacheContinuation = continuation
+            Task { [weak self] in
+                await self?.cacheItemsRegardless(skipRecentMoveCheck: true)
+            }
+        }
+
+        await MainActor.run {
+            appState.imageCache.clearAll()
+            appState.imageCache.performCacheCleanup()
+        }
+
+        if itemCache.displayID != nil {
+            await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
+        } else {
+            try? await Task.sleep(for: .milliseconds(350))
+            await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
+        }
+
+        await MainActor.run {
+            appState.objectWillChange.send()
+        }
+
+        NSScreen.invalidateMenuBarHeightCache()
     }
 
     /// Wrapper for UI callers; kept separate for clarity in call sites.
@@ -6712,7 +6791,7 @@ extension MenuBarItemManager {
     /// which on a notched display drifts items into always-hidden. A display
     /// switch is not a layout edit, so it must not advance the gate; the
     /// divergence check still runs and catches genuine section drift.
-    nonisolated static func windowIDsChanged(
+    static nonisolated func windowIDsChanged(
         previous: Set<CGWindowID>,
         current: Set<CGWindowID>,
         previousDisplayID: CGDirectDisplayID?,

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -120,7 +120,7 @@ struct MenuBarLayoutSettingsPane: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Reset menu bar layout")
                             .font(.headline)
-                        Text("Moves every movable item except the \(Constants.displayName) icon to the selected section — just like a fresh install.")
+                        Text("Moves every movable item except the \(Constants.displayName) icon to the section you select.")
                             .font(.footnote)
                             .foregroundStyle(.secondary)
                             .fixedSize(horizontal: false, vertical: true)
@@ -160,7 +160,7 @@ struct MenuBarLayoutSettingsPane: View {
                 isConfirmingReset = false
             }
         } message: {
-            Text("Moves every movable item except the \(Constants.displayName) icon to the chosen section.")
+            Text("Moves every movable item except the \(Constants.displayName) icon to the section you select.")
         }
     }
 
@@ -267,7 +267,7 @@ struct MenuBarLayoutSettingsPane: View {
             case .successToAlwaysHidden:
                 String(localized: "Layout reset. Items were moved to the Always Hidden section.")
             case .successToVisible:
-                String(localized: "Items were moved to the Visible section.")
+                String(localized: "Layout reset. Items were moved to the Visible section.")
             case let .partialFailure(count):
                 String(localized: "Reset completed with \(count) item(s) that could not be moved. Check the menu bar and try again if needed.")
             case let .failure(message):

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -114,49 +114,53 @@ struct MenuBarLayoutSettingsPane: View {
     }
 
     private var resetControls: some View {
-        IceSection {
-            HStack(alignment: .firstTextBaseline, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Reset menu bar layout")
-                        .font(.headline)
-                    Text("Resets dividers and moves every movable item except the \(Constants.displayName) icon to hidden — just like a fresh install.")
-                        .font(.footnote)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
-                }
-
-                Spacer(minLength: 12)
-
-                Button {
-                    isConfirmingReset = true
-                } label: {
-                    if isResettingLayout {
-                        ProgressView()
-                            .controlSize(.small)
-                    } else {
-                        Text("Reset Layout")
+        IceSection(options: [.isBordered]) {
+            VStack(alignment: .leading, spacing: 12) {
+                HStack(alignment: .top, spacing: 12) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Reset menu bar layout")
+                            .font(.headline)
+                        Text("Moves every movable item except the \(Constants.displayName) icon to the selected section — just like a fresh install.")
+                            .font(.footnote)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
-                }
-                .buttonStyle(.bordered)
-                .disabled(isResettingLayout || areControlItemsDisabledBySystem)
-            }
 
-            if let resetStatus {
-                Text(resetStatus.message)
-                    .font(.footnote)
-                    .foregroundStyle(resetStatus.isError ? .red : .secondary)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+                    Spacer(minLength: 16)
+
+                    Button {
+                        isConfirmingReset = true
+                    } label: {
+                        if isResettingLayout {
+                            ProgressView()
+                                .controlSize(.small)
+                        } else {
+                            Text("Reset Layout…")
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isResettingLayout || areControlItemsDisabledBySystem)
+                }
+
+                if let resetStatus {
+                    Text(resetStatus.message)
+                        .font(.footnote)
+                        .foregroundStyle(resetStatus.isError ? .red : .secondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
             }
         }
-        .alert("Reset menu bar layout?", isPresented: $isConfirmingReset) {
-            Button("Reset", role: .destructive) {
-                resetMenuBarLayout()
+        .confirmationDialog("Reset to…", isPresented: $isConfirmingReset) {
+            Button("Reset to Visible") { resetMenuBarLayout(to: .visible) }
+            Button("Reset to Hidden") { resetMenuBarLayout(to: .hidden) }
+            if appState.settings.advanced.enableAlwaysHiddenSection {
+                Button("Reset to Always Hidden") { resetMenuBarLayout(to: .alwaysHidden) }
             }
             Button("Cancel", role: .cancel) {
                 isConfirmingReset = false
             }
         } message: {
-            Text("Restores divider defaults and moves every movable item except the \(Constants.displayName) icon to Hidden. Use this if the layout looks broken or items won’t load.")
+            Text("Moves every movable item except the \(Constants.displayName) icon to the chosen section.")
         }
     }
 
@@ -204,7 +208,7 @@ struct MenuBarLayoutSettingsPane: View {
         }
     }
 
-    private func resetMenuBarLayout() {
+    private func resetMenuBarLayout(to target: LayoutResetTarget) {
         isResettingLayout = true
         resetStatus = nil
 
@@ -212,16 +216,20 @@ struct MenuBarLayoutSettingsPane: View {
 
         Task { @MainActor in
             do {
-                let failedMoves = try await manager.resetLayoutToFreshState()
+                let failedMoves = try await manager.resetLayout(to: target)
                 if failedMoves == 0 {
-                    resetStatus = .success
+                    resetStatus = switch target {
+                    case .hidden:
+                        .successToHidden
+                    case .alwaysHidden:
+                        .successToAlwaysHidden
+                    case .visible:
+                        .successToVisible
+                    }
                 } else {
                     resetStatus = .partialFailure(failedMoves)
                 }
                 isResettingLayout = false
-
-                // cacheItemsRegardless + updateCacheWithoutChecks already run
-                // inside resetLayoutToFreshState() — no need to repeat here.
             } catch {
                 resetStatus = .failure(error.localizedDescription)
                 isResettingLayout = false
@@ -246,14 +254,20 @@ struct MenuBarLayoutSettingsPane: View {
     }
 
     private enum ResetStatus {
-        case success
+        case successToHidden
+        case successToAlwaysHidden
+        case successToVisible
         case partialFailure(Int)
         case failure(String)
 
         var message: String {
             switch self {
-            case .success:
+            case .successToHidden:
                 String(localized: "Layout reset. Items were moved to the Hidden section.")
+            case .successToAlwaysHidden:
+                String(localized: "Layout reset. Items were moved to the Always Hidden section.")
+            case .successToVisible:
+                String(localized: "Items were moved to the Visible section.")
             case let .partialFailure(count):
                 String(localized: "Reset completed with \(count) item(s) that could not be moved. Check the menu bar and try again if needed.")
             case let .failure(message):
@@ -265,7 +279,7 @@ struct MenuBarLayoutSettingsPane: View {
             switch self {
             case .failure, .partialFailure:
                 true
-            case .success:
+            case .successToHidden, .successToAlwaysHidden, .successToVisible:
                 false
             }
         }

--- a/ThawTests/LayoutResetErrorTests.swift
+++ b/ThawTests/LayoutResetErrorTests.swift
@@ -34,6 +34,11 @@ final class LayoutResetErrorTests: XCTestCase {
         XCTAssertEqual(error.errorDescription, "Couldn't find section dividers in the menu bar")
     }
 
+    func testAlwaysHiddenSectionDisabledErrorDescription() {
+        let error = MenuBarItemManager.LayoutResetError.alwaysHiddenSectionDisabled
+        XCTAssertEqual(error.errorDescription, "The always-hidden section is disabled")
+    }
+
     // MARK: - Recovery Suggestion
 
     func testMissingAppStateRecoverySuggestion() {

--- a/ThawTests/LayoutResetErrorTests.swift
+++ b/ThawTests/LayoutResetErrorTests.swift
@@ -97,6 +97,7 @@ final class LayoutResetErrorTests: XCTestCase {
         let allCases: [MenuBarItemManager.LayoutResetError] = [
             .missingAppState,
             .missingControlItems,
+            .alwaysHiddenSectionDisabled,
         ]
 
         for error in allCases {
@@ -109,6 +110,7 @@ final class LayoutResetErrorTests: XCTestCase {
         let allCases: [MenuBarItemManager.LayoutResetError] = [
             .missingAppState,
             .missingControlItems,
+            .alwaysHiddenSectionDisabled,
         ]
 
         for error in allCases {
@@ -124,6 +126,8 @@ final class LayoutResetErrorTests: XCTestCase {
         case (.missingAppState, .missingAppState):
             return true
         case (.missingControlItems, .missingControlItems):
+            return true
+        case (.alwaysHiddenSectionDisabled, .alwaysHiddenSectionDisabled):
             return true
         default:
             return false

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -52,6 +52,7 @@ $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarScrollView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/LayoutReconciler.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/LayoutResetLegacy.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift


### PR DESCRIPTION
## Summary

- Adds a **Reset Layout…** confirmation dialog with Visible, Hidden, and Always Hidden targets in Menu Bar Layout settings.
- Extracts macOS 26 reset move logic into `LayoutResetLegacy.swift`; existing `resetLayoutToFreshState()` remains the Hidden path.
- Always Hidden option appears only when the always-hidden section is enabled in Advanced settings.

## PR Type

- [x] Feature
- [x] Test addition or update

## Does this PR introduce a breaking change?

- [x] No

## What is the new behavior?

Users can reset all movable items to Visible, Hidden, or Always Hidden via a single picker instead of a Hidden-only button. macOS 27 assignment-model resets (`SimpleItemHider` / `resetLayoutMacOS27`) are intentionally **not** included — those ship with the macOS 27 hiding stack.

Closes: N/A

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable)
- [ ] I've updated documentation as needed

## Test plan

- [x] `swiftlint --strict`
- [x] `LayoutResetErrorTests`
- [x] xcodebuild build
- [ ] Manual: Reset to Visible / Hidden / Always Hidden from Settings → Menu Bar Layout
- [ ] Manual: confirm Always Hidden option hidden when section disabled

## Other information

Part of the `integration/sanitize-dev` extraction series (**PR F — reset picker**). Independent of search (#763) and onboarding (#764).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new menu bar layout reset dialog that lets you choose where to reset items: **Visible**, **Hidden**, or **Always Hidden**.
  * Added clearer status messages showing whether the reset completed successfully or only partially.

* **Bug Fixes**
  * Improved layout reset behavior so items are repositioned more reliably and layout data is refreshed after changes.
  * Added a clearer message when the **Always Hidden** reset option is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->