### PR TITLE
ci(release): automate Sparkle ZIP, appcast, and channels

### DIFF
--- a/.github/actions/sparkle-release/action.yml
+++ b/.github/actions/sparkle-release/action.yml
@@ -1,0 +1,245 @@
+name: Sparkle Release
+description: Package a notarized app ZIP, sign Sparkle updates, and refresh appcast.xml on gh-pages
+
+inputs:
+  tag:
+    description: Release tag / marketing version (for example, 2.0.0-rc.1)
+    required: true
+  channel:
+    description: Sparkle channel (stable, beta, or alpha). Stable omits sparkle:channel.
+    required: true
+  app-name:
+    description: Name of the .app bundle
+    required: false
+    default: Thaw.app
+  sparkle-version:
+    description: Sparkle tools version (must match Package.resolved)
+    required: false
+    default: "2.9.3"
+  sparkle-private-key:
+    description: EdDSA private key contents matching SUPublicEDKey
+    required: true
+  previous-release-count:
+    description: How many prior GitHub release ZIPs to fetch for delta generation
+    required: false
+    default: "3"
+  publish-appcast:
+    description: Push updated appcast.xml to the gh-pages branch
+    required: false
+    default: "true"
+
+outputs:
+  zip-path:
+    description: Path to the Sparkle ZIP asset
+    value: ${{ steps.package.outputs.zip-path }}
+  zip-name:
+    description: File name of the Sparkle ZIP asset
+    value: ${{ steps.package.outputs.zip-name }}
+  appcast-path:
+    description: Path to the generated appcast.xml
+    value: ${{ steps.appcast.outputs.appcast-path }}
+  delta-glob:
+    description: Glob for newly generated delta assets
+    value: ${{ steps.appcast.outputs.delta-glob }}
+
+runs:
+  using: composite
+  steps:
+    - name: Package notarized ZIP
+      id: package
+      shell: bash
+      env:
+        APP_NAME: ${{ inputs.app-name }}
+        TAG: ${{ inputs.tag }}
+      run: |
+        set -euo pipefail
+
+        app_path="build/Export/$APP_NAME"
+        if [[ ! -d "$app_path" ]]; then
+          echo "Missing exported app at $app_path"
+          exit 1
+        fi
+
+        # Ticket from DMG notarization applies to the same CDHash.
+        xcrun stapler staple "$app_path" || true
+
+        zip_name="Thaw_${TAG}.zip"
+        zip_path="build/$zip_name"
+        rm -f "$zip_path"
+        ditto -c -k --sequesterRsrc --keepParent "$app_path" "$zip_path"
+
+        echo "zip-name=$zip_name" >> "$GITHUB_OUTPUT"
+        echo "zip-path=$zip_path" >> "$GITHUB_OUTPUT"
+        ls -lh "$zip_path"
+
+    - name: Install Sparkle tools
+      shell: bash
+      env:
+        SPARKLE_VERSION: ${{ inputs.sparkle-version }}
+      run: |
+        set -euo pipefail
+
+        tools_dir="$RUNNER_TEMP/sparkle-tools"
+        rm -rf "$tools_dir"
+        mkdir -p "$tools_dir"
+
+        archive="$RUNNER_TEMP/Sparkle-${SPARKLE_VERSION}.tar.xz"
+        curl -fsSL -o "$archive" \
+          "https://github.com/sparkle-project/Sparkle/releases/download/${SPARKLE_VERSION}/Sparkle-${SPARKLE_VERSION}.tar.xz"
+        tar -xJf "$archive" -C "$tools_dir"
+
+        if [[ -x "$tools_dir/bin/generate_appcast" ]]; then
+          sparkle_bin="$tools_dir/bin"
+        elif [[ -x "$tools_dir/generate_appcast" ]]; then
+          sparkle_bin="$tools_dir"
+        else
+          echo "generate_appcast not found in Sparkle archive"
+          find "$tools_dir" -maxdepth 3 \( -type f -name 'generate_appcast' -o -name 'sign_update' \) | head
+          exit 1
+        fi
+
+        echo "SPARKLE_BIN=$sparkle_bin" >> "$GITHUB_ENV"
+        "$sparkle_bin/generate_appcast" --help | head -n 20 || true
+
+    - name: Prepare archives and existing appcast
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        ZIP_PATH: ${{ steps.package.outputs.zip-path }}
+        PREVIOUS_COUNT: ${{ inputs.previous-release-count }}
+        GH_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        archives="$RUNNER_TEMP/sparkle-archives"
+        pages="$RUNNER_TEMP/gh-pages"
+        rm -rf "$archives" "$pages"
+        mkdir -p "$archives" "$pages"
+
+        cp "$ZIP_PATH" "$archives/"
+
+        # Best-effort: fetch recent ZIPs so generate_appcast can emit deltas.
+        if command -v gh >/dev/null 2>&1; then
+          fetched=0
+          while IFS= read -r release_tag; do
+            [[ -z "$release_tag" || "$release_tag" == "$TAG" ]] && continue
+            asset="Thaw_${release_tag}.zip"
+            if gh release download "$release_tag" --pattern "$asset" --dir "$archives" 2>/dev/null; then
+              fetched=$((fetched + 1))
+            fi
+            [[ "$fetched" -ge "$PREVIOUS_COUNT" ]] && break
+          done < <(
+            gh release list --limit 20 --json tagName,isDraft \
+              --jq '.[] | select(.isDraft == false) | .tagName' || true
+          )
+          echo "Fetched $fetched prior ZIP(s) for deltas"
+        fi
+
+        git fetch origin gh-pages:gh-pages 2>/dev/null || true
+        if git show origin/gh-pages:appcast.xml > "$pages/appcast.xml" 2>/dev/null \
+          || git show gh-pages:appcast.xml > "$pages/appcast.xml" 2>/dev/null; then
+          echo "Loaded existing appcast from gh-pages"
+        else
+          printf '%s\n' \
+            '<?xml version="1.0" standalone="yes"?>' \
+            '<rss xmlns:sparkle="http://www.andymatuschak.org/xml-namespaces/sparkle" version="2.0">' \
+            '  <channel>' \
+            '    <title>Thaw</title>' \
+            '    <language>en</language>' \
+            '  </channel>' \
+            '</rss>' > "$pages/appcast.xml"
+          echo "Created empty appcast stub"
+        fi
+
+        echo "SPARKLE_ARCHIVES=$archives" >> "$GITHUB_ENV"
+        echo "SPARKLE_PAGES=$pages" >> "$GITHUB_ENV"
+        ls -lh "$archives"
+
+    - name: Generate and sign appcast
+      id: appcast
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        CHANNEL: ${{ inputs.channel }}
+        SPARKLE_PRIVATE_KEY: ${{ inputs.sparkle-private-key }}
+        REPOSITORY: ${{ github.repository }}
+      run: |
+        set -euo pipefail
+
+        key_file="$RUNNER_TEMP/sparkle_eddsa_private.key"
+        printf '%s\n' "$SPARKLE_PRIVATE_KEY" > "$key_file"
+        chmod 600 "$key_file"
+
+        download_prefix="https://github.com/${REPOSITORY}/releases/download/${TAG}/"
+        args=(
+          --ed-key-file "$key_file"
+          --download-url-prefix "$download_prefix"
+          --link "https://github.com/${REPOSITORY}/releases/tag/${TAG}"
+          -o "$SPARKLE_PAGES/appcast.xml"
+        )
+
+        case "$CHANNEL" in
+          stable|"")
+            ;;
+          beta|alpha)
+            args+=(--channel "$CHANNEL")
+            ;;
+          *)
+            echo "Unsupported Sparkle channel: $CHANNEL"
+            exit 1
+            ;;
+        esac
+
+        "$SPARKLE_BIN/generate_appcast" "${args[@]}" "$SPARKLE_ARCHIVES"
+
+        rm -f "$key_file"
+
+        # Expose deltas that belong to this tag for release upload.
+        delta_glob="$SPARKLE_ARCHIVES/*.delta"
+        echo "appcast-path=$SPARKLE_PAGES/appcast.xml" >> "$GITHUB_OUTPUT"
+        echo "delta-glob=$delta_glob" >> "$GITHUB_OUTPUT"
+        echo "SPARKLE_DELTA_DIR=$SPARKLE_ARCHIVES" >> "$GITHUB_ENV"
+
+        echo "Appcast head:"
+        head -n 60 "$SPARKLE_PAGES/appcast.xml"
+
+    - name: Publish appcast to gh-pages
+      if: inputs.publish-appcast == 'true'
+      shell: bash
+      env:
+        TAG: ${{ inputs.tag }}
+        CHANNEL: ${{ inputs.channel }}
+        GITHUB_TOKEN: ${{ github.token }}
+      run: |
+        set -euo pipefail
+
+        work="$RUNNER_TEMP/gh-pages-work"
+        rm -rf "$work"
+        mkdir -p "$work"
+
+        git clone --depth 1 --branch gh-pages \
+          "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+          "$work" 2>/dev/null \
+        || {
+          git clone --depth 1 \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$work"
+          git -C "$work" checkout --orphan gh-pages
+          git -C "$work" rm -rf . >/dev/null 2>&1 || true
+        }
+
+        cp "$SPARKLE_PAGES/appcast.xml" "$work/appcast.xml"
+        if [[ ! -f "$work/.gitignore" ]]; then
+          printf '*\n!appcast.xml\n!.gitignore\n' > "$work/.gitignore"
+        fi
+
+        git -C "$work" config user.name "github-actions[bot]"
+        git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git -C "$work" add appcast.xml .gitignore
+        if git -C "$work" diff --staged --quiet; then
+          echo "appcast.xml unchanged"
+          exit 0
+        fi
+
+        git -C "$work" commit -m "chore(sparkle): publish appcast for ${TAG} (${CHANNEL})"
+        git -C "$work" push origin HEAD:gh-pages

