### PR TITLE
fix(profiles): restore legacy layout snapshots

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -5791,12 +5791,14 @@ extension MenuBarItemManager {
             isRestoringItemOrderTimestamp = nil
         }
 
-        guard let appState else {
-            MenuBarItemManager.diagLog.error("applyProfileLayout: missing appState")
-            return
-        }
         guard !itemOrder.isEmpty else {
             MenuBarItemManager.diagLog.debug("applyProfileLayout: no item order, skipping")
+            concludeProfileApplyWithoutMoves(source: source, items: [])
+            return
+        }
+        guard let appState else {
+            MenuBarItemManager.diagLog.error("applyProfileLayout: missing appState")
+            clearProfileState(source: source, items: [])
             return
         }
 
@@ -5836,6 +5838,7 @@ extension MenuBarItemManager {
               )
         else {
             MenuBarItemManager.diagLog.error("applyProfileLayout: missing control items")
+            clearProfileState(source: source, items: items)
             return
         }
 
@@ -6168,8 +6171,7 @@ extension MenuBarItemManager {
             )
             if fullSequence.isEmpty {
                 MenuBarItemManager.diagLog.info("Profile layout (full sort): current order matches desired, skipping")
-                updateProfileSortedSnapshot(source: source, items: items)
-                persistProfileStateOnSuccess(source: source)
+                concludeProfileApplyWithoutMoves(source: source, items: items)
                 scheduleDeferredCacheRefresh()
                 return
             }
@@ -6490,6 +6492,7 @@ extension MenuBarItemManager {
                     alwaysHiddenControlItemWindowID: alwaysHiddenWID
                 ) else {
                     MenuBarItemManager.diagLog.error("applyProfileLayout: lost control items after phase 1")
+                    clearProfileState(source: source, items: items)
                     scheduleDeferredCacheRefresh()
                     return
                 }

--- a/Thaw/Settings/Models/Profile.swift
+++ b/Thaw/Settings/Models/Profile.swift
@@ -313,6 +313,30 @@ struct MenuBarLayoutSnapshot: Codable {
     /// the menuBarItemHotkeys default. Absent in profiles saved before this
     /// field was introduced.
     var itemHotkeys: [String: Data]?
+
+    /// Resolves the ordering representation used by the layout apply path.
+    /// Profiles written before `itemOrder` was added contain the equivalent
+    /// `savedSectionOrder` representation, so preserve their layout intent.
+    var resolvedItemOrder: [String: [String]] {
+        itemOrder ?? savedSectionOrder
+    }
+
+    /// Resolves per-item section assignments for both current and legacy
+    /// profile formats. When the explicit map is absent, each identifier's
+    /// section is encoded by the compatible ordered representation.
+    var resolvedItemSectionMap: [String: String] {
+        if let itemSectionMap {
+            return itemSectionMap
+        }
+
+        var result = [String: String]()
+        for (sectionKey, identifiers) in resolvedItemOrder {
+            for identifier in identifiers {
+                result[identifier] = sectionKey
+            }
+        }
+        return result
+    }
 }
 
 // MARK: - ProfileContent

--- a/Thaw/Settings/Models/ProfileManager.swift
+++ b/Thaw/Settings/Models/ProfileManager.swift
@@ -271,8 +271,8 @@ final class ProfileManager: ObservableObject {
         let pinnedHidden = Set(profile.menuBarLayout.pinnedHiddenBundleIDs)
         let pinnedAlwaysHidden = Set(profile.menuBarLayout.pinnedAlwaysHiddenBundleIDs)
         let sectionOrder = profile.menuBarLayout.savedSectionOrder
-        let itemSectionMap = profile.menuBarLayout.itemSectionMap ?? [:]
-        let itemOrder = profile.menuBarLayout.itemOrder ?? [:]
+        let itemSectionMap = profile.menuBarLayout.resolvedItemSectionMap
+        let itemOrder = profile.menuBarLayout.resolvedItemOrder
 
         // Snapshot hook config before entering the task. Resolving
         // global hooks inside the Task would still work; doing it now
@@ -755,8 +755,8 @@ final class ProfileManager: ObservableObject {
             pinnedHidden: Set(layout.pinnedHiddenBundleIDs),
             pinnedAlwaysHidden: Set(layout.pinnedAlwaysHiddenBundleIDs),
             sectionOrder: layout.savedSectionOrder,
-            itemSectionMap: layout.itemSectionMap ?? [:],
-            itemOrder: layout.itemOrder ?? [:]
+            itemSectionMap: layout.resolvedItemSectionMap,
+            itemOrder: layout.resolvedItemOrder
         )
     }
 

