### PR TITLE
fix(layout): prune stale title-variant saved entries to stop the macOS 27 reorder storm

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -887,7 +887,8 @@ nonisolated enum LayoutSolver {
         currentInSection: [String],
         oldSavedForSection: [String],
         allCurrentIdentifiers: Set<String>,
-        allCurrentBaseIdentifiers: Set<String>
+        allCurrentBaseIdentifiers: Set<String>,
+        allCurrentNamespaces: Set<String> = []
     ) -> [String] {
         var identifiers = currentInSection
 
@@ -909,6 +910,22 @@ nonisolated enum LayoutSolver {
                 .prefix(2).joined(separator: ":")
             if allCurrentBaseIdentifiers.contains(base) {
                 continue
+            }
+            // Stale title-variant of a still-running app: the app (namespace)
+            // is present in the cache but this exact identifier is not. Items
+            // that vary their title (MeetingBar / Granola countdowns, live
+            // metrics, etc.) mint a fresh identifier whenever the title changes;
+            // without this, every past title is preserved as a "closed app" and
+            // oldSavedForSection grows without bound, making this O(n²) merge
+            // pathologically slow (the macOS 27 reorder "storm"). The app's live
+            // item(s) are already carried by currentInSection, so drop the stale
+            // variant. Namespace is the identifier prefix up to the first ':'
+            // (a namespace — a bundle id or reserved keyword — never contains one).
+            if !allCurrentNamespaces.isEmpty {
+                let namespace = savedUID.prefix { $0 != ":" }
+                if !namespace.isEmpty, allCurrentNamespaces.contains(String(namespace)) {
+                    continue
+                }
             }
 
             // Find an anchor in oldSavedForSection that's also in the

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -845,6 +845,13 @@ final class MenuBarItemManager: ObservableObject {
 
         var allCurrentIdentifiers = Set<String>()
         var allCurrentBaseIdentifiers = Set<String>()
+        // Namespaces (app bundle ids / reserved keywords) of every currently
+        // cached item, so planSectionOrder can drop stale title-variant saved
+        // entries for apps that are still running (title-churning items like
+        // MeetingBar / Granola countdowns would otherwise bloat savedSectionOrder
+        // without bound and make the O(n²) merge pin a core — the macOS 27
+        // reorder "storm").
+        var allCurrentNamespaces = Set<String>()
         for section in MenuBarSection.Name.allCases {
             for item in cache[section] where isPersistable(item) {
                 guard !pendingRehideTagIDs.contains(item.tag.tagIdentifier) else { continue }
@@ -853,6 +860,7 @@ final class MenuBarItemManager: ObservableObject {
                 // isStaleInstanceIndex guard below and not re-injected.
                 let baseID = "\(item.tag.namespace):\(item.tag.canonicalTitle)"
                 allCurrentBaseIdentifiers.insert(baseID)
+                allCurrentNamespaces.insert("\(item.tag.namespace)")
                 // Exclude transient Control Center items (Live Activities,
                 // iPhone Mirroring icons) from the identifier set so their
                 // ephemeral UIDs are never written to savedSectionOrder.
@@ -882,7 +890,8 @@ final class MenuBarItemManager: ObservableObject {
                 currentInSection: currentInSection,
                 oldSavedForSection: oldSavedForSection,
                 allCurrentIdentifiers: allCurrentIdentifiers,
-                allCurrentBaseIdentifiers: allCurrentBaseIdentifiers
+                allCurrentBaseIdentifiers: allCurrentBaseIdentifiers,
+                allCurrentNamespaces: allCurrentNamespaces
             )
 
             if !identifiers.isEmpty {

--- a/ThawTests/PlanSectionOrderStormTests.swift
+++ b/ThawTests/PlanSectionOrderStormTests.swift
@@ -1,0 +1,100 @@
+//
+//  PlanSectionOrderStormTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Regression tests for the macOS 27 reorder "storm". Root cause: menu bar
+/// items that vary their title (MeetingBar / Granola countdowns, live metrics)
+/// mint a new saved identifier every time the title changes, and
+/// planSectionOrder preserved every past title as a "closed app" — so
+/// savedSectionOrder grew without bound (observed in the wild: 1,565 entries).
+/// Because planSectionOrder is O(n²), that bloat made a single call take
+/// ~250 ms and pinned a core on every recache. planSectionOrder now drops a
+/// saved entry when its app (namespace) is present but the exact identifier is
+/// not — a stale title-variant of a still-running app.
+@Suite("Plan section order storm pruning")
+struct PlanSectionOrderStormTests {
+    @Test("Stale title-variants of a still-running app are pruned")
+    func staleTitleVariantsOfRunningAppArePruned() {
+        // "leits.MeetingBar" is running now with one current title.
+        let current = ["leits.MeetingBar:Meeting in 3m", "com.other.app:Item-0"]
+        // Saved order accumulated a long tail of past countdown titles.
+        var saved = ["com.other.app:Item-0"]
+        for minutes in 4 ... 120 { saved.append("leits.MeetingBar:Meeting in \(minutes)m") }
+        saved.append("leits.MeetingBar:Meeting in 3m") // the current one
+
+        let result = LayoutSolver.planSectionOrder(
+            currentInSection: current,
+            oldSavedForSection: saved,
+            allCurrentIdentifiers: Set(current),
+            allCurrentBaseIdentifiers: Set(current),
+            allCurrentNamespaces: ["leits.MeetingBar", "com.other.app"]
+        )
+
+        let meetingBarEntries = result.filter { $0.hasPrefix("leits.MeetingBar:") }
+        #expect(
+            meetingBarEntries == ["leits.MeetingBar:Meeting in 3m"],
+            "stale MeetingBar title-variants of the running app should be pruned, not preserved"
+        )
+        #expect(result.contains("com.other.app:Item-0"))
+    }
+
+    @Test("A genuinely closed app still keeps its saved position")
+    func genuinelyClosedAppStillPreserved() {
+        let current = ["com.a.app:Item-0", "com.c.app:Item-0"]
+        let saved = ["com.a.app:Item-0", "com.b.app:Item-0", "com.c.app:Item-0"]
+
+        let result = LayoutSolver.planSectionOrder(
+            currentInSection: current,
+            oldSavedForSection: saved,
+            allCurrentIdentifiers: Set(current),
+            allCurrentBaseIdentifiers: Set(current),
+            allCurrentNamespaces: ["com.a.app", "com.c.app"] // com.b.app is NOT present
+        )
+
+        #expect(
+            result == ["com.a.app:Item-0", "com.b.app:Item-0", "com.c.app:Item-0"],
+            "com.b.app has quit entirely, so its saved position must be preserved"
+        )
+    }
+
+    @Test("Namespace parsing stops at the first colon even when the title contains one")
+    func namespaceParsedAsPrefixBeforeFirstColon() {
+        let current = ["com.granola.app:Public: in 7m"]
+        let saved = ["com.granola.app:Private: in 9m", "com.granola.app:Public: in 7m"]
+
+        let result = LayoutSolver.planSectionOrder(
+            currentInSection: current,
+            oldSavedForSection: saved,
+            allCurrentIdentifiers: Set(current),
+            allCurrentBaseIdentifiers: Set(current),
+            allCurrentNamespaces: ["com.granola.app"]
+        )
+
+        #expect(
+            result == ["com.granola.app:Public: in 7m"],
+            "the stale 9m variant should be pruned"
+        )
+    }
+
+    @Test("With no namespaces provided, legacy closed-app preservation is unchanged")
+    func defaultParamPreservesLegacyBehavior() {
+        let result = LayoutSolver.planSectionOrder(
+            currentInSection: ["A"],
+            oldSavedForSection: ["A", "leits.MeetingBar:in 5m"],
+            allCurrentIdentifiers: ["A"],
+            allCurrentBaseIdentifiers: ["A"]
+            // allCurrentNamespaces omitted → pruning disabled
+        )
+        #expect(
+            result.contains("leits.MeetingBar:in 5m"),
+            "with no namespaces provided, legacy closed-app preservation is unchanged"
+        )
+    }
+}


### PR DESCRIPTION
# Summary

Fixes the macOS 27 high-CPU / beachball storm on reorder (and at launch) caused by unbounded growth of `savedSectionOrder` from title-varying menu bar items.

**Scope:** One focused layout fix in `planSectionOrder` / `computeSectionOrder`, plus tests. No broader refactor.

> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/stonerl/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [x] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Menu bar items that vary their **title** (MeetingBar / Granola live countdowns, live metrics, etc.) previously minted a new saved identifier on every title change. `LayoutSolver.planSectionOrder` kept every past title as a “closed app” position, so `savedSectionOrder` grew without bound (observed at **1,565 entries**). Because `planSectionOrder` is O(n²), that made each recache ~250 ms and pinned a core on macOS 27 reorder / launch.

`planSectionOrder` now drops a saved entry when its **app namespace is present in the cache but the exact identifier is not** (stale title-variant of a still-running app). Genuinely closed apps (namespace absent) keep their saved position. `computeSectionOrder` passes currently present namespaces; the new parameter defaults to `[]` so existing callers are unaffected.

Verified workaround before the fix: `defaults delete com.stonerl.Thaw MenuBarItemManager.savedSectionOrder` dropped CPU from 100% → ~10%.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.

Test commands run:

- `PlanSectionOrderStormTests` (stale variants pruned, closed apps preserved, namespace parsing with colons in titles, back-compat when new param omitted)
- Built from `feat/macos-27-experimental` (against `prk-bin 0.0.13`) and run on macOS 27.0 (26A5388g), 3 displays: reorder CPU **100% → ~13% avg**, moves land correctly, `savedSectionOrder` stays small (~9 entries)

## Known limitations / follow-ups

- Targets `feat/macos-27-experimental` (not `development`) by design for the macOS 27 train
- General title-variant pruning rather than per-app title canonicalization (iStat Menus already has its own path)

## Other information

Diagnosis discussion referenced as #737. Diff is ~28 lines across `LayoutSolver.swift` and `MenuBarItemManager.swift`, plus tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu ordering stability when applications frequently change titles or identifiers.
  * Prevented stale historical entries from accumulating and slowing down menu updates.
  * Preserved saved ordering for genuinely closed applications.

* **Tests**
  * Added regression coverage for rapidly changing application identifiers, namespace parsing, and legacy ordering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->