### PR TITLE
fix(layout): ignore unresolved Control Center placeholders

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -244,10 +244,17 @@ enum LayoutSolver {
         // Items sitting left of the hidden divider. The Thaw icon is a
         // control item but must always be visible, so we admit it here.
         let leftmostItems = items
-            .filter {
-                $0.bounds.maxX <= observation.hiddenBounds.minX &&
-                    $0.isMovable &&
-                    (!$0.isControlItem || $0.tag == .visibleControlItem)
+            .filter { item in
+                // Generic Control Center placeholders are not draggable, but
+                // the planner must still see them so the unresolved-sourcePID
+                // safety path below can defer relocation without acting on an
+                // unstable identifier.
+                let isUnresolvedControlCenterPlaceholder =
+                    item.tag.isControlCenterGenericItem && item.sourcePID == nil
+
+                return item.bounds.maxX <= observation.hiddenBounds.minX &&
+                    (item.isMovable || isUnresolvedControlCenterPlaceholder) &&
+                    (!item.isControlItem || item.tag == .visibleControlItem)
             }
             .sorted { $0.bounds.minX < $1.bounds.minX }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -34,7 +34,11 @@ struct MenuBarItem: CustomStringConvertible {
 
     /// A Boolean value that indicates whether this item can be moved.
     var isMovable: Bool {
-        tag.isMovable
+        // Generic Control Center slots (``Item-N``) without a resolved
+        // source process are system-owned placeholders. Posting drag events
+        // to Control Center for them always times out, so presenting them as
+        // movable in the layout editor leads to a misleading generic error.
+        tag.isMovable && !(tag.isControlCenterGenericItem && sourcePID == nil)
     }
 
     /// A Boolean value that indicates whether this item can be hidden.

--- a/ThawTests/MenuBarItemTagTests.swift
+++ b/ThawTests/MenuBarItemTagTests.swift
@@ -296,6 +296,26 @@ final class MenuBarItemTagTests: XCTestCase {
         XCTAssertTrue(tag.isMovable)
     }
 
+    func testUnresolvedGenericControlCenterItemIsNotMovable() {
+        let item = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .controlCenter, title: "Item-13"),
+            windowID: 13,
+            sourcePID: nil
+        )
+
+        XCTAssertFalse(item.isMovable)
+    }
+
+    func testResolvedGenericControlCenterItemKeepsItsTagMovability() {
+        let item = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .controlCenter, title: "Item-13"),
+            windowID: 13,
+            sourcePID: 1234
+        )
+
+        XCTAssertTrue(item.isMovable)
+    }
+
     // MARK: - Can Be Hidden Tests
 
     func testVisibleControlItemCannotBeHidden() {

--- a/ThawTests/ProfileTests.swift
+++ b/ThawTests/ProfileTests.swift
@@ -421,7 +421,7 @@ final class ProfileFullTests: XCTestCase {
         let decoded = try decoder.decode(Profile.self, from: json)
 
         // Should use defaults
-        XCTAssertEqual(decoded.name, "Untitled")
+        XCTAssertEqual(decoded.name, String(localized: "Untitled"))
         XCTAssertNotNil(decoded.id)
     }
 


### PR DESCRIPTION
# Summary

Prevent unresolved generic Control Center slots (`Item-N` with no `sourcePID`) from being exposed as movable items, while still preserving the layout planner's existing unresolved-PID safety gate.

The same full-suite run also exposed a locale-dependent profile test. The assertion now compares against the localized `Untitled` fallback instead of hard-coding English, so the suite passes on non-English macOS installations.

**Scope:** Unresolved Control Center placeholder handling and the minimal test correction required to validate the complete suite on a localized system.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Generic Control Center placeholders with an unresolved source process are not presented as movable.
- The leftmost-item planner still observes those placeholders so unresolved-sourcePID can defer relocation.
- Once a generic slot has a resolved `sourcePID`, it keeps normal tag movability.
- Profile decoding tests validate the localized fallback name instead of assuming English.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test … -only-testing:ThawTests/MenuBarItemTagTests -only-testing:ThawTests/PlanLeftmostMoveTests` — 59 passed
- `xcodebuild test … -only-testing:ThawTests/ProfileFullTests/testDecodeProfileWithEmptyJSON` — 1 passed
- Full `xcodebuild test` — 760 passed (CODE_SIGNING_ALLOWED=NO on macOS 26.5.2 / Xcode 26.6)

## Known limitations / follow-ups

- Runtime UI not re-recorded; related context #784 / #785.

## Other information

Rebased onto `upstream/development` at `73c8d3fd` before validation.