--- a/ThawTests/ProfileApplyInFlightFlagTests.swift
+++ b/ThawTests/ProfileApplyInFlightFlagTests.swift
@@ -60,4 +60,20 @@ final class ProfileApplyInFlightFlagTests: XCTestCase {
 
         XCTAssertFalse(manager.isApplyingProfileLayout)
     }
+
+    /// An empty profile layout has no moves to run, but it still must release
+    /// the profile-apply gate so a later saved-layout restore can proceed.
+    func testEmptyProfileApplyClearsInFlightFlag() async {
+        let manager = MenuBarItemManager()
+
+        await manager.applyProfileLayout(
+            pinnedHidden: [],
+            pinnedAlwaysHidden: [],
+            sectionOrder: makeOrder(),
+            itemSectionMap: [:],
+            itemOrder: [:]
+        )
+
+        XCTAssertFalse(manager.isApplyingProfileLayout)
+    }
 }

--- a/ThawTests/ProfileTests.swift
+++ b/ThawTests/ProfileTests.swift
@@ -163,6 +163,30 @@ final class MenuBarLayoutSnapshotTests: XCTestCase {
         XCTAssertNil(decoded.itemHotkeys)
     }
 
+    func testLegacyLayoutUsesSavedOrderForItemOrderAndSections() throws {
+        let json = """
+        {
+            "savedSectionOrder": {
+                "visible": ["com.example.visible:Status"],
+                "hidden": ["com.example.hidden:Status"],
+                "alwaysHidden": ["com.example.alwaysHidden:Status"]
+            },
+            "pinnedHiddenBundleIDs": [],
+            "pinnedAlwaysHiddenBundleIDs": [],
+            "customNames": {}
+        }
+        """.data(using: .utf8)!
+
+        let decoded = try JSONDecoder().decode(MenuBarLayoutSnapshot.self, from: json)
+
+        XCTAssertEqual(decoded.resolvedItemOrder, decoded.savedSectionOrder)
+        XCTAssertEqual(decoded.resolvedItemSectionMap, [
+            "com.example.visible:Status": "visible",
+            "com.example.hidden:Status": "hidden",
+            "com.example.alwaysHidden:Status": "alwaysHidden",
+        ])
+    }
+
     func testEncodeDecodeItemHotkeys() throws {
         let original = MenuBarLayoutSnapshot(
             savedSectionOrder: [:],


### PR DESCRIPTION
# Summary

Restore legacy profile layouts from `savedSectionOrder` when newer per-item fields are absent, derive section assignments from that representation, and clear the profile-apply gate on every confirmed no-move or aborted exit.

**Scope:** Legacy profile layout restore + clear stuck `isApplyingProfileLayout` on empty/incomplete applies.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #778

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [x] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Older profiles with optional `itemOrder` / `itemSectionMap` no longer leave `isApplyingProfileLayout` stuck. Legacy `savedSectionOrder` is restored, and the apply gate clears on no-move / early abort.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- Regression coverage for legacy layout resolution and empty profile applies
- `git diff --check`

## Known limitations / follow-ups

- (none)

## Other information

Root cause: optional layout snapshot fields for older exports.
