### PR TITLE
fix(permissions): allow retrying authorization

### DIFF
--- a/Thaw/Permissions/Permission.swift
+++ b/Thaw/Permissions/Permission.swift
@@ -46,9 +46,6 @@ class Permission: ObservableObject, Identifiable {
     /// Observer that runs on a timer to check permissions.
     private var timerCancellable: AnyCancellable?
 
-    /// Observer that observes the ``hasPermission`` property.
-    private var hasPermissionCancellable: AnyCancellable?
-
     /// Creates a permission.
     ///
     /// - Parameters:
@@ -110,34 +107,10 @@ class Permission: ObservableObject, Identifiable {
         }
     }
 
-    /// Asynchronously waits for the app to be granted this permission.
-    func waitForPermission() async {
-        hasPermissionCancellable?.cancel()
-        configureCancellables()
-        guard !hasPermission else {
-            return
-        }
-        await withCheckedContinuation { continuation in
-            hasPermissionCancellable = $hasPermission.sink { [weak self] hasPermission in
-                guard self != nil else {
-                    continuation.resume()
-                    return
-                }
-                if hasPermission {
-                    continuation.resume()
-                }
-            }
-        }
-        hasPermissionCancellable?.cancel()
-        hasPermissionCancellable = nil
-    }
-
     /// Stops running the permission check.
     func stopCheck() {
         timerCancellable?.cancel()
         timerCancellable = nil
-        hasPermissionCancellable?.cancel()
-        hasPermissionCancellable = nil
     }
 }
 
@@ -157,7 +130,9 @@ final class AccessibilityPermission: Permission {
                 String(localized: "Click menu bar items on your behalf, such as when using the search bar."),
             ],
             isRequired: true,
-            settingsURL: nil,
+            // Keep an explicit settings URL so every click can recover the
+            // flow if the user closes System Settings before granting access.
+            settingsURL: URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"),
             check: {
                 AXHelpers.isProcessTrusted()
             },

