### PR TITLE
docs: fix typo and IceBar references in URI schemes

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2413,7 +2413,7 @@ extension MenuBarItemManager {
     /// paused input for at least the given duration.
     ///
     /// - Parameter duration: The duration that certain types of input
-    ///   events must not have occured within in order to return `true`.
+    ///   events must not have occurred within in order to return `true`.
     private nonisolated func hasUserPausedInput(for duration: Duration) -> Bool {
         NSEvent.modifierFlags.isEmpty &&
             !MouseHelpers.lastMovementOccurred(within: duration) &&

--- a/docs/URI_SCHEMES.md
+++ b/docs/URI_SCHEMES.md
@@ -15,7 +15,7 @@ Thaw registers the `thaw://` URL scheme in `Info.plist` via `CFBundleURLTypes`. 
 | `thaw://toggle-hidden`            | Toggle Hidden Section | Shows/hides the hidden menu bar section  |
 | `thaw://toggle-always-hidden`     | Toggle Always-Hidden  | Shows/hides the always-hidden section    |
 | `thaw://search`                   | Open Search Panel     | Displays the menu bar item search panel  |
-| `thaw://toggle-thawbar`           | Toggle Thaw Bar       | Toggles the IceBar on the active display |
+| `thaw://toggle-thawbar`           | Toggle Thaw Bar       | Toggles the Thaw Bar on the active display |
 | `thaw://toggle-application-menus` | Toggle App Menus      | Shows/hides application menus            |
 | `thaw://open-settings`            | Open Settings         | Opens the Thaw settings window           |
 | `thaw://authorize`                | Authorize App         | Triggers auth dialog to grant an app whitelist access to settings |
@@ -143,7 +143,7 @@ Thaw supports programmatic settings manipulation via the `thaw://` URL scheme wi
 | `enableDiagnosticLogging`                 | Bool | Enable debug logging                         |
 | `customIceIconIsTemplate`                 | Bool | Custom icon renders as template              |
 | `showIceIcon`                             | Bool | Show the Thaw icon in menu bar               |
-| `iceBarLocationOnHotkey`                  | Bool | IceBar appears at mouse location on hotkey     |
+| `iceBarLocationOnHotkey`                  | Bool | Thaw Bar appears at mouse location on hotkey     |
 | `useLCSSortingOnNotchedDisplays`          | Bool | Use LCS sorting on notched displays          |
 
 #### Double/Time Interval Settings


### PR DESCRIPTION
# Summary

Fixes a doc-comment typo (`occured` → `occurred`) in `MenuBarItemManager` and replaces remaining user-facing “IceBar” wording in `docs/URI_SCHEMES.md` with “Thaw Bar”. Setting key names (`useIceBar`, `iceBarLocation`, etc.) are left unchanged as code identifiers.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

- [ ] Bugfix
- [ ] CI/CD
- [x] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

No runtime behavior change. Documentation and comments now consistently use the correct spelling and the “Thaw Bar” product name in URI scheme docs.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

Trivial consistency fixes only:
- `hasUserPausedInput(for:)` doc comment: `occured` → `occurred`
- `thaw://toggle-thawbar` and `iceBarLocationOnHotkey` descriptions: IceBar → Thaw Bar