### PR TITLE
feat(release): publish Sparkle payloads to thaw-app/updates

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,7 @@ jobs:
             if git clone --depth 1 --branch gh-pages "$remote" "$work" 2>/dev/null; then
               :
             else
+              rm -rf "$work"
               git clone --depth 1 "$remote" "$work"
               git -C "$work" checkout --orphan gh-pages
               git -C "$work" rm -rf . >/dev/null 2>&1 || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,7 +137,7 @@ jobs:
 
       - name: Sparkle ZIP and appcast
         id: sparkle
-        uses: thaw-app/org-ci/actions/sparkle-release@9944dd9543eeb383493e428f92e262cb299dc1ff
+        uses: thaw-app/org-ci/actions/sparkle-release@1426ab64607a0b42c02b409486eeb47ef7b9ba25
         with:
           tag: ${{ steps.meta.outputs.tag }}
           channel: ${{ steps.meta.outputs.channel }}
@@ -170,18 +170,6 @@ jobs:
           echo "Update assets (thaw-app/updates):"
           cat "$list"
 
-      - name: Create Thaw GitHub Release (DMG)
-        uses: softprops/action-gh-release@v3
-        with:
-          tag_name: ${{ steps.meta.outputs.tag }}
-          files: build/${{ env.DMG_NAME }}
-          generate_release_notes: false
-          # Draft unless publish_release is checked.
-          draft: ${{ !inputs.publish_release }}
-          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Create updates GitHub Release (ZIP + deltas)
         uses: softprops/action-gh-release@v3
         with:
@@ -198,6 +186,18 @@ jobs:
             Installer DMG: https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}
         env:
           GITHUB_TOKEN: ${{ secrets.UPDATES_GITHUB_TOKEN }}
+
+      - name: Create Thaw GitHub Release (DMG)
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ steps.meta.outputs.tag }}
+          files: build/${{ env.DMG_NAME }}
+          generate_release_notes: false
+          # Draft unless publish_release is checked.
+          draft: ${{ !inputs.publish_release }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Publish appcast to updates gh-pages
         if: inputs.publish_appcast && inputs.publish_release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,10 @@ name: Release
 # Sparkle / channel releases are manual only (workflow_dispatch).
 # Pushing semver tags does NOT run this workflow — safe for backfilling
 # release history or pointing tags at old commits without distributing.
+#
+# Artifact split:
+#   - thaw-app/Thaw releases: DMG only (human installers)
+#   - thaw-app/updates releases + Pages: Sparkle ZIP, deltas, appcast.xml
 
 on:
   workflow_dispatch:
@@ -27,10 +31,14 @@ on:
         type: boolean
         default: false
       publish_appcast:
-        description: Push signed appcast.xml to gh-pages
+        description: Push signed appcast.xml to thaw-app/updates gh-pages
         required: false
         type: boolean
         default: true
+
+concurrency:
+  group: sparkle-appcast
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -40,6 +48,7 @@ jobs:
     env:
       APP_NAME: "Thaw.app"
       DMG_NAME: "Thaw.dmg"
+      UPDATES_REPOSITORY: thaw-app/updates
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -128,7 +137,7 @@ jobs:
 
       - name: Sparkle ZIP and appcast
         id: sparkle
-        uses: thaw-app/org-ci/actions/sparkle-release@d8439b09dfc7dda7323906cd0daeef1752c4bb2a
+        uses: thaw-app/org-ci/actions/sparkle-release@9944dd9543eeb383493e428f92e262cb299dc1ff
         with:
           tag: ${{ steps.meta.outputs.tag }}
           channel: ${{ steps.meta.outputs.channel }}
@@ -136,16 +145,18 @@ jobs:
           asset-prefix: Thaw
           appcast-title: Thaw
           sparkle-private-key: ${{ secrets.SPARKLE_ED25519_PRIVATE_KEY }}
+          updates-repository: ${{ env.UPDATES_REPOSITORY }}
+          updates-token: ${{ secrets.UPDATES_GITHUB_TOKEN }}
+          release-html-url: https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}
           publish-appcast: "false"
 
-      - name: Collect release assets
-        id: assets
+      - name: Collect update assets
+        id: update-assets
         run: |
           set -euo pipefail
 
-          list="$RUNNER_TEMP/release-assets.txt"
+          list="$RUNNER_TEMP/update-assets.txt"
           : > "$list"
-          printf '%s\n' "build/${DMG_NAME}" >> "$list"
           printf '%s\n' "${{ steps.sparkle.outputs.zip-path }}" >> "$list"
 
           shopt -s nullglob
