### PR TITLE
docs: OpenSSF Silver governance, security, and Dependabot

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,6 +41,26 @@ re-push with sign-off before merge.
 > **Note:** This is not a CLA and does not transfer copyright. It is an
 > attestation that you can contribute the change under GPL-3.0.
 
+### AI-assisted contributions
+
+We are **friendly to AI-assisted work**. Using coding assistants is fine when the result is high quality and follows this guide.
+
+The DCO still applies to the **human who signs off**. By adding `Signed-off-by`, you certify that you have the right to contribute the change under GPL-3.0 — including any AI-generated portions. The tool is not a DCO party; you are responsible for the commit.
+
+In practice:
+
+- Prefer tools whose terms allow contributing output to GPL-licensed projects.
+- Do not feed clearly proprietary or third-party-restricted code into an assistant and commit the result as if it were yours.
+- You must understand and be able to explain the change in review.
+
+We use **CodeRabbit** and **SonarCloud** on pull requests. Treat their findings as part of the review bar unless a maintainer marks something won’t-fix. We expect fixes and high quality before (and during) human review.
+
+**We reserve the right** to reject contributions or block automated committers / assistant-driven submission paths when they harm the project (spam, unsafe automation, or repeated low-quality work).
+
+Pull requests that are clear **AI slop**, or that ignore established procedures (wrong base branch, missing issue where required, no tests/docs when expected, unsigned commits, unchecked PR template, drive-by refactors with no issue), **will be closed**. Using AI does not lower the bar.
+
+Maintainer bandwidth is limited. If we request changes and there is **no meaningful follow-up** within a reasonable window, the PR **will be closed**. You can always open a new PR later that addresses the feedback.
+
 ## Before You Start
 
 Regardless of the type of contribution, you'll need a GitHub account and a fork of the repository:

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -57,7 +57,7 @@ We use **CodeRabbit** and **SonarCloud** on pull requests. Treat their findings 
 
 **We reserve the right** to reject contributions or block automated committers / assistant-driven submission paths when they harm the project (spam, unsafe automation, or repeated low-quality work).
 
