### PR TITLE
fix(service): resolve parked items whose title is their bundle identifier

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -535,6 +535,36 @@ final class SourcePIDCache {
             }
         }
 
+        // Title-identity fallback for parked (off-screen) items.
+        //
+        // The spatial passes need an AX child near the CG window and the
+        // marker-pair pass only considers on-screen icons, so a widget whose
+        // window title is its own bundle identifier (Little Snitch's agent)
+        // becomes unresolvable the moment it is parked at off-screen
+        // coordinates — and an unresolvable hidden item can never be matched
+        // back to its saved section. An exact title == bundle-identifier
+        // match against a running application is direct ownership evidence
+        // that needs no geometry; the reverse-DNS shape requirement keeps
+        // generic slot titles (Item-0) away from the lookup.
+        if !unresolvedWindows.isEmpty {
+            let unresolvedInfos = allWindows.filter { unresolvedWindows.contains($0.windowID) }
+            for window in unresolvedInfos {
+                guard let title = window.title,
+                      title.split(separator: ".").count >= 3,
+                      let pid = NSRunningApplication
+                          .runningApplications(withBundleIdentifier: title)
+                          .first?
+                          .processIdentifier
+                else { continue }
+                SourcePIDCache.diagLog.info(
+                    "SourcePIDCache title-identity resolution: windowID=\(window.windowID) → PID \(pid) (title=\(title))"
+                )
+                state.withLock { $0.pids[window.windowID] = pid }
+                unresolvedWindows.remove(window.windowID)
+                totalMatchesFound += 1
+            }
+        }
+
         let finalPID = state.withLock { $0.pids[window.windowID] }
         SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsWithBar) with extras bar, \(totalChildrenChecked) children)")
 


### PR DESCRIPTION
# Summary

Widgets that title their status window with their bundle identifier (e.g. Little Snitch) become unresolvable when parked off-screen in hidden, because spatial/marker-pair passes need on-screen geometry.

**Scope:** Title-identity fallback for parked windows whose title equals a running app’s bundle identifier.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #795

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

After the marker-pair pass, a geometry-free title-identity fallback resolves windows whose title exactly equals a running application’s bundle identifier. Reverse-DNS shape (≥3 segments) keeps generic slot titles out.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild build-for-testing` on macos-26 / Xcode 26.6
- Live repro + ~25h soak (518 resolutions, 0 false positives)

## Known limitations / follow-ups

- Filed by Lathe; diagnosis in #795.

## Other information

Stranded Little Snitch item restored on first pass after this change.
