### PR TITLE
fix(menubar): only run notch overflow on the main display

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -347,6 +347,27 @@ enum LayoutSolver {
         rightBoundary.isFinite && rightBoundary > notchMaxX
     }
 
+    /// Whether the notch-overflow rebalance should run for the current active
+    /// menu bar display.
+    ///
+    /// Overflow ejection is only meaningful on the display the user's persistent
+    /// layout is anchored to — the *main* menu bar display. When a notched
+    /// display is merely a secondary (e.g. a MacBook whose built-in screen sits
+    /// next to a non-notched external that is the main display), macOS relocates
+    /// the status items onto the built-in's menu bar only while it transiently
+    /// holds focus. Computing the narrow beside-notch budget there ejects
+    /// profile items that fit fine on the main display, and they stay stranded
+    /// in hidden once focus returns to the main screen. So overflow runs only
+    /// when the active notched display is also the main display; on a notched
+    /// secondary the saved layout is honoured verbatim.
+    static nonisolated func shouldManageNotchOverflow(
+        overflowEnabled: Bool,
+        activeHasNotch: Bool,
+        activeIsMainDisplay: Bool
+    ) -> Bool {
+        overflowEnabled && activeHasNotch && activeIsMainDisplay
+    }
+
     /// Whether the given menu bar items currently occupy more than one display.
     ///
     /// Each center is matched to the screen frame that contains it. Frames and

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -360,12 +360,20 @@ enum LayoutSolver {
     /// in hidden once focus returns to the main screen. So overflow runs only
     /// when the active notched display is also the main display; on a notched
     /// secondary the saved layout is honoured verbatim.
+    ///
+    /// `activeScreenKnown` is whether `NSScreen.screenWithActiveMenuBar`
+    /// actually resolved a screen. When it is `false` (e.g. mid
+    /// display-reconfiguration) the gate fails closed: guessing a screen —
+    /// such as falling back to `NSScreen.main` — risks computing the budget
+    /// against a display the layout is not anchored to, which is the same
+    /// mis-budget failure this gate exists to prevent.
     static nonisolated func shouldManageNotchOverflow(
         overflowEnabled: Bool,
+        activeScreenKnown: Bool,
         activeHasNotch: Bool,
         activeIsMainDisplay: Bool
     ) -> Bool {
-        overflowEnabled && activeHasNotch && activeIsMainDisplay
+        overflowEnabled && activeScreenKnown && activeHasNotch && activeIsMainDisplay
     }
 
     /// Whether the given menu bar items currently occupy more than one display.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -6025,9 +6025,28 @@ extension MenuBarItemManager {
         // Advanced Settings; when off, the saved profile layout is honoured
         // verbatim and items the notch would otherwise eject stay in visible.
         let activeScreen = NSScreen.screenWithActiveMenuBar ?? NSScreen.main
+        let activeIsMainDisplay = activeScreen?.displayID == CGMainDisplayID()
+        // A notched display that isn't the main menu bar display only hosts the
+        // status items transiently (while it holds focus); ejecting there
+        // strands profile items in hidden once focus returns to the main
+        // screen. Log the skip so the field logs make the reason explicit.
         if appState.settings.advanced.enableMenuBarItemOverflow,
            let screen = activeScreen,
            screen.hasNotch,
+           !activeIsMainDisplay
+        {
+            MenuBarItemManager.diagLog.debug(
+                "Notch overflow: skipping — active notched display \(screen.displayID) is a secondary "
+                    + "(main display is \(CGMainDisplayID())); overflow only manages the main menu bar, "
+                    + "so the saved layout is honoured verbatim"
+            )
+        }
+        if LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: appState.settings.advanced.enableMenuBarItemOverflow,
+            activeHasNotch: activeScreen?.hasNotch ?? false,
+            activeIsMainDisplay: activeIsMainDisplay
+        ),
+           let screen = activeScreen,
            let notch = screen.frameOfNotch
         {
             let notchGap = MenuBarSection.notchGap

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -6024,29 +6024,40 @@ extension MenuBarItemManager {
         // Gated by the user-facing "Enable menu bar item overflow" toggle in
         // Advanced Settings; when off, the saved profile layout is honoured
         // verbatim and items the notch would otherwise eject stay in visible.
-        let activeScreen = NSScreen.screenWithActiveMenuBar ?? NSScreen.main
-        let activeIsMainDisplay = activeScreen?.displayID == CGMainDisplayID()
+        // The overflow gate reads the *actual* active menu bar screen — no
+        // `NSScreen.main` fallback. Guessing a screen while the active one is
+        // unknown risks budgeting against the wrong display, which is the
+        // exact failure this gate prevents, so the gate fails closed instead.
+        // `activeScreen` keeps the fallback solely for the Phase-5 execution
+        // strategy choice below, where a guess only picks a sort strategy.
+        let activeMenuBarScreen = NSScreen.screenWithActiveMenuBar
+        let activeScreen = activeMenuBarScreen ?? NSScreen.main
+        let activeIsMainDisplay = activeMenuBarScreen?.displayID == CGMainDisplayID()
         // A notched display that isn't the main menu bar display only hosts the
         // status items transiently (while it holds focus); ejecting there
         // strands profile items in hidden once focus returns to the main
-        // screen. Log the skip so the field logs make the reason explicit.
-        if appState.settings.advanced.enableMenuBarItemOverflow,
-           let screen = activeScreen,
-           screen.hasNotch,
-           !activeIsMainDisplay
-        {
-            MenuBarItemManager.diagLog.debug(
-                "Notch overflow: skipping — active notched display \(screen.displayID) is a secondary "
-                    + "(main display is \(CGMainDisplayID())); overflow only manages the main menu bar, "
-                    + "so the saved layout is honoured verbatim"
-            )
+        // screen. Log the skips so the field logs make the reason explicit.
+        if appState.settings.advanced.enableMenuBarItemOverflow {
+            if let screen = activeMenuBarScreen, screen.hasNotch, !activeIsMainDisplay {
+                MenuBarItemManager.diagLog.debug(
+                    "Notch overflow: skipping — active notched display \(screen.displayID) is a secondary "
+                        + "(main display is \(CGMainDisplayID())); overflow only manages the main menu bar, "
+                        + "so the saved layout is honoured verbatim"
+                )
+            } else if activeMenuBarScreen == nil {
+                MenuBarItemManager.diagLog.debug(
+                    "Notch overflow: skipping — active menu bar display is unknown; "
+                        + "overflow does not guess a screen, so the saved layout is honoured verbatim"
+                )
+            }
         }
         if LayoutSolver.shouldManageNotchOverflow(
             overflowEnabled: appState.settings.advanced.enableMenuBarItemOverflow,
-            activeHasNotch: activeScreen?.hasNotch ?? false,
+            activeScreenKnown: activeMenuBarScreen != nil,
+            activeHasNotch: activeMenuBarScreen?.hasNotch ?? false,
             activeIsMainDisplay: activeIsMainDisplay
         ),
-           let screen = activeScreen,
+           let screen = activeMenuBarScreen,
            let notch = screen.frameOfNotch
         {
             let notchGap = MenuBarSection.notchGap

--- a/ThawTests/PlanNotchOverflowTests.swift
+++ b/ThawTests/PlanNotchOverflowTests.swift
@@ -455,4 +455,49 @@ final class PlanNotchOverflowTests: XCTestCase {
         )
         XCTAssertEqual(result.updatedSectionMap["a"], "hidden")
     }
+
+    // MARK: - Display gate (shouldManageNotchOverflow)
+
+    /// A notched display that is the main menu bar display runs overflow —
+    /// e.g. a MacBook used on its own, or with the built-in set as main.
+    func testOverflowRunsOnNotchedMainDisplay() {
+        XCTAssertTrue(LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: true,
+            activeHasNotch: true,
+            activeIsMainDisplay: true
+        ))
+    }
+
+    /// A notched *secondary* display must NOT run overflow. This is the field
+    /// bug: a MacBook built-in next to a non-notched external main display.
+    /// The active menu bar transiently flips to the built-in, the 447pt
+    /// beside-notch budget ejects two profile items, and they stay stranded in
+    /// hidden once focus returns to the external. Gating on the main display
+    /// keeps the saved layout intact.
+    func testOverflowSkippedOnNotchedSecondaryDisplay() {
+        XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: true,
+            activeHasNotch: true,
+            activeIsMainDisplay: false
+        ))
+    }
+
+    /// A non-notched main display (e.g. an external as the only/primary screen)
+    /// has no notch to overflow around.
+    func testOverflowSkippedOnNonNotchedMainDisplay() {
+        XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: true,
+            activeHasNotch: false,
+            activeIsMainDisplay: true
+        ))
+    }
+
+    /// The user toggle wins regardless of geometry.
+    func testOverflowSkippedWhenDisabled() {
+        XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: false,
+            activeHasNotch: true,
+            activeIsMainDisplay: true
+        ))
+    }
 }

