### PR TITLE
fix(capture): validate capture bounds before WindowServer handoff

### DIFF
--- a/Shared/Bridging/Bridging.swift
+++ b/Shared/Bridging/Bridging.swift
@@ -576,6 +576,11 @@ nonisolated extension Bridging {
         let boundsDesc = bounds.isNull ? "null (auto)" : String(format: "(%.0f,%.0f %.0fx%.0f)", bounds.origin.x, bounds.origin.y, bounds.width, bounds.height)
         diagLog.debug("captureWindowsImage: using SkyLight API, bounds=\(boundsDesc), windowCount=\(windowIDs.count), options=\(options.rawValue)")
 
+        guard isValidCaptureBounds(bounds) else {
+            diagLog.error("captureWindowsImage: refusing capture with invalid bounds \(boundsDesc) for \(windowIDs.count) windows — see issue #759")
+            return nil
+        }
+
         // Use SkyLight's private API instead of deprecated CGWindowListCreateImageFromArray
         guard let image = fn(bounds, windowArray as CFArray, options)?.takeRetainedValue() else {
             diagLog.warning("captureWindowsImage: SLWindowListCreateImageFromArray returned nil for \(windowIDs.count) windows (IDs: \(windowIDs.prefix(5)))")
@@ -584,6 +589,66 @@ nonisolated extension Bridging {
 
         diagLog.debug("captureWindowsImage: captured \(windowIDs.count) windows → \(image.width)×\(image.height)px")
         return image
+    }
+
+    /// The largest texture dimension the window server will accept for a
+    /// capture, in pixels.
+    ///
+    /// Metal's texture limit on every Apple silicon family is 16384; the
+    /// window server builds an `MTLTexture` for the requested capture size,
+    /// and `-[MTLTextureDescriptorInternal validateWithDevice:]` calls
+    /// `abort()` — inside **WindowServer**, taking down the whole graphical
+    /// session — when the descriptor exceeds it. See issue #759.
+    static let maximumCaptureDimension = 16384
+
+    /// Returns `true` if `bounds` is safe to send to the window server as a
+    /// capture rectangle.
+    ///
+    /// `CGRect.null` is explicitly allowed: both `SLWindowListCreateImageFromArray`
+    /// and this file's ScreenCaptureKit path treat a null rect as "compute the
+    /// bounds automatically", which is a legitimate and common request.
+    ///
+    /// Everything else must describe a real, drawable region. A degenerate
+    /// rectangle does not fail gracefully — it crashes WindowServer for the
+    /// whole machine (issue #759), so this is a hard precondition, not a
+    /// tidiness check.
+    ///
+    /// - Parameters:
+    ///   - bounds: The capture rectangle, in points.
+    ///   - scale: The point-to-pixel scale that will be applied. The window
+    ///     server allocates the *pixel* size, so the limit must be checked
+    ///     after scaling.
+    static func isValidCaptureBounds(_ bounds: CGRect, scale: CGFloat = 1.0) -> Bool {
+        if bounds.isNull {
+            return true
+        }
+        // NOTE: there is no public `CGRect.isFinite`. A member by that name
+        // exists, but it is `package`-visibility inside SwiftUICore and is
+        // inaccessible here. Check the four components instead —
+        // `FloatingPoint.isFinite` is genuinely public and rejects both NaN
+        // and infinity, which also covers the `CGRect.infinite` sentinel.
+        guard
+            bounds.origin.x.isFinite,
+            bounds.origin.y.isFinite,
+            bounds.size.width.isFinite,
+            bounds.size.height.isFinite,
+            scale.isFinite,
+            scale > 0
+        else {
+            return false
+        }
+        guard bounds.width > 0, bounds.height > 0 else {
+            return false
+        }
+        let pixelWidth = (bounds.width * scale).rounded()
+        let pixelHeight = (bounds.height * scale).rounded()
+        guard
+            pixelWidth <= CGFloat(maximumCaptureDimension),
+            pixelHeight <= CGFloat(maximumCaptureDimension)
+        else {
+            return false
+        }
+        return true
     }
 }
 
@@ -652,6 +717,11 @@ nonisolated extension Bridging {
             return unionBounds
         }()
 
+        guard isValidCaptureBounds(effectiveBounds) else {
+            diagLog.error("captureWindowsImageSCK: refusing capture with invalid effectiveBounds=\(effectiveBounds) (screenBounds=\(String(describing: screenBounds)), unionBounds=\(unionBounds)) — see issue #759")
+            return nil
+        }
+
         // Pick the display that holds the largest share of unionBounds. A
         // strict frame.contains check rejected status-item windows whose
         // bounds overshoot NSScreen.frame.maxX by a handful of pixels
@@ -685,6 +755,11 @@ nonisolated extension Bridging {
         let scale: CGFloat = options.contains(.nominalResolution)
             ? 1.0
             : CGFloat(filter.pointPixelScale)
+
+        guard isValidCaptureBounds(effectiveBounds, scale: scale) else {
+            diagLog.error("captureWindowsImageSCK: refusing capture, scaled size exceeds \(maximumCaptureDimension)px: effectiveBounds=\(effectiveBounds) scale=\(scale) — see issue #759")
+            return nil
+        }
 
         configuration.sourceRect = CGRect(
             x: effectiveBounds.origin.x - display.frame.origin.x,

--- a/Thaw/Utilities/ScreenCapture.swift
+++ b/Thaw/Utilities/ScreenCapture.swift
@@ -181,6 +181,11 @@ nonisolated enum ScreenCapture {
         let displayFrame = display.frame
         let scale = Double(filter.pointPixelScale)
 
+        guard Bridging.isValidCaptureBounds(screenBounds, scale: CGFloat(scale)) else {
+            diagLog.error("captureScreenBelowWindow: refusing capture with invalid screenBounds=\(screenBounds) scale=\(scale) — see issue #759")
+            return nil
+        }
+
         let localSourceRect = CGRect(
             x: screenBounds.origin.x - displayFrame.origin.x,
             y: screenBounds.origin.y - displayFrame.origin.y,

--- a/ThawTests/CaptureBoundsValidationTests.swift
+++ b/ThawTests/CaptureBoundsValidationTests.swift
@@ -1,0 +1,84 @@
+//
+//  CaptureBoundsValidationTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+@testable import Thaw
+import XCTest
+
+/// Regression tests for the capture-bounds validation guard added for
+/// issue #759 (degenerate capture rectangles crashing WindowServer).
+final class CaptureBoundsValidationTests: XCTestCase {
+    func testNullBoundsAreValid() {
+        XCTAssertTrue(Bridging.isValidCaptureBounds(.null))
+    }
+
+    func testNormalBoundsAreValid() {
+        let bounds = CGRect(x: 0, y: 0, width: 1470, height: 33)
+        XCTAssertTrue(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testZeroWidthIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 0, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testZeroHeightIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 0)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testNegativeWidthIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: -100, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testNegativeHeightIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: -33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testNonFiniteOriginIsInvalid() {
+        let bounds = CGRect(x: CGFloat.nan, y: 0, width: 100, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testInfiniteRectIsInvalid() {
+        XCTAssertFalse(Bridging.isValidCaptureBounds(.infinite))
+    }
+
+    func testDimensionAtMaximumIsValid() {
+        let bounds = CGRect(x: 0, y: 0, width: CGFloat(Bridging.maximumCaptureDimension), height: 33)
+        XCTAssertTrue(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testDimensionOverMaximumIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: CGFloat(Bridging.maximumCaptureDimension + 1), height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds))
+    }
+
+    func testScaleAppliedBeforeMaximumCheck() {
+        // 8500 points at 2x scale is 17000px, past the 16384px limit even
+        // though the point-space rect looks reasonable on its own.
+        let bounds = CGRect(x: 0, y: 0, width: 8500, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds, scale: 2.0))
+    }
+
+    func testNonFiniteScaleIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds, scale: .nan))
+    }
+
+    func testZeroScaleIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds, scale: 0))
+    }
+
+    func testNegativeScaleIsInvalid() {
+        let bounds = CGRect(x: 0, y: 0, width: 100, height: 33)
+        XCTAssertFalse(Bridging.isValidCaptureBounds(bounds, scale: -1))
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -1,6 +1,6 @@
 $(SRCROOT)/MenuBarItemService/Listener.swift
-$(SRCROOT)/MenuBarItemService/main.swift
 $(SRCROOT)/MenuBarItemService/SourcePIDCache.swift
+$(SRCROOT)/MenuBarItemService/main.swift
 $(SRCROOT)/Shared/Bridging/Bridging.swift
 $(SRCROOT)/Shared/Bridging/Shims.swift
 $(SRCROOT)/Shared/Services/MenuBarItemService.swift
@@ -121,10 +121,10 @@ $(SRCROOT)/Thaw/UI/IceUI/IceSection.swift
 $(SRCROOT)/Thaw/UI/IceUI/IceSlider.swift
 $(SRCROOT)/Thaw/UI/IceUI/IceWindow.swift
 $(SRCROOT)/Thaw/UI/Modifiers/LocalEventMonitorModifier.swift
-$(SRCROOT)/Thaw/UI/Modifiers/Once.swift
 $(SRCROOT)/Thaw/UI/Modifiers/OnFrameChange.swift
 $(SRCROOT)/Thaw/UI/Modifiers/OnKeyDown.swift
 $(SRCROOT)/Thaw/UI/Modifiers/OnWindowChange.swift
+$(SRCROOT)/Thaw/UI/Modifiers/Once.swift
 $(SRCROOT)/Thaw/UI/Shapes/AnyInsettableShape.swift
 $(SRCROOT)/Thaw/UI/Utilities/IceColor.swift
 $(SRCROOT)/Thaw/UI/Utilities/IceGradient.swift


### PR DESCRIPTION
# Summary

Refuse degenerate capture rectangles (zero/negative size, non-finite, or past the Metal texture limit) before handing them to SkyLight / ScreenCaptureKit. Those bounds make WindowServer abort in `-[MTLTextureDescriptorInternal validateWithDevice:]`, taking down the whole graphical session.

**Scope:** Capture-bounds validation at the three sites that send rects to the window server, plus regression tests. No capture-path redesign.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #759

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

`Bridging.isValidCaptureBounds` rejects unsafe rects (and scaled sizes over 16384px). `captureWindowsImage`, `captureWindowsImageSCK`, and `captureScreenBelowWindow` return `nil` and log the offending bounds instead of asking WindowServer to build an invalid Metal texture. `CGRect.null` remains allowed (auto bounds).

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.

Test commands run:

- (not run in this PR open) `CaptureBoundsValidationTests`

## Known limitations / follow-ups

- Does not remove every upstream source of bad bounds; it stops them from reaching WindowServer.
- Follow-up: reproduce the settings-change path from #759 and confirm the refusal log appears if a bad rect is still produced.

## Other information

Crash path from #759: Thaw → replayd → WindowServer / SkyLight Capture → IOSurface → Metal → `MTLTextureDescriptorInternal validateWithDevice` → abort.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented crashes during screen and window capture when capture regions are invalid, oversized, or use unsupported scaling.
  * Added validation for empty, non-finite, degenerate, and excessively large capture bounds.
  * Improved early failure handling for invalid screen capture requests.

* **Tests**
  * Added coverage for capture-bound validation, scaling limits, and invalid dimensions.

* **Chores**
  * Updated SwiftLint file inputs for newly tracked and reordered source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->