--- a/.github/actions/sparkle-release/action.yml
+++ b/.github/actions/sparkle-release/action.yml
@@ -61,7 +61,8 @@ runs:
         fi
 
         # Ticket from DMG notarization applies to the same CDHash.
-        xcrun stapler staple "$app_path" || true
+        xcrun stapler staple "$app_path"
+        xcrun stapler validate "$app_path"
 
         zip_name="Thaw_${TAG}.zip"
         zip_path="build/$zip_name"
@@ -191,6 +192,12 @@ runs:
         esac
 
         "$SPARKLE_BIN/generate_appcast" "${args[@]}" "$SPARKLE_ARCHIVES"
+
+        # generate_appcast applies one --download-url-prefix to every archive.
+        # Rewrite enclosure URLs so each Thaw_<tag>.zip resolves under that tag.
+        perl -i -pe \
+          's#(url="https://github.com/\Q'"$REPOSITORY"'\E/releases/download/)[^/]+/(Thaw_([^"]+)\.zip")#$1$3/$2#g' \
+          "$SPARKLE_PAGES/appcast.xml"
 
         rm -f "$key_file"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,9 +62,9 @@ jobs:
           channel="$CHANNEL_INPUT"
           if [[ "$channel" == "auto" ]]; then
             shopt -s nocasematch
