### PR TITLE
Avoid spurious saved-layout bulk applies on recache

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -6811,6 +6811,28 @@ extension MenuBarItemManager {
         return !previous.isSubset(of: current)
     }
 
+    /// Builds the current windowID set that `applySavedLayout` diffs against
+    /// the previous cycle's stored window list.
+    ///
+    /// ControlItemPair discovery removes the hidden and always-hidden control
+    /// items from the items array, but the stored list from the previous cycle
+    /// still contains their windowIDs. They must be unioned back in; otherwise
+    /// the control items read as "missing" on every cycle, `windowIDsChanged`
+    /// is permanently true, and any recache (an app launching, a transient
+    /// Control Center item appearing) dispatches a spurious full bulk apply
+    /// that re-moves items and warps the cursor.
+    static nonisolated func currentWindowIDSet(
+        items: [MenuBarItem],
+        controlItems: ControlItemPair
+    ) -> Set<CGWindowID> {
+        var windowIDs = Set(items.map(\.windowID))
+        windowIDs.insert(controlItems.hidden.windowID)
+        if let alwaysHidden = controlItems.alwaysHidden {
+            windowIDs.insert(alwaysHidden.windowID)
+        }
+        return windowIDs
+    }
+
     func applySavedLayout(
         items: [MenuBarItem],
         previousWindowIDs: [CGWindowID],
@@ -6870,7 +6892,7 @@ extension MenuBarItemManager {
         // Divergence is computed lazily: only consulted when
         // windowIDsChanged didn't already advance the gate, so the
         // happy path on app quit/relaunch pays nothing.
-        let currentWindowIDSet = Set(items.map(\.windowID))
+        let currentWindowIDSet = Self.currentWindowIDSet(items: items, controlItems: controlItems)
         let previousWindowIDSet = Set(previousWindowIDs)
         let windowIDsChanged = Self.windowIDsChanged(
             previous: previousWindowIDSet,

--- a/ThawTests/WindowIDsChangedGateTests.swift
+++ b/ThawTests/WindowIDsChangedGateTests.swift
@@ -77,6 +77,54 @@ final class WindowIDsChangedGateTests: XCTestCase {
         )
     }
 
+    /// ControlItemPair discovery strips the hidden/always-hidden control items
+    /// out of the items array, but the previous cycle's stored window list
+    /// still contains their windowIDs. The set handed to the gate must union
+    /// the control item windowIDs back in; otherwise the gate reads the
+    /// control items as "missing" on every cycle and dispatches a spurious
+    /// full bulk apply on every recache (the field-reported symptom: the bar
+    /// re-sorts itself and warps the cursor whenever any app launches or a
+    /// transient Control Center item appears).
+    func testCurrentWindowIDSetIncludesStrippedControlItems() {
+        let hiddenWID: CGWindowID = 364
+        let alwaysHiddenWID: CGWindowID = 366
+        let controlItems = MenuBarItemManager.ControlItemPair.fixture(
+            hiddenAt: CGRect(x: 500, y: 0, width: 8, height: 22),
+            alwaysHiddenAt: CGRect(x: 200, y: 0, width: 8, height: 22),
+            hiddenWindowID: hiddenWID,
+            alwaysHiddenWindowID: alwaysHiddenWID
+        )
+        let items = [
+            MenuBarItem.fixture(tag: .appItem(bundleID: "com.example.a", title: "Item-0"), windowID: 10),
+            MenuBarItem.fixture(tag: .appItem(bundleID: "com.example.b", title: "Item-0"), windowID: 11),
+        ]
+
+        let current = MenuBarItemManager.currentWindowIDSet(items: items, controlItems: controlItems)
+        XCTAssertEqual(current, [10, 11, hiddenWID, alwaysHiddenWID])
+
+        // Steady state: previous stored list (raw, includes control items)
+        // against the reconstructed current set. Nothing disappeared, so the
+        // gate must not fire.
+        XCTAssertFalse(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, 11, hiddenWID, alwaysHiddenWID],
+                current: current,
+                previousDisplayID: d1,
+                currentDisplayID: d1
+            )
+        )
+
+        // A transient item appearing (pure addition) must not fire either.
+        XCTAssertFalse(
+            MenuBarItemManager.windowIDsChanged(
+                previous: [10, hiddenWID, alwaysHiddenWID],
+                current: current,
+                previousDisplayID: d1,
+                currentDisplayID: d1
+            )
+        )
+    }
+
     /// Unknown display on either side (nil): fall back to the plain
     /// windowID-disappearance signal rather than suppressing a real change.
     func testNilDisplayFallsBackToWindowIDSignal() {


### PR DESCRIPTION
## Scope

This is one isolated, release-appropriate reliability fix from a broader stabilization effort. It is **not** the deferred full feature implementation.

The broader 2.1 feature work remains parked and will be re-submitted against the appropriate 2.1 integration branch when that branch is available. This PR is intentionally limited to a small fix suitable for `integration/sanitize-dev`.

## Change

Gates saved-layout reapplication on actual window-ID changes rather than every recache cycle, with focused coverage for that gate.

## Why

Prevents repeated bulk layout work when the underlying menu-bar item set has not changed.

## Validation

- Built and tested from the clean `integration/sanitize-dev` base.
- Included in a 72-hour normal-use soak with the other isolated reliability fixes.