### PR TITLE
fix(menubar): don't persist notch-overflow ejections into the saved layout

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -318,6 +318,15 @@ final class MenuBarItemManager: ObservableObject {
     /// Persisted per-section item order. Maps section key to an ordered list of
     /// `uniqueIdentifier` strings (right-to-left, matching cache array order).
     private var savedSectionOrder = [String: [String]]()
+
+    /// Identifiers most recently moved from visible to hidden by the
+    /// notch-overflow rebalance (Phase 4 of the layout apply). The ejection
+    /// is a transient, per-display accommodation — these items must not be
+    /// persisted as hidden (the user never moved them), and their divergence
+    /// from the saved layout is intentional while the notched display is
+    /// active. Cleared when overflow no longer applies, when a non-notched
+    /// apply restores them, or when the user moves them to another section.
+    private var notchOverflowEjectedUIDs = Set<String>()
     /// Placement preference for newly detected menu bar items.
     @Published private(set) var newItemsPlacement = NewItemsPlacement.defaultValue
 
@@ -504,11 +513,23 @@ final class MenuBarItemManager: ObservableObject {
             return !item.isControlItem && item.sourcePID != nil
         }
 
+        // Items the notch-overflow rebalance ejected that are still sitting
+        // in hidden are treated as absent from the current layout: they then
+        // ride planSectionOrder's closed-app position-preserving merge and
+        // keep their saved visible positions instead of being persisted as
+        // hidden. An ejected item found in any OTHER section was moved by
+        // the user — drop it from the tracked set and persist it normally.
+        let ejectedStillInHidden = notchOverflowEjectedUIDs.intersection(
+            Set(cache[.hidden].map(\.uniqueIdentifier))
+        )
+        notchOverflowEjectedUIDs = ejectedStillInHidden
+
         var allCurrentIdentifiers = Set<String>()
         var allCurrentBaseIdentifiers = Set<String>()
         for section in MenuBarSection.Name.allCases {
             for item in cache[section] where isPersistable(item) {
                 guard !pendingRehideTagIDs.contains(item.tag.tagIdentifier) else { continue }
+                guard !ejectedStillInHidden.contains(item.uniqueIdentifier) else { continue }
                 // Always track base identifier so stale saved entries for
                 // transient items (Live Activities) get pruned by the
                 // isStaleInstanceIndex guard below and not re-injected.
@@ -529,7 +550,8 @@ final class MenuBarItemManager: ObservableObject {
                 .filter {
                     isPersistable($0) &&
                         !$0.isTransientControlCenterItem &&
-                        !pendingRehideTagIDs.contains($0.tag.tagIdentifier)
+                        !pendingRehideTagIDs.contains($0.tag.tagIdentifier) &&
+                        !ejectedStillInHidden.contains($0.uniqueIdentifier)
                 }
                 .map(\.uniqueIdentifier)
 
@@ -6131,6 +6153,10 @@ extension MenuBarItemManager {
                 availableWidth: availableWidth
             )
 
+            // Replace (not union) so items freed by a previous overflow drop
+            // out of the tracked set once they no longer overflow.
+            notchOverflowEjectedUIDs = Set(overflowResult.overflowUIDs)
+
             if !overflowResult.overflowUIDs.isEmpty {
                 MenuBarItemManager.diagLog.info(
                     "Profile layout: notch overflow; \(overflowResult.overflowUIDs.count) item(s) moved from visible to hidden"
@@ -6138,6 +6164,11 @@ extension MenuBarItemManager {
                 desiredFiltered = overflowResult.updatedDesiredFiltered
                 sectionMap = overflowResult.updatedSectionMap
             }
+        } else if !notchOverflowEjectedUIDs.isEmpty {
+            // Overflow doesn't apply here (no notch, or the feature is off):
+            // this apply restores the saved layout verbatim, so the ejection
+            // bookkeeping is obsolete.
+            notchOverflowEjectedUIDs.removeAll()
         }
 
         // MARK: Phase 5: choose execution strategy (full-sort vs LCS)
@@ -6674,6 +6705,18 @@ extension MenuBarItemManager {
         let hiddenMaxX = controlItems.hidden.bounds.maxX
         let ahBounds = controlItems.alwaysHidden?.bounds
 
+        // While the overflow feature is enabled and the active menu bar is
+        // on a notched display, items the overflow rebalance ejected into
+        // hidden diverge from the saved layout by design — reporting them
+        // as divergent would re-dispatch a bulk apply every cache cycle.
+        // The skip requires all three of: the feature still enabled (a
+        // toggle-off must restore items promptly), a notched active display
+        // (elsewhere the divergence is what triggers the restoring apply),
+        // and the item actually sitting in hidden (an ejected item that
+        // drifted to another section is genuine drift).
+        let overflowSkipActive = (appState?.settings.advanced.enableMenuBarItemOverflow ?? false)
+            && ((NSScreen.screenWithActiveMenuBar ?? NSScreen.main)?.hasNotch ?? false)
+
         for item in items where !item.isControlItem && item.canBeHidden && item.isMovable {
             let baseID = "\(item.tag.namespace):\(item.tag.title)"
             guard let expectedSection = savedSectionByBaseID[baseID] else {
@@ -6693,6 +6736,12 @@ extension MenuBarItemManager {
             }
 
             guard let currentSection else { continue }
+            if overflowSkipActive,
+               currentSection == .hidden,
+               notchOverflowEjectedUIDs.contains(item.uniqueIdentifier)
+            {
+                continue
+            }
             if currentSection != expectedSection {
                 return true
             }


### PR DESCRIPTION
# Summary

Phase-4 notch-overflow rebalance is transient, but section-order persistence captured post-ejection arrangements as user moves and permanently rewrote the saved layout.

**Scope:** Do not persist notch-overflow ejections into saved section order; restore on non-notched displays.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #790

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Tracks `notchOverflowEjectedUIDs` in memory:
1. Persistence — ejected items in hidden keep saved visible slots.
2. Divergence — skip ejected divergence only while a notched display is active.
3. Lifecycle — set replaced each overflow computation; cleared when overflow does not apply.

Independent of #785.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild build-for-testing` on macos-26 / Xcode 26.6
- ~25h soak: 5 notch ejections, zero persisted

## Known limitations / follow-ups

- In-memory set only; after restart, first notched apply recomputes ejections.

## Other information

Diagnosis and log evidence in #790.
