### PR TITLE
fix(menubar): skip saved-layout bulk apply while sourcePIDs are unresolved

### DIFF
--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import Foundation
+import Security
 import XPC
 
 /// A wrapper around an XPC listener object.
@@ -70,6 +71,35 @@ final class Listener: @unchecked Sendable {
         }
     }
 
+    /// Activates the listener without a peer requirement. Used for builds
+    /// signed without a team identifier (ad-hoc/personal builds), where
+    /// `.isFromSameTeam()` can never be satisfied and every session is
+    /// cancelled before the first message.
+    private func uncheckedActivateWithoutPeerRequirement() throws {
+        xpcListener = try XPCListener(service: name) { request in
+            request.accept { [self] message in
+                self.handleMessage(message)
+            }
+        }
+    }
+
+    /// The team identifier of the current process, or `nil` when signed
+    /// without one (ad-hoc).
+    private static let processTeamIdentifier: String? = {
+        var code: SecCode?
+        guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { return nil }
+        var staticCode: SecStaticCode?
+        guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode else { return nil }
+        var info: CFDictionary?
+        let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+        guard SecCodeCopySigningInformation(staticCode, flags, &info) == errSecSuccess,
+              let dict = info as? [String: Any]
+        else {
+            return nil
+        }
+        return dict[kSecCodeInfoTeamIdentifier as String] as? String
+    }()
+
     /// Activates the listener.
     func activate() {
         guard xpcListener == nil else {
@@ -80,7 +110,12 @@ final class Listener: @unchecked Sendable {
         diagLog.debug("Activating listener")
 
         do {
-            try uncheckedActivateWithSameTeamRequirement()
+            if Self.processTeamIdentifier == nil {
+                diagLog.notice("Listener: no team identifier (ad-hoc build), activating without peer requirement")
+                try uncheckedActivateWithoutPeerRequirement()
+            } else {
+                try uncheckedActivateWithSameTeamRequirement()
+            }
         } catch {
             diagLog.error("Failed to activate listener with error \(error)")
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -6732,6 +6732,22 @@ extension MenuBarItemManager {
         return !previous.isSubset(of: current)
     }
 
+
+    /// Whether enough menu bar items are missing a resolved source PID that
+    /// bulk-applying the saved layout would act on unmatchable identities.
+    ///
+    /// When the MenuBarItemService XPC connection fails (service cold start,
+    /// connection interruption), most third-party items resolve to a nil
+    /// sourcePID and collapse to ambiguous Control-Center-owned identifiers.
+    /// A bulk apply dispatched in that state rearranges items it cannot match
+    /// to the saved layout. A few system items (WiFi, Clock, BentoBox) and
+    /// notch-hidden stragglers legitimately resolve to nil, so a minority
+    /// share is normal; only a majority signals a resolution failure. The
+    /// item-count floor keeps degenerate tiny sets from tripping the gate.
+    nonisolated static func majorityOfSourcePIDsUnresolved(unresolvedCount: Int, itemCount: Int) -> Bool {
+        itemCount >= 4 && unresolvedCount * 2 > itemCount
+    }
+
     func applySavedLayout(
         items: [MenuBarItem],
         previousWindowIDs: [CGWindowID],
@@ -6844,6 +6860,21 @@ extension MenuBarItemManager {
         if LayoutSolver.itemsSpanMultipleDisplays(itemCenters: itemCenters, screenFrames: screenFrames) {
             MenuBarItemManager.diagLog.debug(
                 "applySavedLayout: skipping, menu bar items span multiple displays (relocation in progress)"
+            )
+            return false
+        }
+
+        // Identity-resolution gate. When the XPC sourcePID resolution fails
+        // (service cold start or connection failure), third-party items
+        // collapse to ambiguous Control-Center-owned identifiers that cannot
+        // be matched against the saved layout, and the bulk apply rearranges
+        // them blindly. Skip and let a later cache tick retry once identities
+        // resolve — mirrors relocateNewLeftmostItems's unresolved-sourcePID
+        // noop.
+        let unresolvedSourcePIDCount = items.filter { $0.sourcePID == nil }.count
+        if Self.majorityOfSourcePIDsUnresolved(unresolvedCount: unresolvedSourcePIDCount, itemCount: items.count) {
+            MenuBarItemManager.diagLog.info(
+                "applySavedLayout: skipping, \(unresolvedSourcePIDCount)/\(items.count) items have unresolved sourcePIDs (XPC resolution likely failed)"
             )
             return false
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 import os.lock
+import Security
 import XPC
 
 // MARK: - MenuBarItemService.Connection
@@ -137,7 +138,15 @@ extension MenuBarItemService {
                     diagLog.warning("Session was cancelled with error \(error.localizedDescription)")
                     self.session = nil
                 }
-                session.setPeerRequirement(.isFromSameTeam())
+                // Same-team peer validation can never pass in a build signed
+                // without a team identifier (ad-hoc/personal builds) — every
+                // send would fail with "Peer forbidden (code signing)".
+                // Mirrors the teamless fallback in the service's Listener.
+                if Self.processTeamIdentifier != nil {
+                    session.setPeerRequirement(.isFromSameTeam())
+                } else {
+                    diagLog.notice("getOrCreateSession: no team identifier (ad-hoc build), skipping peer requirement")
+                }
                 session.setTargetQueue(queue)
                 try session.activate()
                 diagLog.debug("getOrCreateSession: XPC session activated successfully")
@@ -151,6 +160,24 @@ extension MenuBarItemService {
                 }
                 session.cancel(reason: reason)
             }
+
+            /// The team identifier of the current process, or `nil` when
+            /// signed without one (ad-hoc). Duplicated from the service's
+            /// Listener to avoid cross-target file membership changes.
+            private static let processTeamIdentifier: String? = {
+                var code: SecCode?
+                guard SecCodeCopySelf([], &code) == errSecSuccess, let code else { return nil }
+                var staticCode: SecStaticCode?
+                guard SecCodeCopyStaticCode(code, [], &staticCode) == errSecSuccess, let staticCode else { return nil }
+                var info: CFDictionary?
+                let flags = SecCSFlags(rawValue: kSecCSSigningInformation)
+                guard SecCodeCopySigningInformation(staticCode, flags, &info) == errSecSuccess,
+                      let dict = info as? [String: Any]
+                else {
+                    return nil
+                }
+                return dict[kSecCodeInfoTeamIdentifier as String] as? String
+            }()
         }
 
         /// Protected storage for the underlying XPC session.

--- a/ThawTests/SourcePIDResolutionGateTests.swift
+++ b/ThawTests/SourcePIDResolutionGateTests.swift
@@ -1,0 +1,59 @@
+//
+//  SourcePIDResolutionGateTests.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Characterizes the identity-resolution gate consulted before a saved-layout
+/// bulk apply.
+///
+/// When the MenuBarItemService XPC connection fails, most third-party items
+/// resolve to a nil sourcePID and collapse to ambiguous Control-Center-owned
+/// identifiers. Dispatching the bulk apply in that state rearranges items that
+/// cannot be matched to the saved layout. The gate must trip on that
+/// majority-unresolved signature while tolerating the small number of system
+/// items (WiFi, Clock, BentoBox) that legitimately resolve to nil.
+final class SourcePIDResolutionGateTests: XCTestCase {
+    func testHealthyBarWithSystemItemNilsDoesNotTrip() {
+        // 27 items, 3 system items unresolved — the everyday shape.
+        XCTAssertFalse(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 3, itemCount: 27)
+        )
+    }
+
+    func testColdStartMinorityShareDoesNotTrip() {
+        // Observed during service warm-up: 9 of 27 unresolved on the first
+        // cache pass, resolving fully a moment later.
+        XCTAssertFalse(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 9, itemCount: 27)
+        )
+    }
+
+    func testResolutionFailureSignatureTrips() {
+        // Observed with a failed XPC connection: 21 of 24 unresolved.
+        XCTAssertTrue(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 21, itemCount: 24)
+        )
+    }
+
+    func testExactMajorityBoundary() {
+        XCTAssertFalse(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 12, itemCount: 24)
+        )
+        XCTAssertTrue(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 13, itemCount: 24)
+        )
+    }
+
+    func testTinyItemSetsNeverTrip() {
+        // Below the floor, a legitimate handful of system-item nils would
+        // read as a majority; the gate must stay out of the way.
+        XCTAssertFalse(
+            MenuBarItemManager.majorityOfSourcePIDsUnresolved(unresolvedCount: 3, itemCount: 3)
+        )
+    }
+}


### PR DESCRIPTION
# Summary

Fixes menu bar scramble on app launch/quit (#784): `applySavedLayout` dispatched bulk apply even when sourcePID resolution failed and a majority of items were unmatchable.

**Scope:** Skip saved-layout bulk apply while a majority of sourcePIDs are unresolved; optional teamless XPC fallback for ad-hoc dev builds.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #784

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

1. **Identity-resolution gate** — if ≥4 items and a majority have nil `sourcePID`, skip bulk apply and retry later.
2. **Teamless dev-build fallback** — skip same-team XPC peer requirement when the process has no team identifier.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test -only-testing:ThawTests/SourcePIDResolutionGateTests` on macos-26 / Xcode 26.6

## Known limitations / follow-ups

- Teamless XPC fallback is separable if maintainers prefer to split it out.

## Other information

Runtime-validated on macOS 26.5.2 (M1 Pro). Full logs in #784.