--- a/Thaw/Permissions/Permission.swift
+++ b/Thaw/Permissions/Permission.swift
@@ -43,6 +43,9 @@ class Permission: ObservableObject, Identifiable {
     /// The function that requests permissions.
     private let request: () -> Void
 
+    /// The function that opens a System Settings URL.
+    private let openSettings: (URL) -> Bool
+
     /// Observer that runs on a timer to check permissions.
     private var timerCancellable: AnyCancellable?
 
@@ -55,6 +58,7 @@ class Permission: ObservableObject, Identifiable {
     ///   - settingsURL: The URL of the settings pane to open.
     ///   - check: A function that checks permissions.
     ///   - request: A function that requests permissions.
+    ///   - openSettings: A function that opens the settings URL.
     init(
         title: String,
         iconName: String,
@@ -63,7 +67,8 @@ class Permission: ObservableObject, Identifiable {
         isRequired: Bool,
         settingsURL: URL?,
         check: @escaping () -> Bool,
-        request: @escaping () -> Void
+        request: @escaping () -> Void,
+        openSettings: @escaping (URL) -> Bool = { NSWorkspace.shared.open($0) }
     ) {
         self.title = title
         self.iconName = iconName
@@ -73,6 +78,7 @@ class Permission: ObservableObject, Identifiable {
         self.settingsURL = settingsURL
         self.check = check
         self.request = request
+        self.openSettings = openSettings
         self.hasPermission = check()
         configureCancellables()
     }
@@ -106,7 +112,7 @@ class Permission: ObservableObject, Identifiable {
         configureCancellables()
         request()
         if let settingsURL {
-            NSWorkspace.shared.open(settingsURL)
+            _ = openSettings(settingsURL)
         }
     }
 

--- a/Thaw/Permissions/Permission.swift
+++ b/Thaw/Permissions/Permission.swift
@@ -101,6 +101,9 @@ class Permission: ObservableObject, Identifiable {
 
     /// Performs the request and opens the System Settings app to the appropriate pane.
     func performRequest() {
+        // Setup stops background permission polling once the app is running.
+        // Restart it for every explicit request so later grants are observed.
+        configureCancellables()
         request()
         if let settingsURL {
             NSWorkspace.shared.open(settingsURL)

--- a/Thaw/Permissions/PermissionsView.swift
+++ b/Thaw/Permissions/PermissionsView.swift
@@ -231,7 +231,6 @@ struct PermissionsView<Manager: PermissionsManaging>: View {
 struct PermissionCard: View {
     @EnvironmentObject var appState: AppState
     @ObservedObject var permission: Permission
-    @State var isRequestingPermission = false
 
     /// Whether granting the permission should bring the permissions window
     /// back to the front. Disabled when hosted in a context — like the
@@ -265,19 +264,11 @@ struct PermissionCard: View {
                 Spacer(minLength: 0)
 
                 Button {
-                    guard !isRequestingPermission else {
-                        return
-                    }
-                    isRequestingPermission = true
+                    // The request is intentionally fire-and-forget. The
+                    // permission object keeps polling until the user grants
+                    // access, so closing System Settings leaves this button
+                    // available for another attempt.
                     permission.performRequest()
-                    Task {
-                        defer { isRequestingPermission = false }
-                        await permission.waitForPermission()
-                        appState.activate(withPolicy: .regular)
-                        if refocusesWindowAfterGrant {
-                            appState.openWindow(.permissions)
-                        }
-                    }
                 } label: {
                     if permission.hasPermission {
                         Label("Permission Granted", systemImage: "checkmark")
@@ -290,10 +281,18 @@ struct PermissionCard: View {
                 .buttonStyle(.borderedProminent)
                 .tint(permission.hasPermission ? .green : .accentColor)
                 .allowsHitTesting(!permission.hasPermission)
-                .disabled(isRequestingPermission)
             }
             .padding(12)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+        }
+        .onChange(of: permission.hasPermission) { _, hasPermission in
+            guard hasPermission else {
+                return
+            }
+            appState.activate(withPolicy: .regular)
+            if refocusesWindowAfterGrant {
+                appState.openWindow(.permissions)
+            }
         }
     }
 }

--- a/ThawTests/PermissionTests.swift
+++ b/ThawTests/PermissionTests.swift
@@ -1,0 +1,47 @@
+//
+//  PermissionTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Combine
+import SwiftUI
+@testable import Thaw
+import XCTest
+
+// MARK: - Permission Tests
+
+@MainActor
+final class PermissionTests: XCTestCase {
+    func testPerformRequestRestartsPollingAfterChecksStop() {
+        var isGranted = false
+        var requestCount = 0
+        let permission = Permission(
+            title: "Test Permission",
+            iconName: "checkmark",
+            iconColor: .blue,
+            details: [],
+            isRequired: false,
+            settingsURL: nil,
+            check: { isGranted },
+            request: { requestCount += 1 }
+        )
+
+        permission.stopCheck()
+        permission.performRequest()
+        isGranted = true
+
+        let granted = expectation(description: "Permission grant is observed after polling restarts")
+        let cancellable = permission.$hasPermission
+            .filter(\.self)
+            .sink { _ in granted.fulfill() }
+
+        wait(for: [granted], timeout: 5)
+
+        XCTAssertEqual(requestCount, 1)
+        XCTAssertTrue(permission.hasPermission)
+        withExtendedLifetime(cancellable) {}
+    }
+}

--- a/ThawTests/PermissionTests.swift
+++ b/ThawTests/PermissionTests.swift
@@ -15,20 +15,30 @@ import XCTest
 
 @MainActor
 final class PermissionTests: XCTestCase {
-    func testPerformRequestRestartsPollingAfterChecksStop() {
+    func testPerformRequestRestartsPollingAfterChecksStop() throws {
         var isGranted = false
         var requestCount = 0
+        var openedSettingsURLs = [URL]()
+        let settingsURL = try XCTUnwrap(
+            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")
+        )
         let permission = Permission(
             title: "Test Permission",
             iconName: "checkmark",
             iconColor: .blue,
             details: [],
             isRequired: false,
-            settingsURL: nil,
+            settingsURL: settingsURL,
             check: { isGranted },
-            request: { requestCount += 1 }
+            request: { requestCount += 1 },
+            openSettings: { url in
+                openedSettingsURLs.append(url)
+                return true
+            }
         )
 
+        permission.stopCheck()
+        permission.performRequest()
         permission.stopCheck()
         permission.performRequest()
         isGranted = true
@@ -40,7 +50,8 @@ final class PermissionTests: XCTestCase {
 
         wait(for: [granted], timeout: 5)
 
-        XCTAssertEqual(requestCount, 1)
+        XCTAssertEqual(requestCount, 2)
+        XCTAssertEqual(openedSettingsURLs, [settingsURL, settingsURL])
         XCTAssertTrue(permission.hasPermission)
         withExtendedLifetime(cancellable) {}
     }

--- a/docs/URI_SCHEMES.md
+++ b/docs/URI_SCHEMES.md
@@ -108,6 +108,7 @@ Thaw uses the following system URLs to open macOS Settings:
 
 | URL                                                                             | Opens                     |
 | ------------------------------------------------------------------------------- | ------------------------- |
+| `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility` | Accessibility settings    |
 | `x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture` | Screen Recording settings |
 
 ## Settings URI (Automation)


### PR DESCRIPTION
# Summary

Keep the permission request button available until access is granted so users can reopen System Settings after abandoning the first authorization attempt.

The fix also removes the obsolete async permission waiter, gives Accessibility an explicit System Settings URL, and restarts permission polling for every explicit request so grants are still observed after normal app setup has stopped background checks.

Closes: #780

## PR Type

- [x] Bugfix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Clicking **Grant Permission** no longer disables the button for the full authorization wait.
- Closing System Settings without granting access leaves the button available for another attempt.
- Every explicit permission request restarts polling, including onboarding replay and Advanced Settings after background checks have stopped.
- Granting access still restores Thaw's regular activation policy and refocuses the permissions window where appropriate.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

Validation performed:

- `swiftformat --lint` passes for all changed Swift files.
- Full `swiftlint lint --strict` passes with 0 violations across 148 files.
- The SwiftLint tracked-input list matches the generated list.
- `xcodebuild build-for-testing` succeeds with signing disabled.
- `PermissionTests.testPerformRequestRestartsPollingAfterChecksStop()` passes and covers the stopped-check → explicit request → delayed grant lifecycle.
- The app builds, accepts an ad hoc signature, and launches successfully on macOS 26.5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Accessibility permission requests now open the correct macOS System Settings pane.
  * Permission checks automatically resume when a new permission request is initiated.
  * The app activates/updates automatically when requested permissions are granted.

* **Bug Fixes**
  * Improved behavior when permission polling has been stopped and a new request is made.
  * Permission request actions stay available (no temporary disabled state while requesting).

* **Tests**
  * Added coverage to confirm polling restarts and settings are opened for repeated requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->