### PR TITLE
fix(menubar): keep menu bar move events out of screen corners

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2946,6 +2946,23 @@ extension MenuBarItemManager {
             }
         }
 
+        /// Returns the drag point for placing an item relative to the target bounds.
+        ///
+        /// Targets parked beyond the display's left edge use their vertical
+        /// midpoint so a synthetic event clamped to the edge cannot land on a
+        /// top Hot Corner. On-screen targets retain the existing top-edge
+        /// coordinate to avoid changing normal cursor-warp behavior.
+        func targetPoint(in targetBounds: CGRect, on displayBounds: CGRect) -> CGPoint {
+            let targetIsParkedOffscreen = targetBounds.maxX <= displayBounds.minX
+            let targetY = targetIsParkedOffscreen ? targetBounds.midY : targetBounds.minY
+            return switch self {
+            case .leftOfItem:
+                CGPoint(x: targetBounds.minX, y: targetY)
+            case .rightOfItem:
+                CGPoint(x: targetBounds.maxX, y: targetY)
+            }
+        }
+
         /// A string to use for logging purposes.
         var logString: String {
             switch self {
@@ -2953,6 +2970,18 @@ extension MenuBarItemManager {
             case let .rightOfItem(item): "right of \(item.logString)"
             }
         }
+    }
+
+    /// Returns a safe location for an off-screen move's initial mouse-down.
+    ///
+    /// `NSScreen` frames use AppKit coordinates, while `CGEvent` locations use
+    /// Core Graphics coordinates. Their horizontal axes align, so the notch
+    /// supplies only the x-coordinate; the target supplies the event's y-coordinate.
+    static nonisolated func notchMouseDownPoint(
+        notchFrameAppKit: CGRect,
+        targetPointCoreGraphics: CGPoint
+    ) -> CGPoint {
+        CGPoint(x: notchFrameAppKit.midX, y: targetPointCoreGraphics.y)
     }
 
     /// Returns the default timeout for move operations associated