-Pull requests that are clear **AI slop**, or that ignore established procedures (wrong base branch, missing issue where required, no tests/docs when expected, unsigned commits, unchecked PR template, drive-by refactors with no issue), **will be closed**. Using AI does not lower the bar.
+Pull requests **will be closed** when they show observable process or quality failures — for example unreviewed generated content pasted without human cleanup, missing required tests or documentation, failing CI or review checks left unaddressed, ignored maintainer feedback, wrong base branch, missing issue where required, unsigned commits, unchecked PR template, or drive-by refactors with no issue. Using AI does not lower the bar.
 
 Maintainer bandwidth is limited. If we request changes and there is **no meaningful follow-up** within a reasonable window, the PR **will be closed**. You can always open a new PR later that addresses the feedback.
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,6 +16,31 @@ Please read and follow our [Code of Conduct][coc].
 
 Looking for a concrete task? See the living list in **[Ways to contribute (#316)](https://github.com/stonerl/Thaw/issues/316)** (docs/screenshots, triage, small cleanups, and more).
 
+## Developer Certificate of Origin (DCO)
+
+Thaw requires contributors to certify that they have the right to submit their
+work under the project’s license. We use the
+[Developer Certificate of Origin (DCO) v1.1](https://developercertificate.org/).
+
+By adding a `Signed-off-by` line to each commit, you assert the DCO. Use your
+real name (not a pseudonym) as in:
+
+```bash
+git commit -s -m "fix(menubar): explain the change"
+```
+
+which appends:
+
+```text
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Pull requests whose commits lack a valid sign-off may be asked to amend or
+re-push with sign-off before merge.
+
+> **Note:** This is not a CLA and does not transfer copyright. It is an
+> attestation that you can contribute the change under GPL-3.0.
+
 ## Before You Start
 
 Regardless of the type of contribution, you'll need a GitHub account and a fork of the repository:
@@ -87,6 +112,11 @@ This includes but is not limited to:
 
 Thaw uses [SwiftLint](https://github.com/realm/SwiftLint) and [SwiftFormat](https://github.com/nicklockwood/SwiftFormat) to enforce consistent code style.
 
+Primary language style guides are embodied in:
+
+- [`.swiftlint.yml`](../.swiftlint.yml)
+- [`.swiftformat`](../.swiftformat)
+
 Before submitting a request, run:
 
 ```bash
@@ -96,12 +126,20 @@ swiftlint lint --strict
 
 Pull requests are automatically reviewed by SonarCloud for code quality and CodeRabbit for AI-assisted review. You may receive automated comments from these tools, so please address any findings before requesting a human review.
 
+### Tests
+
+Major new functionality must include automated tests in `ThawTests` (or the
+relevant package test target) unless a maintainer agrees that no seam exists.
+Bug fixes should add a regression test when practical. The PR template checklist
+asks you to confirm this.
+
 ### Project conventions
 
 - **Branch & base:** All external PRs must target `development` (not `main`), unless a maintainer asks otherwise.
 - **PR size:** Aim for ≤500 lines / ≤20 files per PR. If you expect to exceed this, say why in the Summary and link the design/issue.
 - **Templates & issues:** Bugfix and feature PRs should always reference a GitHub issue (`Closes: #123`, or `Closes: N/A` when agreed).
 - **Commit / PR titles:** Prefer conventional commits, e.g. `fix(menubar): …`, `feat(settings): …`.
+- **DCO:** Every commit must be signed off (`git commit -s`).
 - **Code review bots:** CodeRabbit and SonarCloud comments are treated as *required* unless a maintainer marks them won’t-fix. If you’re unsure, wait for a maintainer reply before large refactors spurred by bots alone.
 - **Sensitive areas:** Expect deeper review and stronger tests when touching menu bar hiding/layout, IceBar / Thaw Bar, triggers/automation, logging, or permissions.
 
@@ -109,14 +147,26 @@ Pull requests are automatically reviewed by SonarCloud for code quality and Code
 
 Open a pull request via the [Thaw pull requests page][pr] and select the [appropriate template][prt] — it will guide you through the required information and checklist.
 
+## Project docs (orientation)
+
+- [Governance][gov] — roles and decision-making
+- [Architecture][arch] — high-level design
+- [Security policy][sec] — reporting and security requirements
+- [URI schemes][uri] — external automation surface
+
 ## Resources
 
 - [How to Contribute to Open Source](https://opensource.guide/how-to-contribute/)
 - [Using Issues](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues)
 - [Using Pull Requests](https://help.github.com/articles/about-pull-requests/)
+- [Developer Certificate of Origin](https://developercertificate.org/)
 
 [coc]: CODE_OF_CONDUCT.md
 [fq]: ../FREQUENT_ISSUES.md
 [it]: https://github.com/stonerl/Thaw/issues
 [pr]: https://github.com/stonerl/Thaw/pulls
 [prt]: https://github.com/stonerl/Thaw/blob/development/.github/pull_request_template.md
+[gov]: GOVERNANCE.md
+[arch]: ../docs/ARCHITECTURE.md
+[sec]: SECURITY.md
+[uri]: ../docs/URI_SCHEMES.md

--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -1,0 +1,168 @@
+# Thaw project governance
+
+This document describes how the Thaw project makes decisions, who holds which
+roles, and how the project continues if a key person is unavailable.
+
+## Decision model
+
+Thaw uses a **benevolent dictator / project-lead** model suitable for a small
+maintainer team, backed by shared **organization admin** access:
+
+1. **Day-to-day:** Maintainers with write access review and merge pull requests
+   to `development`, triage issues, and ship routine releases according to
+   established CI/release workflows. Informal coordination and design discussion
+   often happen in the project [Discord](https://discord.gg/5cnKkKbMFd) (same
+   invite as the README); GitHub issues and pull requests remain the record for
+   decisions that affect the codebase or releases.
+2. **Disputes and final decisions:** The **Project Lead** has final say on
+   roadmap direction, breaking changes, security policy, licensing, and
+   application-repository settings for [stonerl/Thaw](https://github.com/stonerl/Thaw).
+3. **Consensus preferred:** Maintainers seek rough consensus in issues/PRs
+   (and Discord when useful) before the Project Lead decides. Silence after a
+   reasonable discussion window is treated as assent for non-breaking changes.
+4. **Organization:** Shared project assets and CI building blocks already live
+   under the [`thaw-app`](https://github.com/thaw-app) GitHub organization. Org
+   **owners** can administer org settings and org-owned repositories if any one
+   owner is unavailable. The application repository is still
+   [stonerl/Thaw](https://github.com/stonerl/Thaw); migrating it into `thaw-app`
+   is a **planned, gradual** move (see [Repository migration](#repository-migration)).
+5. **Security:** Vulnerability handling follows
+   [SECURITY.md](SECURITY.md). Public discussion of unfixed vulnerabilities is
+   not appropriate.
+
+Forking remains always available under the GPL-3.0 license; governance here
+only describes how *this* project operates.
+
+## Roles and responsibilities
+
+| Role | Who (GitHub) | Responsibilities |
+| --- | --- | --- |
+| **Project Lead** | [@stonerl](https://github.com/stonerl) | Final product decisions; release authority for Thaw; app-repo admin (today under `stonerl/`); OpenSSF badge entry; security advisory publishing |
+| **Organization owner** | [@stonerl](https://github.com/stonerl), [@nightah](https://github.com/nightah), [@diazdesandi](https://github.com/diazdesandi) | Admin of [`thaw-app`](https://github.com/thaw-app): org settings, org-owned repos/assets (brand assets, shared CI, etc.), membership; eventual home for the application repo |
+| **Maintainer** | Write collaborators on the application repo (today [stonerl/Thaw](https://github.com/stonerl/Thaw); later under `thaw-app`) | Review/merge PRs; triage issues; approve routine releases when delegated; enforce Code of Conduct with Lead |
+| **Contributor** | Anyone submitting issues, PRs, Crowdin translations, or docs | Follow [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md) |
+| **Security contact** | Project Lead (via [private vulnerability reporting](https://github.com/stonerl/Thaw/security/advisories/new)) | Acknowledge and coordinate vulnerability reports |
+
+Translations are reviewed via [Crowdin](https://crowdin.com/project/thaw), not
+via translation PRs.
+
+## Community channels
+
+| Channel | Purpose |
+| --- | --- |
+| [GitHub Issues / PRs](https://github.com/stonerl/Thaw) | Bugs, features, code review, durable decisions |
+| [Discord](https://discord.gg/5cnKkKbMFd) | Day-to-day maintainer and community discussion |
+| [Crowdin](https://crowdin.com/project/thaw) | Localization |
+
+## Members with repository access
+
+### `thaw-app` organization (admins / owners)
+
+| GitHub login | Org role | Notes |
+| --- | --- | --- |
+| `stonerl` | Owner | Project Lead |
+| `nightah` | Owner | Maintainer |
+| `diazdesandi` | Owner | Maintainer |
+
+Org profile: https://github.com/thaw-app
+
+### Application repository (current and target)
+
+| Stage | Location | Status |
+| --- | --- | --- |
+| **Current** | [stonerl/Thaw](https://github.com/stonerl/Thaw) | Canonical app source, issues, releases, CI |
+| **Target** | `thaw-app/Thaw` (name TBD) under [`thaw-app`](https://github.com/thaw-app) | Planned transfer when release/signing/Pages dependencies are stable enough |
+
+Sensitive Actions secrets for Developer ID signing, notarization, and Sparkle
+EdDSA updates are configured on the application repository and/or org as
+applicable. Write collaborators (in addition to the Project Lead) include
+maintainers such as `nightah`, `diazdesandi`, and others granted write on the
+repo.
+
+Public contributor history:
+https://github.com/stonerl/Thaw/graphs/contributors
+
+## Repository migration
+
+The long-term home for Thaw is the [`thaw-app`](https://github.com/thaw-app)
+organization. Migration is **intentional and incremental**: pieces move when
+they are safe to move, not as a single cutover.
+
+Already under or consumed via `thaw-app` (examples; list may grow):
+
+- Brand / marketing assets
+- Shared CI building blocks used by release workflows
+
+Still on the personal namespace until transfer is low-risk:
+
+- Application git history, issues, Discussions, and GitHub Releases
+- Release signing / notarization wiring and Sparkle appcast publish path
+- User-facing URLs (clone URL, badge links, Homebrew taps, docs) that must be
+  redirected without breaking installs or updates
+
+Guiding rules until the app repo lives in the org:
+
+1. Prefer extracting **shared, non-fragile** pieces into `thaw-app` first.
+2. Keep a single canonical app repository at any time (no long-lived dual
+   masters).
+3. After transfer, GitHub’s repository redirect should preserve old
+   `stonerl/Thaw` links; update Homebrew, Sparkle feed, and docs in the same
+   release window as the move.
+4. Org owners (`stonerl`, `nightah`, `diazdesandi`) jointly decide when the app
+   repo is ready to transfer.
+
+## Access continuity
+
+The project MUST be able to continue with minimal interruption if any one
+person is unavailable (illness, departure, etc.). Within about one week the
+remaining maintainers should still be able to:
+
+- Create and close issues
+- Accept pull requests
+- Cut a release (or publish a hotfix)
+- Administer `thaw-app` org-owned assets
+
+### Continuity measures
+
+1. **Organization owners:** Three people (`stonerl`, `nightah`, `diazdesandi`)
+   are owners of [`thaw-app`](https://github.com/thaw-app). Loss of any one
+   owner does not remove org admin capability. Migrating the app repo into the
+   org further reduces single-namespace risk; until then, continuity relies on
+   write collaborators on `stonerl/Thaw` plus the three org owners for shared
+   assets and planning.
+2. **Repository access:** Multiple maintainers have **write** access on the
+   application repo so issues and PRs are not single-person blocked.
+3. **Admin / secrets:** Release-signing and notarization credentials used by
+   GitHub Actions are available to the Project Lead and, for continuity, to
+   the other org owners as needed so a release can still be cut if one person
+   is unavailable. As workflows move to org-owned reusable actions/secrets,
+   prefer **org-level** secrets owned by `thaw-app` so all three owners share
+   administrative access without depending on one personal account.
+4. **Release tags:** Important release tags are GPG-signed by the releaser.
+5. **Update feed / Pages:** The Sparkle appcast is published to GitHub Pages
+   (`stonerl.github.io/Thaw`). Continuity requires that at least one remaining
+   admin can update that feed or redeploy Pages; relocating the feed under
+   org-owned hosting is part of the gradual migration when safe.
+
+## Bus factor
+
+Thaw aims for a **bus factor of 2 or more**: more than one person understands
+menu-bar layout, release CI, and contributor workflow well enough to keep the
+project moving.
+
+Evidence:
+
+- Three `thaw-app` organization owners
+- Multiple write collaborators on the application repo
+- Active multi-author commit history on `development`
+- Documented contribution and release automation under `.github/`
+- Explicit plan to house the canonical repo under the multi-owner org
+- Active maintainer discussion on Discord in addition to GitHub
+
+## Related documents
+
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
+- [SECURITY.md](SECURITY.md)
+- [docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)
+- [docs/ASSURANCE_CASE.md](../docs/ASSURANCE_CASE.md)

--- a/.github/GOVERNANCE.md
+++ b/.github/GOVERNANCE.md
@@ -37,9 +37,9 @@ only describes how *this* project operates.
 
 | Role | Who (GitHub) | Responsibilities |
 | --- | --- | --- |
-| **Project Lead** | [@stonerl](https://github.com/stonerl) | Final product decisions; release authority for Thaw; app-repo admin (today under `stonerl/`); OpenSSF badge entry; security advisory publishing |
-| **Organization owner** | [@stonerl](https://github.com/stonerl), [@nightah](https://github.com/nightah), [@diazdesandi](https://github.com/diazdesandi) | Admin of [`thaw-app`](https://github.com/thaw-app): org settings, org-owned repos/assets (brand assets, shared CI, etc.), membership; eventual home for the application repo |
-| **Maintainer** | Write collaborators on the application repo (today [stonerl/Thaw](https://github.com/stonerl/Thaw); later under `thaw-app`) | Review/merge PRs; triage issues; approve routine releases when delegated; enforce Code of Conduct with Lead |
+| **Project Lead** | [@stonerl](https://github.com/stonerl) | Final product decisions; primary release authority for Thaw; app-repo admin (today under `stonerl/`); OpenSSF badge entry; security advisory publishing; release-secret stewardship (see below) |
+| **Organization owner** | [@stonerl](https://github.com/stonerl), [@nightah](https://github.com/nightah), [@diazdesandi](https://github.com/diazdesandi) | Admin of [`thaw-app`](https://github.com/thaw-app): org settings, org-owned repos/assets (brand assets, shared CI, etc.), membership; eventual home for the application repo; **continuity access** to release secrets and Environments under least privilege (see [Release secrets](#release-secrets)) |
+| **Maintainer** | Write collaborators on the application repo (today [stonerl/Thaw](https://github.com/stonerl/Thaw); later under `thaw-app`) | Review/merge PRs; triage issues; approve routine releases when delegated; enforce Code of Conduct with Lead. **No** routine access to signing/notarization/Sparkle private keys |
 | **Contributor** | Anyone submitting issues, PRs, Crowdin translations, or docs | Follow [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md) |
 | **Security contact** | Project Lead (via [private vulnerability reporting](https://github.com/stonerl/Thaw/security/advisories/new)) | Acknowledge and coordinate vulnerability reports |
 
@@ -73,14 +73,77 @@ Org profile: https://github.com/thaw-app
 | **Current** | [stonerl/Thaw](https://github.com/stonerl/Thaw) | Canonical app source, issues, releases, CI |
 | **Target** | `thaw-app/Thaw` (name TBD) under [`thaw-app`](https://github.com/thaw-app) | Planned transfer when release/signing/Pages dependencies are stable enough |
 
-Sensitive Actions secrets for Developer ID signing, notarization, and Sparkle
-EdDSA updates are configured on the application repository and/or org as
-applicable. Write collaborators (in addition to the Project Lead) include
-maintainers such as `nightah`, `diazdesandi`, and others granted write on the
-repo.
+Write collaborators (in addition to the Project Lead) include maintainers such
+as `nightah`, `diazdesandi`, and others granted write on the repo. Write access
+alone does **not** include release-secret administration.
 
 Public contributor history:
 https://github.com/stonerl/Thaw/graphs/contributors
+
+## Release secrets
+
+Credentials used to ship signed builds (Apple Developer ID certificate material,
+notarization credentials, Sparkle EdDSA **private** key, and related CI tokens)
+are treated as **release secrets**. They are injected only via GitHub Actions
+Secrets / Environments — never committed to git.
+
+### Who may access what (least privilege)
+
+| Access | Who | Purpose |
+| --- | --- | --- |
+| **View / edit release secrets** | Organization owners (`stonerl`, `nightah`, `diazdesandi`), scoped to the repo or org secret store that holds them | Continuity: any one owner unavailable must not block a hotfix |
+| **Trigger release workflows that consume secrets** | Project Lead by default; other org owners when delegated for a specific release | Cut signed/notarized builds |
+| **Write collaborators / contributors** | Everyone else with repo write | Code and docs only — no secret read |
+
+Prefer GitHub **Environments** (e.g. `release`) with required reviewers so
+secret-consuming jobs need an org-owner approval. Prefer **org-owned** secrets
+under [`thaw-app`](https://github.com/thaw-app) as migration progresses so
+admin is not tied to one personal account.
+
+### Approval path
+
+1. Routine releases: Project Lead (or delegated org owner) starts the release
+   workflow; Environment protection rules require approval from an org owner
+   when configured.
+2. Secret create / rotate / delete: proposed by an org owner; a **second** org
+   owner confirms out-of-band (Discord or GitHub) before the change is applied,
+   except true emergencies (compromised key) where one owner may rotate
+   immediately and must notify the others within 24 hours.
+3. Granting a new person secret access requires unanimous agreement of the
+   current org owners and an update to this document.
+
+### Audit and logging
+
+- Prefer GitHub’s built-in audit log / Actions run history for who approved
+  Environment jobs and which workflow run used secrets (values are never logged).
+- Record secret rotations (what rotated, by whom, when) in a private maintainer
+  note or closed tracking issue — not in public issues with secret material.
+- Do not print secret values in workflow logs.
+
+### Rotation
+
+- Rotate after known or suspected compromise immediately.
+- Rotate when an owner leaves the project or loses devices used for 2FA.
+- Periodic rotation of long-lived credentials is encouraged (at least annually
+  for notarization app-specific passwords / similar); Apple certificates follow
+  Apple’s expiry and re-issuance cycle.
+- After rotation, update GitHub Secrets, confirm a dry-run or staging release
+  path still works, then ship.
+
+### Recovery and continuity
+
+If the Project Lead is unavailable, the remaining org owners must be able to:
+
+1. Access the secret store (org/repo Secrets and/or Environment).
+2. Approve or run the release workflow.
+3. Publish the Sparkle appcast / GitHub Release artifacts.
+
+Recovery of lost Apple account access follows Apple’s account recovery; Sparkle
+key recovery requires the offline backup held by org owners (password manager or
+equivalent). At least **two** owners must be able to recover signing material
+without the third.
+
+Document the private backup location among owners only — never in this repo.
 
 ## Repository migration
 
@@ -132,12 +195,10 @@ remaining maintainers should still be able to:
    assets and planning.
 2. **Repository access:** Multiple maintainers have **write** access on the
    application repo so issues and PRs are not single-person blocked.
-3. **Admin / secrets:** Release-signing and notarization credentials used by
-   GitHub Actions are available to the Project Lead and, for continuity, to
-   the other org owners as needed so a release can still be cut if one person
-   is unavailable. As workflows move to org-owned reusable actions/secrets,
-   prefer **org-level** secrets owned by `thaw-app` so all three owners share
-   administrative access without depending on one personal account.
+3. **Admin / secrets:** Follow [Release secrets](#release-secrets). All three
+   org owners have continuity access under least privilege; write collaborators
+   do not. Prefer org-level secrets and Environment approvals under `thaw-app`
+   as migration progresses.
 4. **Release tags:** Important release tags are GPG-signed by the releaser.
 5. **Update feed / Pages:** The Sparkle appcast is published to GitHub Pages
    (`stonerl.github.io/Thaw`). Continuity requires that at least one remaining

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,42 +1,108 @@
 # Security Policy
 
-Thank you for helping keep Thaw secure. We take the security of our users and their data seriously. 
+Thank you for helping keep Thaw secure. We take the security of our users and
+their data seriously.
 
 ## Supported Versions
 
-Since Thaw is a macOS menu bar manager, we primarily support security updates for the latest stable release. Please ensure you are running the most recent version of Thaw before submitting a vulnerability report.
+Thaw is a macOS menu bar manager. We primarily support security updates for the
+**latest stable release**. Please run the most recent version before submitting
+a vulnerability report. Upgrade via [GitHub Releases](https://github.com/stonerl/Thaw/releases),
+Homebrew, or in-app Sparkle updates.
 
 | Version | Supported          |
 | ------- | ------------------ |
 | Latest  | :white_check_mark: |
 | Older   | :x:                |
 
+## Security requirements (what users can and cannot expect)
+
+This section is the project’s security requirements statement for the software
+Thaw produces.
+
+### You can expect
+
+- **Local-first:** Thaw does not require an account and does not operate a
+  first-party tracking or analytics backend.
+- **Explicit permissions:** Features that need Accessibility or Screen Recording
+  ask via normal macOS TCC prompts and do not work without those grants.
+- **Guarded automation:** Settings changes via `thaw://` require a
+  user-approved application allowlist and matching code-signing Team ID. See
+  [docs/URI_SCHEMES.md](../docs/URI_SCHEMES.md).
+- **Authenticated updates:** Release builds are Developer ID–signed and
+  notarized. In-app updates use HTTPS + Sparkle EdDSA. See
+  [docs/VERIFYING_RELEASES.md](../docs/VERIFYING_RELEASES.md).
+- **Coordinated disclosure:** Private reporting channel and a target
+  acknowledgement window (below).
+
+### You cannot expect
+
+- Protection against attackers who already control your unlocked Mac session,
+  or who share the same powerful TCC rights.
+- Server-style multi-tenant isolation (Thaw is a single-user desktop app).
+- Security maintenance of outdated releases.
+- That third-party menu bar apps Thaw interacts with are themselves secure.
+
+A longer argument (threat model, trust boundaries, design principles) lives in
+[docs/ASSURANCE_CASE.md](../docs/ASSURANCE_CASE.md). Architecture overview:
+[docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md).
+
 ## Scope of Security Reports
 
-As a macOS application, Thaw may interact with local system APIs and require certain permissions (like Accessibility or Screen Recording, depending on features). 
+**In scope**
 
-**We consider the following in-scope for security reports:**
-- Privilege escalation (e.g., escaping the app sandbox if applicable, or unauthorized root access).
+- Privilege escalation (e.g. escaping intended privilege boundaries, unauthorized
+  root access).
 - Unauthorized access to local user data managed by the app.
-- Execution of arbitrary code via malicious input or crafted configuration files.
+- Execution of arbitrary code via malicious input, crafted configuration, or
+  abused `thaw://` automation.
+- Bypass of settings-URI allowlist / code-signature checks.
+- Compromised or forgeable update paths attributable to Thaw’s release process.
 
-**The following are generally out of scope:**
-- Bugs that crash the application without a viable exploit path (e.g., standard Null Pointer Dereferences).
-- Issues requiring physical access to the user's unlocked Mac.
-- Issues related to third-party macOS libraries, unless there is a specific mitigation Thaw needs to implement.
+**Generally out of scope**
+
+- Crashes without a viable exploit path.
+- Issues requiring physical access to an unlocked Mac.
+- Issues solely in third-party macOS components or other apps, unless Thaw needs
+  a specific mitigation.
+- Social engineering of maintainers outside the product.
 
 ## Reporting a Vulnerability
 
-Please **do not** report security vulnerabilities through public GitHub issues. 
+Please **do not** report security vulnerabilities through public GitHub issues.
 
-Instead, please report them using [GitHub's Private Vulnerability Reporting](https://github.com/stonerl/Thaw/security/advisories/new) if it is enabled for this repository. 
+Use [GitHub Private Vulnerability Reporting](https://github.com/stonerl/Thaw/security/advisories/new)
+when enabled for this repository.
 
-If private vulnerability reporting is not enabled, please reach out privately by contacting the maintainer directly or checking the maintainer's GitHub profile for a public email address. 
+If private vulnerability reporting is unavailable, contact the Project Lead
+privately via the email or contact method on their GitHub profile.
 
-Please include the following in your report:
+Include:
+
 - A detailed description of the vulnerability.
-- Steps to reproduce the issue.
-- Your macOS version and the version of Thaw you are testing against.
-- Any potential impact on the user.
+- Steps to reproduce.
+- Your macOS version and Thaw version.
+- Potential impact.
 
-We will try to acknowledge your report within 48 hours and provide an estimated timeline for a fix. We ask that you keep the vulnerability confidential until we have released an update that mitigates the issue.
+## Vulnerability response process
+
+1. **Acknowledge** the report within **48 hours** (best effort).
+2. **Triage** severity, affected versions, and exploitability.
+3. **Fix** on a private branch when needed; prepare a release for the latest
+   supported line.
+4. **Credit** reporters in the advisory / release notes unless they request
+   anonymity ([OpenSSF vulnerability_report_credit](https://www.bestpractices.dev/)).
+5. **Disclose** via GitHub Security Advisories (and CVE when appropriate) after
+   a fix is available or per coordinated timing with the reporter.
+6. Ask reporters to keep issues confidential until a mitigating release ships.
+
+We aim to fix critical, exploitable issues promptly; timelines depend on
+complexity and whether an OS update is also required.
+
+## Public vulnerability history
+
+Published advisories (when any exist):  
+https://github.com/stonerl/Thaw/security/advisories
+
+If there are no published advisories, that means none have been disclosed yet—not
+that the project ignores reports.

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+# SwiftPM and GitHub Actions dependency updates (OpenSSF dependency_monitoring).
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    assignees:
+      - "diazdesandi"
+    target-branch: "development"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    assignees:
+      - "diazdesandi"
+    target-branch: "development"

--- a/README.md
+++ b/README.md
@@ -157,45 +157,6 @@ and contribution practices. Items may slip; the list is intent, not a contract.
 - **Hotkeys**: enable/disable auto rehide; temporarily show individual menu bar items
 - **Other**: menu bar widgets
 
-## Gallery
-
-> Click any screenshot to view it full size.
-
-<p align="center">
-  <a href="https://github.com/user-attachments/assets/9584065d-f840-4545-9a42-cfc5534b5ac3"><img alt="Thaw overview" src="https://github.com/user-attachments/assets/9584065d-f840-4545-9a42-cfc5534b5ac3" width="800" /></a><br />
-  <sub><b>Overview</b></sub>
-</p>
-
-<table>
-  <tr>
-    <td align="center" width="50%">
-      <a href="https://github.com/user-attachments/assets/f2f6b9a6-55c5-40b3-910f-b27b114577dd"><img alt="Item layout" src="https://github.com/user-attachments/assets/f2f6b9a6-55c5-40b3-910f-b27b114577dd" width="400" /></a><br />
-      <sub><b>Item layout</b></sub>
-    </td>
-    <td align="center" width="50%">
-      <a href="https://github.com/user-attachments/assets/c6ac6364-30f8-4c92-8f6f-9efe15f99573"><img alt="Show hidden menu bar items below the menu bar" src="https://github.com/user-attachments/assets/c6ac6364-30f8-4c92-8f6f-9efe15f99573" width="400" /></a><br />
-      <sub><b>Show hidden items below the menu bar</b></sub>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <a href="https://github.com/user-attachments/assets/54273d41-fcf3-4c9a-834b-e62a162a6b0c"><img alt="Drag-and-drop interface to arrange menu bar items" src="https://github.com/user-attachments/assets/54273d41-fcf3-4c9a-834b-e62a162a6b0c" width="400" /></a><br />
-      <sub><b>Drag-and-drop arrangement</b></sub>
-    </td>
-    <td align="center" width="50%">
-      <a href="https://github.com/user-attachments/assets/d95302df-26b0-4608-896e-4966c822fb5e"><img alt="Customize the menu bar's appearance" src="https://github.com/user-attachments/assets/d95302df-26b0-4608-896e-4966c822fb5e" width="400" /></a><br />
-      <sub><b>Customize the appearance</b></sub>
-    </td>
-  </tr>
-  <tr>
-    <td align="center" width="50%">
-      <a href="https://github.com/user-attachments/assets/ebafc745-7220-46c9-9297-f7a00ef6c15d"><img alt="Menu bar item search" src="https://github.com/user-attachments/assets/ebafc745-7220-46c9-9297-f7a00ef6c15d" width="400" /></a><br />
-      <sub><b>Menu bar item search</b></sub>
-    </td>
-    <td width="50%"></td>
-  </tr>
-</table>
-
 ## Contributors
 
 This project exists thanks to the awesome people who contribute code and documentation:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,6 @@
 <a href="https://trendshift.io/repositories/21173" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21173" alt="stonerl%2FThaw | Trendshift" style="width: 250px; height: 55px;" width="250" height="55"/></a>
 </div>
 
-<br>
-
-![thaw-banner](https://github.com/user-attachments/assets/9584065d-f840-4545-9a42-cfc5534b5ac3)
-
 > [!NOTE]
 > Thaw is an actively maintained fork of [Ice](https://github.com/jordanbaird/Ice), focused on fixes, compatibility, and new features.
 
@@ -164,6 +160,11 @@ and contribution practices. Items may slip; the list is intent, not a contract.
 ## Gallery
 
 > Click any screenshot to view it full size.
+
+<p align="center">
+  <a href="https://github.com/user-attachments/assets/9584065d-f840-4545-9a42-cfc5534b5ac3"><img alt="Thaw overview" src="https://github.com/user-attachments/assets/9584065d-f840-4545-9a42-cfc5534b5ac3" width="800" /></a><br />
+  <sub><b>Overview</b></sub>
+</p>
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -66,13 +66,6 @@ Beta (or stable, whichever is newer):
 brew install thaw@beta
 ```
 
-### Verifying releases
-
-Release builds are Developer ID–signed and notarized. In-app updates use Sparkle
-with an embedded EdDSA public key. See
-[docs/VERIFYING_RELEASES.md](docs/VERIFYING_RELEASES.md) for how to check a
-download or Git tag.
-
 ## Language Support
 
 Thaw is translated into the languages listed below. Translations are managed on [Crowdin](https://crowdin.com/project/thaw), and you can request additional languages there.
@@ -227,7 +220,6 @@ Want to contribute? Start with [Ways to contribute](https://github.com/stonerl/T
 - [Security policy](.github/SECURITY.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Assurance case](docs/ASSURANCE_CASE.md)
-- [Verifying releases](docs/VERIFYING_RELEASES.md)
 - [URI schemes](docs/URI_SCHEMES.md)
 
 ## License

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Beta (or stable, whichever is newer):
 brew install thaw@beta
 ```
 
+### Verifying releases
+
+Release builds are Developer ID–signed and notarized. In-app updates use Sparkle
+with an embedded EdDSA public key. See
+[docs/VERIFYING_RELEASES.md](docs/VERIFYING_RELEASES.md) for how to check a
+download or Git tag.
+
 ## Language Support
 
 Thaw is translated into the languages listed below. Translations are managed on [Crowdin](https://crowdin.com/project/thaw), and you can request additional languages there.
@@ -152,6 +159,10 @@ Automation via `thaw://` URI schemes: [docs/URI_SCHEMES.md](docs/URI_SCHEMES.md)
 
 ## Roadmap
 
+Near-term direction (roughly the next year): keep Thaw compatible with current
+macOS releases, finish menu-bar layout/trigger work below, and harden release
+and contribution practices. Items may slip; the list is intent, not a contract.
+
 - **Menu bar item management**: individual spacer items; menu bar item groups; show menu bar items when trigger conditions are met
 - **Menu bar appearance**: rounded screen corners
 - **Hotkeys**: enable/disable auto rehide; temporarily show individual menu bar items
@@ -208,6 +219,16 @@ Want to contribute? Start with [Ways to contribute](https://github.com/stonerl/T
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=stonerl/Thaw&type=Date" width="100%" />
   </picture>
 </a>
+
+## Project documentation
+
+- [Contributing](.github/CONTRIBUTING.md)
+- [Governance](.github/GOVERNANCE.md)
+- [Security policy](.github/SECURITY.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Assurance case](docs/ASSURANCE_CASE.md)
+- [Verifying releases](docs/VERIFYING_RELEASES.md)
+- [URI schemes](docs/URI_SCHEMES.md)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ Want to contribute? Start with [Ways to contribute](https://github.com/stonerl/T
 - [Security policy](.github/SECURITY.md)
 - [Architecture](docs/ARCHITECTURE.md)
 - [Assurance case](docs/ASSURANCE_CASE.md)
+- [Verifying releases](docs/VERIFYING_RELEASES.md)
 - [URI schemes](docs/URI_SCHEMES.md)
 
 ## License

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,113 @@
+# Thaw architecture
+
+High-level design of the software produced by the Thaw project. This is a map
+of major components and trust boundaries, not an API reference.
+
+Thaw is a native **macOS menu bar manager** (Swift / AppKit / SwiftUI). It
+hides and shows menu bar items, provides search and hotkeys, supports layout
+profiles, and customizes menu bar appearance. It is a maintained fork of
+[Ice](https://github.com/jordanbaird/Ice).
+
+## Goals
+
+- Keep the menu bar usable (hide clutter, reveal on demand) without surprising
+  loss of status items.
+- Prefer local-only operation: no accounts, no telemetry/tracking backend.
+- Fail closed for privileged automation surfaces (`thaw://` settings APIs).
+- Stay compatible with current macOS releases (26+; experimental 27 work on a
+  feature branch).
+
+## Repository layout
+
+| Path | Role |
+| --- | --- |
+| `Thaw/` | Main application target (UI, menu bar logic, settings, events, permissions) |
+| `Shared/` | Code shared between the app and helper processes (bridging, XPC client types, utilities) |
+| `MenuBarItemService/` | XPC helper process for menu-bar item source PID resolution and related work off the main app |
+| `ThawCtl/` | Small SwiftPM CLI / control utilities |
+| `ThawTests/` | XCTest suite run in CI |
+| `docs/` | User/developer documentation (e.g. URI schemes) |
+| `.github/` | CI, release, contributing, security policy |
+
+External dependencies are declared via Swift Package Manager and locked in
+`Thaw.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved`
+(e.g. Sparkle, AXSwift, CompactSlider, Ifrit, LaunchAtLogin-Modern).
+
+## Runtime components
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│                        Thaw.app                             │
+│  AppDelegate / AppState                                     │
+│  ├── MenuBar (ItemManager, layout, IceBar/Thaw Bar, …)      │
+│  ├── Events / Hotkeys / HID                                 │
+│  ├── Settings + URI handler (thaw://)                       │
+│  ├── Permissions (Accessibility, Screen Recording, …)       │
+│  └── Updates (Sparkle)                                      │
+│                         │ XPC                               │
+│                         ▼                                   │
+│              MenuBarItemService.xpc                         │
+│              (source PID cache / listener)                  │
+└─────────────────────────────────────────────────────────────┘
+          │                         │
+          ▼                         ▼
+   macOS WindowServer /        HTTPS appcast
+   Accessibility /             (Sparkle updates)
+   private menu-bar APIs
+```
+
+### Main app (`Thaw/`)
+
+- **MenuBar:** Enumerates and moves status items, maintains hidden /
+  always-hidden sections, layout reconciliation, spacing, appearance overlay,
+  and the Thaw Bar (IceBar) UI.
+- **Events / Hotkeys:** User input paths that show or hide sections without
+  going through the settings UI.
+- **Settings:** UserDefaults-backed configuration, profiles, onboarding.
+- **Permissions:** Guides the user through TCC prompts required for AX and
+  screen capture features.
+- **Updates:** Sparkle client; feed URL and EdDSA public key live in
+  `Thaw/Resources/Info.plist`.
+
+### `MenuBarItemService` (XPC)
+
+A separate process (`com.stonerl.Thaw.MenuBarItemService`) isolates some
+WindowServer / PID lookup work from the UI process. The shared protocol is a
+small Codable request/response surface (`start`, `configureLogging`,
+`sourcePID` / `sourcePIDs`). Logging to a shared diagnostic file is configured
+by the main app after launch.
+
+### External interfaces
+
+| Interface | Direction | Notes |
+| --- | --- | --- |
+| `thaw://` URL scheme | Inbound | Automation / deep links; settings mutation is allowlisted + sender-signed — see [URI_SCHEMES.md](URI_SCHEMES.md) |
+| Sparkle appcast HTTPS | Outbound | Update metadata and downloads over TLS |
+| Accessibility / Screen Recording | System | Required for core menu-bar manipulation and capture |
+| Crowdin | Out-of-band | Localization workflow (not runtime) |
+| GitHub Releases / Homebrew | Distribution | Install and upgrade channels |
+
+## Data and persistence
+
+- Preferences and profiles: `UserDefaults` / app support files on the local Mac.
+- Diagnostic logs: optional local files (General settings); not uploaded by Thaw.
+- No first-party cloud backend; no user accounts.
+
+## Build and release
+
+- **Dev loop:** Open `Thaw.xcodeproj` in Xcode 26+, build/run.
+- **CI:** `.github/workflows/ci.yml` — SwiftLint, `xcodebuild test`, SonarCloud.
+  Shared release/CI pieces are gradually moving into the
+  [`thaw-app`](https://github.com/thaw-app) org.
+- **Release:** Signed with Developer ID, notarized, packaged (ZIP/DMG), Sparkle
+  appcast updated. See [VERIFYING_RELEASES.md](VERIFYING_RELEASES.md).
+- **Hosting:** Canonical source is [stonerl/Thaw](https://github.com/stonerl/Thaw)
+  today; governance targets a later transfer into `thaw-app` once fragile
+  release paths are stable (see [GOVERNANCE.md](../.github/GOVERNANCE.md)).
+
+## Related documents
+
+- [ASSURANCE_CASE.md](ASSURANCE_CASE.md) — threat model and security argument
+- [URI_SCHEMES.md](URI_SCHEMES.md) — external URL/API surface
+- [SECURITY.md](../.github/SECURITY.md) — security requirements and reporting
+- [GOVERNANCE.md](../.github/GOVERNANCE.md) — project roles

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -1,0 +1,144 @@
+# Thaw security assurance case
+
+This document argues that Thaw’s [security requirements](../.github/SECURITY.md)
+are met for its intended environment: a **local macOS menu bar utility** used by
+a single interactive user on their own Mac.
+
+Update it when trust boundaries or major features change. It supports OpenSSF
+Silver (`assurance_case`) and related Baseline security-assessment criteria.
+
+## 1. Security requirements (summary)
+
+Users **can** expect:
+
+1. Thaw runs locally; no Thaw account and no first-party tracking backend.
+2. Privileged OS permissions (Accessibility, Screen Recording) are requested
+   explicitly and used for menu-bar management features.
+3. Automation that **mutates settings** via `thaw://` requires an explicit
+   user-approved allowlist and matching code signature / Team ID.
+4. Software updates are delivered over HTTPS and authenticated with Sparkle
+   EdDSA; release builds are Developer ID–signed and notarized.
+5. Security issues can be reported privately; maintainers aim to acknowledge
+   within 48 hours.
+
+Users **cannot** expect:
+
+1. Protection against an attacker who already controls their unlocked Mac
+   session or who has been granted the same TCC permissions.
+2. A hardened multi-tenant server security model (Thaw is not a network service).
+3. Security fixes for abandoned old releases (only the latest stable is
+   supported).
+4. That third-party menu bar apps themselves are trustworthy.
+
+## 2. Threat model
+
+### Assets
+
+| Asset | Why it matters |
+| --- | --- |
+| Integrity of menu bar layout / visibility | Unexpected hide/show can disrupt status indicators and user trust |
+| User preferences and profiles | Local configuration; automation abuse could change behavior |
+| Diagnostic logs | May contain environment details if logging is enabled |
+| Update channel | Compromised updates → arbitrary code as the user |
+| TCC permissions held by Thaw | AX / screen capture are powerful on macOS |
+
+### Adversaries / scenarios
+
+| ID | Scenario | Likelihood | Impact |
+| --- | --- | --- | --- |
+| T1 | Malicious local app sends `thaw://` settings URLs | Medium | Config abuse, UX disruption |
+| T2 | Supply-chain compromise of a SwiftPM dependency or CI | Low–Med | Code execution in Thaw |
+| T3 | Tampered download / MITM on update feed | Low (HTTPS + signatures) | Code execution |
+| T4 | Malicious crafted profile / defaults data | Low–Med | Crash or unexpected layout |
+| T5 | Confused-deputy via Accessibility APIs | Inherent | Thaw can affect other apps’ status items by design |
+| T6 | Untrusted network attacker remote to the Mac | Low | Limited: no open server socket by design |
+
+Out of scope: physical access to unlocked Mac; bugs in macOS itself; compromise
+of Apple’s notarization infrastructure.
+
+## 3. Trust boundaries
+
+```text
+  Untrusted local apps / scripts          User (interactive)
+           │                                     │
+           │ thaw://                             │ UI / TCC prompts
+           ▼                                     ▼
+  ┌────────────────── Settings URI handler ──────────────────┐
+  │  allowlist + Team ID check  │  boolean/enum/range checks │
+  └──────────────────────────────┬───────────────────────────┘
+                                 │
+                                 ▼
+                    Thaw.app (user privileges)
+                                 │
+              ┌──────────────────┼──────────────────┐
+              ▼                  ▼                  ▼
+     MenuBarItemService     macOS TCC / AX     Sparkle (HTTPS)
+          (XPC)             WindowServer       EdDSA verify
+```
+
+| Boundary | What crosses | Controls |
+| --- | --- | --- |
+| External URL → settings | `thaw://set` etc. | Allowlisted keys; range checks; sender whitelist + `SecCode` Team ID binding |
+| App ↔ XPC helper | Codable requests | Fixed service name; limited request vocabulary |
+| App ↔ network | Appcast / downloads | HTTPS; Sparkle EdDSA (`SUPublicEDKey`); Apple notarization on shipped builds |
+| App ↔ OS | AX / capture | Explicit TCC; features degrade without grants |
+
+## 4. Secure design principles (Saltzer & Schroeder)
+
+| Principle | How Thaw applies it |
+| --- | --- |
+| **Economy of mechanism** | Small XPC protocol; URI settings limited to known keys |
+| **Fail-safe defaults** | Settings URI mutation denied unless allowlisted; permissions off until user grants |
+| **Complete mediation** | Each settings URI request re-checks whitelist + signature; numeric keys clamped to ranges |
+| **Open design** | GPL-3.0; public repo; security policy and this assurance case |
+| **Separation of privilege** | XPC helper separated from UI; release signing keys not on the public download host as long-lived plaintext |
+| **Least privilege** | Requests only needed TCC rights; no root requirement for normal use |
+| **Least common mechanism** | Per-user install; no shared multi-user daemon for core features |
+| **Psychological acceptability** | Clear permission prompts; authorize dialog lists what automation can do |
+
+## 5. Common implementation weaknesses countered
+
+Mapped loosely to CWE / OWASP-style classes relevant to a desktop app:
+
+| Weakness | Countermeasure |
+| --- | --- |
+| Memory corruption (CWE-119 etc.) | Primary implementation in Swift (memory-safe); limited bridging |
+| Injection via URLs / settings | Allowlist of keys; typed parsers; range validation (`SettingsURIHandler`) |
+| Broken access control for automation | User confirm + persistent whitelist + Team ID re-verify |
+| Insecure update / delivery | HTTPS + Sparkle EdDSA + Developer ID + notarization |
+| Hard-coded secrets in repo | Signing material in GitHub Actions secrets, not source |
+| Dependency vulnerabilities | SPM lockfile; CI; Dependabot (`.github/dependabot.yml`) |
+| Overly verbose public logging of secrets | Diagnostic logging is optional and local; avoid logging secrets |
+
+Static analysis (SonarCloud) and SwiftLint run in CI to catch a subset of
+defect classes before merge.
+
+## 6. Residual risks
+
+1. Accessibility by design can manipulate other apps’ menu bar items — users
+   must trust Thaw similarly to other AX utilities.
+2. Private/undocumented WindowServer interactions increase compatibility and
+   maintenance risk across macOS versions.
+3. Application repo is still under `stonerl/Thaw` while shared assets/CI move
+   first into [`thaw-app`](https://github.com/thaw-app) (three owners:
+   `stonerl`, `nightah`, `diazdesandi`). Full repo transfer is planned but
+   deliberately gradual so signing, Sparkle, and install URLs do not break.
+4. Statement coverage may sit below OpenSSF Silver’s 80% bar; tests reduce but
+   do not eliminate logic risk in UI-heavy modules excluded from coverage gates.
+
+## 7. Evidence pointers
+
+| Claim | Evidence |
+| --- | --- |
+| Private vuln reporting + response SLA | `.github/SECURITY.md` |
+| URI allowlist + signature binding | `Thaw/Utilities/SettingsURIHandler.swift`, `docs/URI_SCHEMES.md` |
+| Update authenticity | `SUFeedURL` / `SUPublicEDKey` in `Thaw/Resources/Info.plist`; Sparkle release actions |
+| Architecture | `docs/ARCHITECTURE.md` |
+| Automated analysis | `.github/workflows/ci.yml`, SonarCloud project `stonerl_Thaw` |
+| Dependency monitoring | `.github/dependabot.yml` |
+
+## Revision
+
+| Date | Note |
+| --- | --- |
+| 2026-07-27 | Initial version from `development` for OpenSSF Silver |

--- a/docs/ASSURANCE_CASE.md
+++ b/docs/ASSURANCE_CASE.md
@@ -5,7 +5,9 @@ are met for its intended environment: a **local macOS menu bar utility** used by
 a single interactive user on their own Mac.
 
 Update it when trust boundaries or major features change. It supports OpenSSF
-Silver (`assurance_case`) and related Baseline security-assessment criteria.
+Best Practices documentation criteria (`assurance_case`, security requirements,
+architecture). OpenSSF Silver **`test_statement_coverage80` is not yet claimed**
+— see residual risks.
 
 ## 1. Security requirements (summary)
 
@@ -123,8 +125,15 @@ defect classes before merge.
    first into [`thaw-app`](https://github.com/thaw-app) (three owners:
    `stonerl`, `nightah`, `diazdesandi`). Full repo transfer is planned but
    deliberately gradual so signing, Sparkle, and install URLs do not break.
-4. Statement coverage may sit below OpenSSF Silver’s 80% bar; tests reduce but
-   do not eliminate logic risk in UI-heavy modules excluded from coverage gates.
+4. **OpenSSF Silver statement coverage (`test_statement_coverage80`) is deferred.**
+   SonarCloud currently reports about **44%** coverage for `stonerl_Thaw` (not
+   ≥80%). CI collects coverage XML and uploads to SonarCloud
+   (`.github/workflows/ci.yml`, `sonar-project.properties`), but there is **no
+   80% gate** and this assurance case does **not** claim that criterion is Met.
+   Raise coverage (or document an accepted exclusion set with measured coverage
+   of the remainder) before marking Silver coverage Met. Tests still reduce
+   logic risk; UI-heavy modules excluded from coverage requirements remain a
+   residual testing gap.
 
 ## 7. Evidence pointers
 
@@ -135,10 +144,12 @@ defect classes before merge.
 | Update authenticity | `SUFeedURL` / `SUPublicEDKey` in `Thaw/Resources/Info.plist`; Sparkle release actions |
 | Architecture | `docs/ARCHITECTURE.md` |
 | Automated analysis | `.github/workflows/ci.yml`, SonarCloud project `stonerl_Thaw` |
+| Test coverage (measured, not Silver-met) | SonarCloud `coverage` measure; CI `coverage.xml` — **~44%, Silver 80% deferred** |
 | Dependency monitoring | `.github/dependabot.yml` |
 
 ## Revision
 
 | Date | Note |
 | --- | --- |
-| 2026-07-27 | Initial version from `development` for OpenSSF Silver |
+| 2026-07-27 | Initial version from `development` for OpenSSF docs |
+| 2026-07-27 | Deferred Silver coverage claim; measured ~44% |

--- a/docs/VERIFYING_RELEASES.md
+++ b/docs/VERIFYING_RELEASES.md
@@ -1,0 +1,73 @@
+# Verifying Thaw releases
+
+Thaw ships macOS app builds intended for wide use. Releases are protected by
+several layers. This page explains what those layers are and how you can check
+them.
+
+## What we sign
+
+| Layer | What it proves | How it is produced |
+| --- | --- | --- |
+| **Apple Developer ID + notarization** | Binary came from the Thaw developer team and passed Apple’s notarization checks | Release GitHub Actions (signing + `notarytool`) |
+| **Sparkle EdDSA** | Appcast / update payload matches the project’s Sparkle private key | Sparkle tools in release pipeline; public key embedded in the app |
+| **Git tag signatures** | Important version tags are GPG-signed by the releaser | `git tag -s` (or equivalent) on release tags |
+
+The Sparkle **private** key and Apple signing credentials are stored as CI
+secrets. They are not kept on the public download host as the long-term way
+users fetch builds (GitHub Releases / Homebrew are the distribution surfaces;
+signing happens in CI before publish).
+
+## Public Sparkle key
+
+The EdDSA public key shipped inside Thaw:
+
+```text
+fQ2kWqCLfAPAxQX1rp8gVNoG9hlAV/Gmm7kMBbxFe+A=
+```
+
+Source of truth in-tree: `Thaw/Resources/Info.plist` key `SUPublicEDKey`.  
+Appcast URL: `https://stonerl.github.io/Thaw/appcast.xml` (`SUFeedURL`).
+
+Sparkle uses this key automatically when checking for updates inside the app.
+You normally do **not** need to verify EdDSA by hand if you install a notarized
+build and use in-app updates.
+
+## Check a downloaded `.app` (Gatekeeper / notarization)
+
+After unzipping a GitHub Release archive:
+
+```sh
+# Quarantine + Gatekeeper assessment (macOS)
+spctl --assess --type execute -v /path/to/Thaw.app
+
+# Notarization ticket staple / history (when available)
+xcrun stapler validate /path/to/Thaw.app
+codesign --verify --deep --strict --verbose=2 /path/to/Thaw.app
+codesign -dv --verbose=4 /path/to/Thaw.app 2>&1 | grep -E 'Authority|TeamIdentifier|Timestamp'
+```
+
+Expect a **Developer ID Application** certificate and a successful assessment
+for notarized release builds. Homebrew-installed builds follow Homebrew’s own
+cask/bottle verification in addition to Apple’s checks.
+
+## Check a Git version tag
+
+```sh
+git fetch --tags
+git verify-tag <tag>    # e.g. 2.0.0-rc.1
+```
+
+Import the releaser’s public GPG key from their GitHub profile or a published
+keyserver if `git verify-tag` reports an unknown key.
+
+## Install channels
+
+- **GitHub Releases:** https://github.com/stonerl/Thaw/releases  
+- **Homebrew:** `brew install thaw` / `brew install thaw@beta`  
+- **In-app updates:** Sparkle (stable / beta channels in Settings)
+
+## Related
+
+- [ARCHITECTURE.md](ARCHITECTURE.md)
+- [ASSURANCE_CASE.md](ASSURANCE_CASE.md)
+- [SECURITY.md](../.github/SECURITY.md)

--- a/docs/VERIFYING_RELEASES.md
+++ b/docs/VERIFYING_RELEASES.md
@@ -9,7 +9,7 @@ them.
 | Layer | What it proves | How it is produced |
 | --- | --- | --- |
 | **Apple Developer ID + notarization** | Binary came from the Thaw developer team and passed Apple’s notarization checks | Release GitHub Actions (signing + `notarytool`) |
-| **Sparkle EdDSA** | Appcast / update payload matches the project’s Sparkle private key | Sparkle tools in release pipeline; public key embedded in the app |
+| **Sparkle EdDSA** | Downloaded **update archives** (e.g. release ZIPs) match signatures produced with the project’s Sparkle private key; the app verifies them with `SUPublicEDKey` | Sparkle tools in the release pipeline sign update packages; public key embedded in the app (`Info.plist`). The appcast lists those updates over HTTPS; **feed-level** signing (`SURequireSignedFeed`) is not enabled |
 | **Git tag signatures** | Important version tags are GPG-signed by the releaser | `git tag -s` (or equivalent) on release tags |
 
 The Sparkle **private** key and Apple signing credentials are stored as CI
@@ -52,13 +52,29 @@ cask/bottle verification in addition to Apple’s checks.
 
 ## Check a Git version tag
 
+1. Fetch tags and identify the release tag (e.g. `2.0.0-rc.1`).
+2. **Before trusting a new key:** obtain the releaser’s **full GPG fingerprint**
+   from a source you already trust (for example the Project Lead’s GitHub
+   profile GPG keys page, or a fingerprint previously confirmed out-of-band).
+   Compare that fingerprint **character-for-character** to the key you are about
+   to import. Do not import or trust a key solely because `git verify-tag`
+   downloaded it from a keyserver.
+3. Verify the tag signature, then confirm the tag points at the intended release
+   commit (the commit published for that GitHub Release).
+
 ```sh
-git fetch --tags
+git fetch --tags origin
+
+# After importing a key whose full fingerprint you already matched to a trusted source:
 git verify-tag <tag>    # e.g. 2.0.0-rc.1
+
+# Tag must resolve to the intended release commit:
+git rev-parse <tag>^{}
+# Compare to the commit SHA shown on the GitHub Release page for that tag.
 ```
 
-Import the releaser’s public GPG key from their GitHub profile or a published
-keyserver if `git verify-tag` reports an unknown key.
+If `git verify-tag` reports an unknown key, import only after the fingerprint
+check above succeeds.
 
 ## Install channels
 


### PR DESCRIPTION
# Summary

Add OpenSSF Silver–oriented project documentation and Dependabot: governance, architecture, assurance case, release verification, expanded security/response policy, DCO in CONTRIBUTING, and README links.

**Scope:** Documentation and Dependabot config only — no application code changes.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `Fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [ ] Bug fix
- [ ] CI/CD
- [x] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [x] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Adds `.github/GOVERNANCE.md` (project lead / org owners, Discord coordination, gradual `thaw-app` migration).
- Adds `docs/ARCHITECTURE.md`, `docs/ASSURANCE_CASE.md`, and `docs/VERIFYING_RELEASES.md`.
- Expands `.github/SECURITY.md` with security requirements and response process; requires DCO in `.github/CONTRIBUTING.md`.
- Enables Dependabot (SwiftPM + GitHub Actions) on `development`, auto-assigned to @diazdesandi.
- Links the new docs from `README.md` (install verification, roadmap horizon, project documentation).

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected. *(N/A — docs / Dependabot config only; no app code changes)*
- [x] I've run `swiftformat .` to keep the code style consistent. *(N/A — no Swift source changes)*
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`. *(N/A — documentation-only PR)*
- [ ] I've added tests for new behavior (if applicable). *(N/A)*
- [ ] I've documented new public APIs / non-obvious helpers. *(N/A)*
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- N/A (docs-only)

## Known limitations / follow-ups

- Filling OpenSSF Best Practices **Silver** answers with the new URLs once merged
- Confirm Dependabot appears under Insights → Dependency graph → Dependabot after merge
- Gradual application-repo migration into `thaw-app` remains planned, not executed here

## Other information

Unlocks / supports OpenSSF Best Practices **Silver** (and related Baseline) criteria around:

- Documented **governance** and roles (bus factor / continuity)
- Documented **architecture** and **assurance case**
- Clear **security requirements** and vulnerability response (`SECURITY.md`)
- **Contributor** expectations including DCO
- **Release verification** guidance for consumers
- Automated **dependency update** tooling (Dependabot)

Reviewer skim: `.github/GOVERNANCE.md` (owners / Discord), README links on the PR branch, Dependabot paths after merge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded contribution guidance with Developer Certificate of Origin (DCO) sign-off requirements, AI-assisted contribution expectations, and stronger PR/contribution conventions (including testing guidance).
  - Added governance, security policy, architecture overview, an OpenSSF-style assurance case, and a release-verification guide; updated the README with clearer direction and links to core project documentation.
- **Maintenance**
  - Enabled weekly automated dependency updates for Swift packages and GitHub Actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->