--- a/ThawTests/PlanNotchOverflowTests.swift
+++ b/ThawTests/PlanNotchOverflowTests.swift
@@ -463,6 +463,7 @@ final class PlanNotchOverflowTests: XCTestCase {
     func testOverflowRunsOnNotchedMainDisplay() {
         XCTAssertTrue(LayoutSolver.shouldManageNotchOverflow(
             overflowEnabled: true,
+            activeScreenKnown: true,
             activeHasNotch: true,
             activeIsMainDisplay: true
         ))
@@ -477,6 +478,7 @@ final class PlanNotchOverflowTests: XCTestCase {
     func testOverflowSkippedOnNotchedSecondaryDisplay() {
         XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
             overflowEnabled: true,
+            activeScreenKnown: true,
             activeHasNotch: true,
             activeIsMainDisplay: false
         ))
@@ -487,7 +489,20 @@ final class PlanNotchOverflowTests: XCTestCase {
     func testOverflowSkippedOnNonNotchedMainDisplay() {
         XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
             overflowEnabled: true,
+            activeScreenKnown: true,
             activeHasNotch: false,
+            activeIsMainDisplay: true
+        ))
+    }
+
+    /// While the active menu bar display is unknown (e.g. mid
+    /// display-reconfiguration), overflow must not run against a guessed
+    /// screen — even one that would qualify (notched + main).
+    func testOverflowSkippedWhileActiveDisplayUnknown() {
+        XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
+            overflowEnabled: true,
+            activeScreenKnown: false,
+            activeHasNotch: true,
             activeIsMainDisplay: true
         ))
     }
