### PR TITLE
fix(icebar): keep tooltips above grid items

### DIFF
--- a/Thaw/UI/Views/CustomTooltip.swift
+++ b/Thaw/UI/Views/CustomTooltip.swift
@@ -50,7 +50,9 @@ final class CustomTooltipPanel: NSPanel {
         isOpaque = false
         backgroundColor = .clear
         hasShadow = true
-        level = .floating
+        // The Thaw Bar sits at `.mainMenu + 1`. Keep tooltips one level
+        // above it so grid items cannot obscure their labels.
+        level = .mainMenu + 2
         ignoresMouseEvents = true
         collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .stationary]
         animationBehavior = .none

--- a/ThawTests/CustomTooltipPanelTests.swift
+++ b/ThawTests/CustomTooltipPanelTests.swift
@@ -1,0 +1,24 @@
+//
+//  CustomTooltipPanelTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+@MainActor
+final class CustomTooltipPanelTests: XCTestCase {
+    func testTooltipAppearsAboveIceBar() {
+        let iceBar = IceBarPanel()
+        let tooltip = CustomTooltipPanel.shared
+
+        XCTAssertGreaterThan(
+            tooltip.level.rawValue,
+            iceBar.level.rawValue,
+            "Tooltips must be above the Thaw Bar so grid items cannot obscure them"
+        )
+    }
+}


### PR DESCRIPTION
# Summary

Raise the custom tooltip panel above the Thaw Bar so tooltips remain visible over grid items. The Thaw Bar uses `.mainMenu + 1`, while the tooltip previously used the lower `.floating` level. The tooltip now uses `.mainMenu + 2`, and a regression test locks the relative ordering.

Closes: #760

## PR Type

- [x] Bugfix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Tooltips shown for items in the Thaw Bar are ordered above the bar instead of being obscured by grid rows.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

- Red/green regression proof: before the fix, the tooltip level was 3 and the Thaw Bar level was 25; after the fix, the tooltip level is 26.
- Full English test suite: 757 tests passed, 0 failed.
- SwiftLint strict: passed.
- Both changed files pass SwiftFormat lint.
- An ad hoc-signed Debug build launched successfully on macOS 26.5.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tooltip visibility by ensuring tooltips appear above the Thaw Bar and remain unobscured by grid items.

* **Tests**
  * Added coverage to verify that tooltips display above the Thaw Bar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->