-            if [[ "$TAG_NAME" == *alpha* || "$TAG_NAME" == *nightly* ]]; then
+            if [[ "$TAG_NAME" =~ -(alpha|nightly)(\.|$) ]]; then
               channel="alpha"
-            elif [[ "$TAG_NAME" == *beta* || "$TAG_NAME" == *rc* ]]; then
+            elif [[ "$TAG_NAME" =~ -(beta|rc)(\.|$) ]]; then
               channel="beta"
             else
               channel="stable"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-26
+    runs-on: xcode-27
     permissions:
       contents: write
     env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,29 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to publish (for example, 1.2.3)
+        description: Release tag to publish (for example, 1.2.3 or 2.0.0-rc.1)
         required: true
         type: string
+      channel:
+        description: Sparkle channel (auto infers from tag suffix)
+        required: true
+        type: choice
+        default: auto
+        options:
+          - auto
+          - stable
+          - beta
+          - alpha
+      publish_release:
+        description: Publish the GitHub Release (uncheck to leave as draft)
+        required: false
+        type: boolean
+        default: false
+      publish_appcast:
+        description: Push signed appcast.xml to gh-pages
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   release:
@@ -23,18 +43,58 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          fetch-depth: 0
           ref: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', inputs.tag) || github.ref }}
 
