### PR TITLE
ci(sonar): exclude Icon Composer bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - ".github/workflows/ci.yml"
       - "Package.swift"
+      - "sonar-project.properties"
       - "**/*.swift"
       - "**/*.xcstrings"
   push:
@@ -16,6 +17,7 @@ on:
     paths:
       - ".github/workflows/ci.yml"
       - "Package.swift"
+      - "sonar-project.properties"
       - "**/*.swift"
       - "**/*.xcstrings"
   workflow_dispatch:

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,7 +9,7 @@ sonar.sources = Thaw,Shared,MenuBarItemService
 sonar.tests = ThawTests
 
 sonar.exclusions = \
-  **/*.png,**/*.pdf,**/*.xcassets/**,**/*.xcstrings,**/*.imageset/**
+  **/*.png,**/*.pdf,**/*.xcassets/**,**/*.xcstrings,**/*.imageset/**,**/*.icon/**
 
 # Exclude UI and system-dependent code from coverage requirements
 sonar.coverage.exclusions = \


### PR DESCRIPTION
# Summary

- Exclude Xcode Icon Composer `.icon` bundles from Sonar source analysis while leaving generated icon asset data unchanged.
- Trigger CI when `sonar-project.properties` changes so the trusted post-merge scan verifies the exclusion immediately.

Refs #316

## PR Type

- [ ] Bugfix
- [x] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the new behavior?

Sonar no longer tries to parse Xcode-managed `.icon` bundle contents as ordinary source files. CI path filters now include `sonar-project.properties`, allowing fork PRs to run the normal non-secret checks and trusted repository pushes to run Sonar analysis.

This targets the remaining `json:S2260` issue on `development` for `Thaw/Resources/AppIcon.icon/icon.json`.

## Validation

- `jq empty Thaw/Resources/AppIcon.icon/icon.json`
- Verified `**/*.icon/**` matches the reported Icon Composer JSON path
- Parsed `.github/workflows/ci.yml` as YAML
- `git diff --check`
- Unsigned arm64 Debug build with Xcode completed successfully

## PR Checklist

- [ ] I have built and run the app locally and verified that it works as expected
- [ ] I have run `swiftformat .` to keep the code style consistent
- [x] Tests are not applicable to the configuration behavior itself; the repository CI remains the integration gate
- [x] Documentation is not required for this configuration-only change

## Other information

Because this fork PR modifies the workflow, GitHub requires upstream approval before the CI jobs can start. Once approved, the fork PR will run the normal non-secret checks and skip Sonar because repository secrets are unavailable. After merge, the `development` push workflow will run the trusted Sonar scan because the config path is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to run when code-quality configuration changes.
  * Refined code-quality analysis exclusions for additional icon-related assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->