@@ -156,14 +167,14 @@ jobs:
           echo "files<<EOF" >> "$GITHUB_OUTPUT"
           cat "$list" >> "$GITHUB_OUTPUT"
           echo "EOF" >> "$GITHUB_OUTPUT"
-          echo "Release assets:"
+          echo "Update assets (thaw-app/updates):"
           cat "$list"
 
-      - name: Create GitHub Release
+      - name: Create Thaw GitHub Release (DMG)
         uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.meta.outputs.tag }}
-          files: ${{ steps.assets.outputs.files }}
+          files: build/${{ env.DMG_NAME }}
           generate_release_notes: false
           # Draft unless publish_release is checked.
           draft: ${{ !inputs.publish_release }}
@@ -171,45 +182,79 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish appcast to gh-pages
+      - name: Create updates GitHub Release (ZIP + deltas)
+        uses: softprops/action-gh-release@v3
+        with:
+          repository: ${{ env.UPDATES_REPOSITORY }}
+          tag_name: ${{ steps.meta.outputs.tag }}
+          target_commitish: main
+          files: ${{ steps.update-assets.outputs.files }}
+          generate_release_notes: false
+          draft: ${{ !inputs.publish_release }}
+          prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
+          body: |
+            Sparkle update payloads for Thaw `${{ steps.meta.outputs.tag }}`.
+
+            Installer DMG: https://github.com/${{ github.repository }}/releases/tag/${{ steps.meta.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.UPDATES_GITHUB_TOKEN }}
+
+      - name: Publish appcast to updates gh-pages
         if: inputs.publish_appcast && inputs.publish_release
         env:
           TAG: ${{ steps.meta.outputs.tag }}
           CHANNEL: ${{ steps.meta.outputs.channel }}
           APPCAST_PATH: ${{ steps.sparkle.outputs.appcast-path }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          UPDATES_REPO: ${{ env.UPDATES_REPOSITORY }}
+          UPDATES_TOKEN: ${{ secrets.UPDATES_GITHUB_TOKEN }}
         run: |
           set -euo pipefail
 
-          work="$RUNNER_TEMP/gh-pages-work"
-          rm -rf "$work"
+          work="$RUNNER_TEMP/updates-gh-pages-work"
+          remote="https://x-access-token:${UPDATES_TOKEN}@github.com/${UPDATES_REPO}.git"
+          max_attempts=5
+          attempt=1
 
-          git clone --depth 1 --branch gh-pages \
-            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-            "$work" 2>/dev/null \
-          || {
-            git clone --depth 1 \
-              "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" \
-              "$work"
-            git -C "$work" checkout --orphan gh-pages
-            git -C "$work" rm -rf . >/dev/null 2>&1 || true
-          }
+          while true; do
+            rm -rf "$work"
 
-          cp "$APPCAST_PATH" "$work/appcast.xml"
-          if [[ ! -f "$work/.gitignore" ]]; then
-            printf '*\n!appcast.xml\n!.gitignore\n' > "$work/.gitignore"
-          fi
+            if git clone --depth 1 --branch gh-pages "$remote" "$work" 2>/dev/null; then
+              :
+            else
+              git clone --depth 1 "$remote" "$work"
+              git -C "$work" checkout --orphan gh-pages
+              git -C "$work" rm -rf . >/dev/null 2>&1 || true
+            fi
 
-          git -C "$work" config user.name "github-actions[bot]"
-          git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git -C "$work" add appcast.xml .gitignore
-          if git -C "$work" diff --staged --quiet; then
-            echo "appcast.xml unchanged"
-            exit 0
-          fi
+            cp "$APPCAST_PATH" "$work/appcast.xml"
+            if [[ ! -f "$work/.gitignore" ]]; then
+              printf '*\n!appcast.xml\n!.gitignore\n' > "$work/.gitignore"
+            fi
 
-          git -C "$work" commit -m "chore(sparkle): publish appcast for ${TAG} (${CHANNEL})"
-          git -C "$work" push origin HEAD:gh-pages
+            git -C "$work" config user.name "github-actions[bot]"
+            git -C "$work" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git -C "$work" add appcast.xml .gitignore
+            if git -C "$work" diff --staged --quiet; then
+              echo "appcast.xml unchanged"
+              exit 0
+            fi
+
+            git -C "$work" commit -m "chore(sparkle): publish appcast for ${TAG} (${CHANNEL})"
+
+            if git -C "$work" push origin HEAD:gh-pages; then
+              echo "Published appcast to ${UPDATES_REPO}@gh-pages"
+              exit 0
+            fi
+
+            if [[ "$attempt" -ge "$max_attempts" ]]; then
+              echo "Failed to push gh-pages after $max_attempts attempts"
+              exit 1
+            fi
+
+            echo "gh-pages push failed (attempt $attempt/$max_attempts); refetching…"
+            attempt=$((attempt + 1))
+            sleep $((attempt * 2))
+          done
 
       - name: Cleanup keychain
         if: always()

--- a/Thaw/Resources/Info.plist
+++ b/Thaw/Resources/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>SUFeedURL</key>
-	<string>https://stonerl.github.io/Thaw/appcast.xml</string>
+	<string>https://thaw-app.github.io/updates/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>fQ2kWqCLfAPAxQX1rp8gVNoG9hlAV/Gmm7kMBbxFe+A=</string>
 	<key>CFBundleURLTypes</key>

--- a/docs/VERIFYING_RELEASES.md
+++ b/docs/VERIFYING_RELEASES.md
@@ -26,7 +26,9 @@ fQ2kWqCLfAPAxQX1rp8gVNoG9hlAV/Gmm7kMBbxFe+A=
 ```
 
 Source of truth in-tree: `Thaw/Resources/Info.plist` key `SUPublicEDKey`.  
-Appcast URL: `https://stonerl.github.io/Thaw/appcast.xml` (`SUFeedURL`).
+Appcast URL: `https://thaw-app.github.io/updates/appcast.xml` (`SUFeedURL`).
+Legacy installs may still poll `https://stonerl.github.io/Thaw/appcast.xml`
+until that host redirects here.
 
 Sparkle uses this key automatically when checking for updates inside the app.
 You normally do **not** need to verify EdDSA by hand if you install a notarized


### PR DESCRIPTION
# Summary

Split release artifacts so installers stay on Thaw and Sparkle update payloads live on the dedicated `thaw-app/updates` feed host. Pins `sparkle-release` to the org-ci SHA that supports `updates-repository` ([thaw-app/org-ci#2](https://github.com/thaw-app/org-ci/pull/2)) and points `SUFeedURL` at the new Pages URL.

**Scope:** Release pipeline + feed URL only. No product UI changes.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [ ] Bug fix
- [x] CI/CD
- [x] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [x] updates
- [x] ops

## Does this PR introduce a breaking change?

- [x] Yes - if yes, please describe the impact and migration path
- [ ] No

New builds poll `https://thaw-app.github.io/updates/appcast.xml`. Existing installs keep the baked-in legacy `SUFeedURL` (`stonerl.github.io/Thaw`) until that host redirects (or users update via the old feed once it is back). Historical enclosure URLs in the seeded appcast are left unchanged.

## What is the new behavior?

- **Thaw GitHub Releases:** DMG only (human installers)
- **`thaw-app/updates` releases:** Sparkle ZIP + deltas
- **Appcast:** published to `thaw-app/updates` `gh-pages`
- **`SUFeedURL`:** `https://thaw-app.github.io/updates/appcast.xml`
- Release workflow requires secret **`UPDATES_GITHUB_TOKEN`** (`contents: write` on `thaw-app/updates`)

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- N/A (workflow / plist / docs only — verify via draft release below)

## Known limitations / follow-ups

- [ ] Merge [org-ci#2](https://github.com/thaw-app/org-ci/pull/2); re-pin to merge commit if desired
- [ ] Add `UPDATES_GITHUB_TOKEN` on Thaw (repo or org secret)
- [ ] Enable Pages on `thaw-app/updates` (`gh-pages`) and seed current `appcast.xml`
- [ ] Bring `stonerl.github.io/Thaw` back with an HTTP redirect to the new feed

## Other information

Manual verification:

- [ ] Draft release (`publish_release` unchecked): DMG draft on Thaw, ZIP/deltas draft on `updates`, no appcast push
- [ ] Publish release with `publish_appcast`: enclosure URLs under `github.com/thaw-app/updates/releases/download/...`
- [ ] Confirm live feed at `https://thaw-app.github.io/updates/appcast.xml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Release artifacts are now published separately: DMG downloads from the main repo and Sparkle update payloads from the updates repo.
  * Automatic updates use the new appcast feed at `https://thaw-app.github.io/updates/appcast.xml`.

* **Bug Fixes**
  * Improved appcast publishing reliability with serialized runs and retry logic during `appcast.xml` updates.

* **Documentation**
  * Updated release verification guidance to reference the new feed URL and note legacy polling behavior until redirect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->