@@ -3045,17 +3074,11 @@ extension MenuBarItemManager {
         let itemBounds = try await getCurrentBounds(for: item)
         let targetBounds = try await getCurrentBounds(for: destination.targetItem)
 
-        let start: CGPoint
-        let end: CGPoint
-
-        switch destination {
-        case .leftOfItem:
-            start = CGPoint(x: targetBounds.minX, y: targetBounds.minY)
-        case .rightOfItem:
-            start = CGPoint(x: targetBounds.maxX, y: targetBounds.minY)
-        }
-
-        end = start
+        let start = destination.targetPoint(
+            in: targetBounds,
+            on: CGDisplayBounds(displayID)
+        )
+        let end = start
 
         MenuBarItemManager.diagLog.debug(
             "Move points: startX=\(start.x) endX=\(end.x) startY=\(start.y) targetMinX=\(targetBounds.minX) itemMinX=\(itemBounds.minX) targetTag=\(destination.targetItem.tag) itemTag=\(item.tag) display=\(displayID)"
@@ -3209,7 +3232,9 @@ extension MenuBarItemManager {
         // when slow apps have to register the tracking events before the
         // mouseDown; irrelevant offscreen.
         let warpPoint = targetPoints.start
-        let warpIsOnScreen = NSScreen.screens.contains { $0.frame.contains(warpPoint) }
+        let warpIsOnScreen = NSScreen.screens.contains {
+            CGDisplayBounds($0.displayID).contains(warpPoint)
+        }
         if warpIsOnScreen {
             MouseHelpers.warpCursor(to: warpPoint)
         }
@@ -3218,13 +3243,15 @@ extension MenuBarItemManager {
             await eventSleep(for: .milliseconds(20))
         }
         // For notched displays, when the target is offscreen, redirect
-        // mouseDown's hit-test location into the notch itself. The
-        // notch is hardware with no clickable UI, so the OS hit-test
-        // there has nothing to dismiss, no menu to open, and no app
-        // window to surface a click against. mouseUp keeps its
-        // original location (the drop position the receiving app
-        // uses to place the item). For non-notched displays the
-        // original behaviour is preserved (no override).
+        // mouseDown's horizontal hit-test location into the notch itself. The
+        // notch is hardware with no clickable UI, so the OS hit-test there has
+        // nothing to dismiss, no menu to open, and no app window to surface a
+        // click against. Keep the Core Graphics y-coordinate inside the menu
+        // bar; frameOfNotch is in AppKit coordinates and its y-coordinate would
+        // instead point near the bottom of the display. mouseUp keeps its
+        // original location (the drop position the receiving app uses to place
+        // the item). For non-notched displays the original behaviour is
+        // preserved (no override).
         if !warpIsOnScreen {
             let activeScreen = NSScreen.screens.first(where: { $0.displayID == displayID })
                 ?? NSScreen.main
@@ -3232,9 +3259,9 @@ extension MenuBarItemManager {
                activeScreen.hasNotch,
                let notch = activeScreen.frameOfNotch
             {
-                mouseDown.location = CGPoint(
-                    x: notch.midX,
-                    y: notch.midY
+                mouseDown.location = Self.notchMouseDownPoint(
+                    notchFrameAppKit: notch,
+                    targetPointCoreGraphics: targetPoints.start
                 )
             }
         }

--- a/ThawTests/MoveEventCoordinatesTests.swift
+++ b/ThawTests/MoveEventCoordinatesTests.swift
@@ -1,0 +1,95 @@
+//
+//  MoveEventCoordinatesTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Regression tests for the synthetic event coordinates used to move menu bar items.
+final class MoveEventCoordinatesTests: XCTestCase {
+    /// Off-screen destinations preserve their horizontal edge while keeping the
+    /// event away from the top-left Hot Corner.
+    func testOffscreenTargetPointsUseBoundsMidpoint() {
+        let displayBounds = CGRect(x: 0, y: 0, width: 1470, height: 956)
+        let bounds = CGRect(x: -4193, y: 0, width: 22, height: 33)
+        let target = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.target", title: "Target"),
+            windowID: 100,
+            bounds: bounds,
+            isOnScreen: false
+        )
+
+        XCTAssertEqual(
+            MenuBarItemManager.MoveDestination.leftOfItem(target).targetPoint(
+                in: bounds,
+                on: displayBounds
+            ),
+            CGPoint(x: bounds.minX, y: bounds.midY)
+        )
+        XCTAssertEqual(
+            MenuBarItemManager.MoveDestination.rightOfItem(target).targetPoint(
+                in: bounds,
+                on: displayBounds
+            ),
+            CGPoint(x: bounds.maxX, y: bounds.midY)
+        )
+    }
+
+    /// The safe vertical coordinate is derived from the target rather than a
+    /// hard-coded primary-display inset.
+    func testTargetPointUsesMidpointOnVerticallyOffsetDisplay() {
+        let displayBounds = CGRect(x: 1200, y: -900, width: 1920, height: 1080)
+        let bounds = CGRect(x: -4193, y: -900, width: 24, height: 24)
+        let target = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.target", title: "Target"),
+            windowID: 101,
+            bounds: bounds
+        )
+
+        let point = MenuBarItemManager.MoveDestination.leftOfItem(target).targetPoint(
+            in: bounds,
+            on: displayBounds
+        )
+
+        XCTAssertEqual(point, CGPoint(x: bounds.minX, y: bounds.midY))
+        XCTAssertNotEqual(point.y, bounds.minY)
+    }
+
+    /// On-screen moves retain their existing top-edge coordinate because those
+    /// moves still physically warp the cursor before posting events.
+    func testOnscreenTargetPointPreservesExistingYCoordinate() {
+        let displayBounds = CGRect(x: 0, y: 0, width: 1470, height: 956)
+        let bounds = CGRect(x: 1100, y: 0, width: 24, height: 33)
+        let target = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.target", title: "Target"),
+            windowID: 102,
+            bounds: bounds
+        )
+
+        let point = MenuBarItemManager.MoveDestination.leftOfItem(target).targetPoint(
+            in: bounds,
+            on: displayBounds
+        )
+
+        XCTAssertEqual(point, CGPoint(x: bounds.minX, y: bounds.minY))
+    }
+
+    /// The notch frame comes from AppKit, so only its horizontal position is
+    /// safe to reuse in a Core Graphics event.
+    func testNotchMouseDownKeepsCoreGraphicsMenuBarYCoordinate() {
+        let notchFrameAppKit = CGRect(x: 646, y: 924, width: 179, height: 32)
+        let targetPointCoreGraphics = CGPoint(x: -4193, y: 16.5)
+
+        let point = MenuBarItemManager.notchMouseDownPoint(
+            notchFrameAppKit: notchFrameAppKit,
+            targetPointCoreGraphics: targetPointCoreGraphics
+        )
+
+        XCTAssertEqual(point, CGPoint(x: notchFrameAppKit.midX, y: targetPointCoreGraphics.y))
+        XCTAssertNotEqual(point.y, notchFrameAppKit.midY)
+    }
+}


### PR DESCRIPTION
# Summary

Hidden-item move events previously used the target top edge as y, which WindowServer can clamp into a display corner and fire Hot Corners. Uses the parked item’s vertical midpoint for off-screen moves.

**Scope:** Coordinate path for off-screen/hidden moves so Hot Corners are not triggered (#766; Hot Corner part of #625).

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #766

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Returning or reordering an item in the hidden section keeps synthetic mouse events inside the menu bar’s vertical band. Visible-only reordering keeps its existing path.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test`: 760 passed
- Four coordinate regression tests

## Known limitations / follow-ups

- #625 also tracks click consistency / Screen Capture / auto-hide — left open.

## Other information

Live validation on macOS 26.5 with Hot Corner = Lock Screen; no activation observed.