-      - name: Validate tag name format
-        id: validate
+      - name: Resolve tag and channel
+        id: meta
         env:
           TAG_NAME: ${{ inputs.tag || github.ref_name }}
+          CHANNEL_INPUT: ${{ inputs.channel || 'auto' }}
         run: |
+          set -euo pipefail
+
           if [[ ! "$TAG_NAME" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9._]+)?$ ]]; then
-            echo "Invalid tag name format. Must be in the form 1.2.3"
+            echo "Invalid tag name format. Must be in the form 1.2.3 or 1.2.3-rc.1"
             exit 1
           fi
-      - run: sudo xcode-select -s /Applications/Xcode_26.5.app/Contents/Developer
+
+          channel="$CHANNEL_INPUT"
+          if [[ "$channel" == "auto" ]]; then
+            shopt -s nocasematch
+            if [[ "$TAG_NAME" == *alpha* || "$TAG_NAME" == *nightly* ]]; then
+              channel="alpha"
+            elif [[ "$TAG_NAME" == *beta* || "$TAG_NAME" == *rc* ]]; then
+              channel="beta"
+            else
+              channel="stable"
+            fi
+            shopt -u nocasematch
+          fi
+
+          case "$channel" in
+            stable|beta|alpha) ;;
+            *)
+              echo "Unsupported channel: $channel"
+              exit 1
+              ;;
+          esac
+
+          prerelease=false
+          if [[ "$channel" != "stable" ]]; then
+            prerelease=true
+          fi
+
+          {
+            echo "tag=$TAG_NAME"
+            echo "channel=$channel"
+            echo "prerelease=$prerelease"
+          } >> "$GITHUB_OUTPUT"
+
+          echo "tag=$TAG_NAME channel=$channel prerelease=$prerelease"
+
+      - run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
+
       - name: Configure signing
         uses: ./.github/actions/configure-signing
         with:
@@ -62,15 +122,91 @@ jobs:
           dmg-name: ${{ env.DMG_NAME }}
           app-name: ${{ env.APP_NAME }}
 