@@ -496,6 +511,7 @@ final class PlanNotchOverflowTests: XCTestCase {
     func testOverflowSkippedWhenDisabled() {
         XCTAssertFalse(LayoutSolver.shouldManageNotchOverflow(
             overflowEnabled: false,
+            activeScreenKnown: true,
             activeHasNotch: true,
             activeIsMainDisplay: true
         ))


### PR DESCRIPTION
# Summary

Gates Phase-4 notch-overflow rebalance in `applyProfileLayout` on the active notched display also being the **main** display (`CGMainDisplayID()`). On a notched secondary, the saved layout is honoured verbatim.

**Scope:** Notch-overflow gate only — stop spurious ejections when the notched display is not main.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #808

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- New pure helper `LayoutSolver.shouldManageNotchOverflow(...)`.
- `applyProfileLayout` Phase 4 consults it; notched-secondary skips are logged.
- Unit tests cover all four gate combinations.
- Unchanged for a notched laptop alone or with the built-in as main.

Related but distinct from #790.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test` green on macos-26 CI (`PlanNotchOverflowTests`)

## Known limitations / follow-ups

- Needs real multi-display / notch validation beyond CI.

## Other information

Field-validated on the affected arrangement; full log analysis in #808.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar notch-overflow handling across multiple displays.
  * Preserves saved layouts on secondary displays with notches.
  * Prevents overflow adjustments when the active display cannot be determined or is not eligible.
* **Tests**
  * Added coverage for main, secondary, non-notched, unknown-display, and disabled-overflow scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->