### PR TITLE
fix(layout): avoid redundant notch full-sort replays

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -706,6 +706,12 @@ nonisolated enum LayoutSolver {
     /// Returns an empty array when the current order already matches the
     /// desired order (no moves needed) or when desired is empty.
     ///
+    /// Items already in the correct relative order at the left of the bar
+    /// are trimmed from the replay. Every replayed item lands at the right in
+    /// sequence order, so the final order is the untouched physical prefix
+    /// followed by the replayed suffix. This avoids re-dragging an entire
+    /// notched layout when a transient item is the only divergence.
+    ///
     /// Pure over its inputs. The orchestrator handles per-item live
     /// fetching, the move() loop, and control-item state restoration.
     static nonisolated func planFullSortSequence(
@@ -741,7 +747,58 @@ nonisolated enum LayoutSolver {
         fullSequence.append(contentsOf: hiddenUIDs)
         fullSequence.append(hiddenCtrlUID)
         fullSequence.append(contentsOf: visibleUIDs)
-        return fullSequence
+
+        // currentFlat is flattened visible-first, with the hidden and
+        // always-hidden control IDs between their respective sections.
+        // Reconstruct the physical left-to-right order before finding the
+        // longest already-ordered prefix of the target sequence.
+        var visible = [String]()
+        var hidden = [String]()
+        var alwaysHidden = [String]()
+        var section = 0
+        var sawHiddenControl = false
+        var sawAlwaysHiddenControl = false
+        for uid in currentFlat {
+            if uid == hiddenCtrlUID {
+                section = 1
+                sawHiddenControl = true
+                continue
+            }
+            if let ahCtrlUID, uid == ahCtrlUID {
+                section = 2
+                sawAlwaysHiddenControl = true
+                continue
+            }
+            switch section {
+            case 0: visible.append(uid)
+            case 1: hidden.append(uid)
+            default: alwaysHidden.append(uid)
+            }
+        }
+
+        var physicalOrder = alwaysHidden
+        if sawAlwaysHiddenControl, let ahCtrlUID {
+            physicalOrder.append(ahCtrlUID)
+        }
+        physicalOrder.append(contentsOf: hidden)
+        if sawHiddenControl {
+            physicalOrder.append(hiddenCtrlUID)
+        }
+        physicalOrder.append(contentsOf: visible)
+
+        var positions = [String: Int]()
+        for (index, uid) in physicalOrder.enumerated() where positions[uid] == nil {
+            positions[uid] = index
+        }
+
+        var previousPosition = -1
+        var prefixCount = 0
+        for uid in fullSequence {
+            guard let position = positions[uid], position > previousPosition else { break }
+            previousPosition = position
+            prefixCount += 1
+        }
+        return Array(fullSequence.dropFirst(prefixCount))
     }
 
     // MARK: - Saved-position lookup

--- a/ThawTests/PlanFullSortSequenceTests.swift
+++ b/ThawTests/PlanFullSortSequenceTests.swift
@@ -86,6 +86,63 @@ final class PlanFullSortSequenceTests: XCTestCase {
         XCTAssertEqual(sequence, [ahCtrl, hiddenCtrl, "v1"])
     }
 
+    func testTrimsOrderedPrefixForSingleOutOfPlaceItem() {
+        let desired = ["v1", "v2", "v3", hiddenCtrl, "h1", "nowPlaying", ahCtrl, "ah1", "ah2"]
+        let sectionMap: [String: String] = [
+            "v1": "visible", "v2": "visible", "v3": "visible",
+            "h1": "hidden", "nowPlaying": "hidden",
+            "ah1": "alwaysHidden", "ah2": "alwaysHidden",
+        ]
+        let currentFlat = ["v1", "v2", "nowPlaying", "v3", hiddenCtrl, "h1", ahCtrl, "ah1", "ah2"]
+
+        let sequence = LayoutSolver.planFullSortSequence(
+            currentFlat: currentFlat,
+            desiredFiltered: desired,
+            sectionMap: sectionMap,
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: ahCtrl
+        )
+
+        XCTAssertEqual(sequence, [hiddenCtrl, "v1", "v2", "v3"])
+    }
+
+    func testLeftEdgeSwapReplaysFromFirstOutOfOrderItem() {
+        let desired = ["v1", hiddenCtrl, "h1", ahCtrl, "ah1", "ah2"]
+        let sectionMap: [String: String] = [
+            "v1": "visible", "h1": "hidden",
+            "ah1": "alwaysHidden", "ah2": "alwaysHidden",
+        ]
+        let currentFlat = ["v1", hiddenCtrl, "h1", ahCtrl, "ah2", "ah1"]
+
+        let sequence = LayoutSolver.planFullSortSequence(
+            currentFlat: currentFlat,
+            desiredFiltered: desired,
+            sectionMap: sectionMap,
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: ahCtrl
+        )
+
+        XCTAssertEqual(sequence, ["ah2", ahCtrl, "h1", hiddenCtrl, "v1"])
+    }
+
+    func testUnmanagedItemsDoNotBreakPrefixTrim() {
+        let desired = ["v1", "v2", hiddenCtrl, "h1"]
+        let sectionMap: [String: String] = [
+            "v1": "visible", "v2": "visible", "h1": "hidden",
+        ]
+        let currentFlat = ["v2", "v1", hiddenCtrl, "h1", "unmanaged"]
+
+        let sequence = LayoutSolver.planFullSortSequence(
+            currentFlat: currentFlat,
+            desiredFiltered: desired,
+            sectionMap: sectionMap,
+            hiddenCtrlUID: hiddenCtrl,
+            ahCtrlUID: nil
+        )
+
+        XCTAssertEqual(sequence, ["v2"])
+    }
+
     /// If currentFlat already filtered against desiredFiltered matches
     /// desiredFiltered exactly, the sequence is empty (no-op signal).
     func testNoOpWhenAlreadyMatches() {


### PR DESCRIPTION
# Summary

Reconstructs the current physical order and skips the already-correct prefix of a notch full-sort plan, replaying only the suffix after the first divergence.

**Scope:** One focused layout reliability fix (plus tests). Broader 2.1 feature work remains parked.

> We are on the process of migrating from XCTest to Swift Test. If you are adding new tests, please use Swift Test.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [x] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

On notched displays, `planFullSortSequence` trims the already-ordered prefix of the intended order and only replays from the first divergence. That avoids unnecessary cursor movement and repositioning when most of the bar is already correct.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.

Test commands run:

- Built and tested from the clean `integration/sanitize-dev` base (retargeted/rebased onto `integration/menubar-scramble`)
- Included in a 72-hour normal-use soak with the other isolated reliability fixes
- `PlanFullSortSequenceTests` (prefix trim / left-edge swap / unmanaged items)

## Known limitations / follow-ups

- Intentionally limited to this reliability fix; deferred full 2.1 feature work stays parked
- Targets `integration/menubar-scramble` (not `development`) by design for the scramble integration train
- New tests added in the existing XCTest file to match current suite style

## Other information

Rebased onto latest `integration/menubar-scramble` (cherry-picked the notch-only commit) so the PR no longer includes unrelated sanitize-era history.