+      - name: Sparkle ZIP and appcast
+        id: sparkle
+        uses: ./.github/actions/sparkle-release
+        with:
+          tag: ${{ steps.meta.outputs.tag }}
+          channel: ${{ steps.meta.outputs.channel }}
+          app-name: ${{ env.APP_NAME }}
+          sparkle-private-key: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+          publish-appcast: "false"
+
+      - name: Collect release assets
+        id: assets
+        run: |
+          set -euo pipefail
+
+          list="$RUNNER_TEMP/release-assets.txt"
+          : > "$list"
+          printf '%s\n' "build/${DMG_NAME}" >> "$list"
+          printf '%s\n' "${{ steps.sparkle.outputs.zip-path }}" >> "$list"
+
+          shopt -s nullglob
+          for delta in "$RUNNER_TEMP"/sparkle-archives/*.delta; do
+            printf '%s\n' "$delta" >> "$list"
+          done
+
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          cat "$list" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "Release assets:"
+          cat "$list"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ inputs.tag || github.ref_name }}
-          files: build/${{ env.DMG_NAME }}
+          tag_name: ${{ steps.meta.outputs.tag }}
+          files: ${{ steps.assets.outputs.files }}
           generate_release_notes: false
-          draft: true
+          # Tag pushes publish immediately so Sparkle download URLs work.
+          # workflow_dispatch stays draft unless publish_release is checked.
+          draft: ${{ github.event_name == 'workflow_dispatch' && !inputs.publish_release }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish appcast to gh-pages
+        if: >-
+          (github.event_name != 'workflow_dispatch' || inputs.publish_appcast)
+          && (github.event_name != 'workflow_dispatch' || inputs.publish_release)
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          CHANNEL: ${{ steps.meta.outputs.channel }}
+          APPCAST_PATH: ${{ steps.sparkle.outputs.appcast-path }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          work="$RUNNER_TEMP/gh-pages-work"
+          rm -rf "$work"
+
+          git clone --depth 1 --branch gh-pages \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+            "$work" 2>/dev/null \
+          || {
+            git clone --depth 1 \
+              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
+              "$work"
+            git -C "$work" checkout --orphan gh-pages
+            git -C "$work" rm -rf . >/dev/null 2>&1 || true
+          }
+
+          cp "$APPCAST_PATH" "$work/appcast.xml"
+          if [[ ! -f "$work/.gitignore" ]]; then
+            printf '*\n!appcast.xml\n!.gitignore\n' > "$work/.gitignore"
+          fi
+
+          git -C "$work" config user.name "github-actions[bot]"
+          git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git -C "$work" add appcast.xml .gitignore
+          if git -C "$work" diff --staged --quiet; then
+            echo "appcast.xml unchanged"
+            exit 0
+          fi
+
+          git -C "$work" commit -m "chore(sparkle): publish appcast for ${TAG} (${CHANNEL})"
+          git -C "$work" push origin HEAD:gh-pages
 
       - name: Cleanup keychain
         if: always()


### PR DESCRIPTION
# Summary

Automates the Sparkle half of Thaw releases: produce a Sparkle ZIP, generate the appcast (EdDSA + deltas), attach assets to the GitHub Release, and publish `appcast.xml` to `gh-pages`. Infers Sparkle channel from the tag (`stable` / `beta` for `-rc`/`-beta` / `alpha` for `-alpha`/`-nightly`), with a `workflow_dispatch` override. Apple sign/notarize stays as-is.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

- [ ] Bug fix
- [x] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Extends the Release workflow to build `Thaw_<tag>.zip`, run `generate_appcast`, attach ZIP/deltas to the GitHub Release, then publish `appcast.xml` to `gh-pages` when the release is published.
- Infers Sparkle channel from the tag (`stable` / `beta` / `alpha`), with a `workflow_dispatch` channel override.
- Adds independent flags for publishing the GitHub Release vs the appcast (draft dry-runs remain possible).

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've added tests for new behavior (if applicable)
- [x] I've updated documentation as needed

## Other information

**Maintainer action required** before the first Sparkle release run — add this Actions secret:

- `SPARKLE_ED25519_PRIVATE_KEY` — EdDSA private key matching `SUPublicEDKey` in `Info.plist` (`fQ2kWqCLfAPAxQX1rp8gVNoG9hlAV/Gmm7kMBbxFe+A=`).

Without that secret, the new Sparkle step fails; DMG notarization is unchanged.

**Validation**

- [ ] Confirm `SPARKLE_ED25519_PRIVATE_KEY` is set in repo Actions secrets
- [ ] Dry-run via `workflow_dispatch` with `publish_release` unchecked (draft release, no appcast push)
- [ ] Tag or dispatch a prerelease (e.g. `x.y.z-rc.N`) and verify ZIP + deltas on the release, `sparkle:channel` = `beta` in appcast when published
- [ ] Verify `https://stonerl.github.io/Thaw/appcast.xml` updates only after the release is published (not while draft)
- [ ] Existing installs on Stable/Development still verify signatures against the current public key

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated Sparkle release packaging with notarized ZIPs, update feeds, and delta updates.
  * Supports stable, beta, alpha, and nightly release channels.
  * Release assets can include DMG, ZIP, and delta archives.
* **Improvements**
  * Release tags now automatically determine the appropriate update channel.
  * Manual releases can be prepared as drafts before publication.
  * Appcast publishing can be managed separately from GitHub Release publication.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->