### PR TITLE
fix(menubar): back off negative-cache TTL instead of flat 60s

### DIFF
--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -159,6 +159,14 @@ actor SourcePIDCache {
         /// discovered immediately.
         var negativeUntil = [CGWindowID: ContinuousClock.Instant]()
 
+        /// Consecutive full scans that have left each window unresolved.
+        /// Drives the negative-cache TTL ladder: early failures get short
+        /// deadlines so the app's startup settling window can retry while
+        /// AX trees are still warming up, repeat failures back off to the
+        /// steady-state TTL. Reset when a window resolves; pruned alongside
+        /// `negativeUntil` so it stays bounded.
+        var negativeFailures = [CGWindowID: Int]()
+
         /// Reorders the cached apps so that those that are confirmed
         /// to have an extras menu bar are first in the array.
         mutating func partitionApps() {
@@ -180,8 +188,9 @@ actor SourcePIDCache {
     /// The shared cache.
     static let shared = SourcePIDCache()
 
-    /// How long an unresolved window is barred from initiating a new scan.
-    private static let negativeCacheTTL: Duration = .seconds(60)
+    // The per-failure negative-cache deadline lives in
+    // SourcePIDNegativeCachePolicy (Shared/), so the ladder is unit-testable
+    // from ThawTests.
 
     /// Minimum interval between unresolved-diagnostic dumps for an unchanged
     /// unresolved set. The dump re-walks every app's AX tree, so repeating it
@@ -275,6 +284,7 @@ actor SourcePIDCache {
             // immediately after every application-list update.
             let now = ContinuousClock.now
             let carriedNegativeUntil = state.negativeUntil.filter { $0.value > now }
+            let carriedNegativeFailures = state.negativeFailures
 
             // Create a new state that matches the current running apps.
             state = runningApps.reduce(into: State()) { result, app in
@@ -296,7 +306,15 @@ actor SourcePIDCache {
                     }
                 }
             }
-            state.negativeUntil = carriedNegativeUntil
+            // Carry negative state only for windows that are still unresolved.
+            // A scan driven by any one window resolves every window it can, so
+            // a previously negative-cached window may now hold a PID; keeping
+            // its failure count would start its next miss partway up the
+            // ladder instead of at the first rung.
+            state.negativeUntil = carriedNegativeUntil.filter { state.pids[$0.key] == nil }
+            state.negativeFailures = carriedNegativeFailures.filter {
+                state.negativeUntil[$0.key] != nil
+            }
 
             // Log cleanup activity
             if !terminatedPids.isEmpty {
@@ -657,17 +675,35 @@ actor SourcePIDCache {
         let finalPID = state.withLock { $0.pids[window.windowID] }
         SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsWithBar) with extras bar, \(totalChildrenChecked) children)")
 
-        // Negative-cache every window that survived the full scan unresolved.
-        // Expired entries are pruned on the same write to bound the dictionary.
-        if !unresolvedWindows.isEmpty {
-            let now = ContinuousClock.now
-            let deadline = now + Self.negativeCacheTTL
-            let unresolvedSnapshot = unresolvedWindows
-            state.withLock { state in
-                state.negativeUntil = state.negativeUntil.filter { $0.value > now }
-                for windowID in unresolvedSnapshot {
-                    state.negativeUntil[windowID] = deadline
-                }
+        // Negative-cache every window that survived the full scan unresolved,
+        // with a deadline that backs off as consecutive failures accumulate:
+        // short at first so the app's startup settling window can retry while
+        // AX trees are still warming up, then the steady-state TTL. A flat
+        // TTL here wedged resolution permanently — the first cold scan
+        // under-resolves, its deadline outlasts every retry the app makes,
+        // and no scan runs again (the app stops requesting once settled).
+        // Entries that expired, and entries whose window this scan resolved,
+        // are dropped on the same write, so both dictionaries stay bounded and
+        // a resolved window's next miss starts at the first rung. This runs
+        // unconditionally: a scan that resolves everything leaves
+        // unresolvedWindows empty, and that is exactly when the stale entries
+        // need clearing.
+        let now = ContinuousClock.now
+        let unresolvedSnapshot = unresolvedWindows
+        state.withLock { state in
+            var negativeUntil = state.negativeUntil.filter { entry in
+                entry.value > now && state.pids[entry.key] == nil
+            }
+            for windowID in unresolvedSnapshot {
+                let failures = (state.negativeFailures[windowID] ?? 0) + 1
+                state.negativeFailures[windowID] = failures
+                negativeUntil[windowID] = now + SourcePIDNegativeCachePolicy.ttl(
+                    afterConsecutiveFailures: failures
+                )
+            }
+            state.negativeUntil = negativeUntil
+            state.negativeFailures = state.negativeFailures.filter {
+                negativeUntil[$0.key] != nil
             }
         }
 

--- a/Shared/Utilities/SourcePIDNegativeCachePolicy.swift
+++ b/Shared/Utilities/SourcePIDNegativeCachePolicy.swift
@@ -1,0 +1,36 @@
+//
+//  SourcePIDNegativeCachePolicy.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+/// TTL ladder for the source-PID negative cache.
+///
+/// The first full AX scan after launch routinely under-resolves: other apps'
+/// accessibility trees are still warming up, so a scan that runs seconds
+/// after launch can miss windows that a scan half a minute later resolves.
+/// The app's resolution requests are also front-loaded into its startup
+/// settling window. A flat TTL as long as that window absorbs every retry —
+/// each window fails one cold scan, is barred from initiating another until
+/// after the app has stopped asking, and the cache never converges.
+///
+/// Short deadlines for the first failures let the settling window retry a
+/// window while a better scan result is still likely; repeated failures back
+/// off to the steady-state TTL that guards against the scan storms the
+/// negative cache exists to prevent.
+nonisolated enum SourcePIDNegativeCachePolicy {
+    /// The negative-cache deadline applied after `failures` consecutive
+    /// full scans have left a window unresolved (1 = the first failure).
+    ///
+    /// Values at or below 1 clamp to the first rung so a bookkeeping error
+    /// upstream degrades to more scanning, never to a permanent bar.
+    static func ttl(afterConsecutiveFailures failures: Int) -> Duration {
+        switch failures {
+        case ...1: .seconds(5)
+        case 2: .seconds(15)
+        default: .seconds(60)
+        }
+    }
+}

--- a/ThawTests/SourcePIDNegativeCachePolicyTests.swift
+++ b/ThawTests/SourcePIDNegativeCachePolicyTests.swift
@@ -1,0 +1,61 @@
+//
+//  SourcePIDNegativeCachePolicyTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+import Testing
+@testable import Thaw
+
+/// Pins the negative-cache TTL ladder.
+///
+/// The regression this ladder fixes: the app front-loads its sourcePID
+/// resolution requests into its startup settling window (~90s), and the
+/// first cold AX scan routinely under-resolves. With a flat 60s TTL, one
+/// failed cold scan barred a window past the last request the app would
+/// ever make for it, wedging resolution for the whole session. The early
+/// rungs must therefore stay comfortably inside the settling window, and
+/// the ladder must never bar a window permanently.
+struct SourcePIDNegativeCachePolicyTests {
+    @Test func firstFailureRetriesQuickly() {
+        #expect(SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 1) == .seconds(5))
+    }
+
+    @Test func secondFailureBacksOff() {
+        #expect(SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 2) == .seconds(15))
+    }
+
+    @Test func repeatFailuresReachSteadyStateAndStayThere() {
+        for failures in 3...20 {
+            #expect(SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: failures) == .seconds(60))
+        }
+    }
+
+    @Test func ladderIsMonotonicNondecreasing() {
+        var previous = SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 1)
+        for failures in 2...10 {
+            let current = SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: failures)
+            #expect(current >= previous)
+            previous = current
+        }
+    }
+
+    @Test func nonPositiveCountsClampToFirstRung() {
+        // A bookkeeping error upstream must degrade to more scanning,
+        // never to a longer bar.
+        #expect(SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 0) == .seconds(5))
+        #expect(SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: -3) == .seconds(5))
+    }
+
+    @Test func earlyRungsFitInsideTheSettlingWindow() {
+        // First two retries must complete within the app's ~90s settling
+        // window with margin: 5 + 15 leaves three scan opportunities
+        // before requests stop.
+        let firstTwo = SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 1)
+            + SourcePIDNegativeCachePolicy.ttl(afterConsecutiveFailures: 2)
+        #expect(firstTwo < .seconds(30))
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -10,6 +10,7 @@ $(SRCROOT)/Shared/Utilities/DiagnosticLogger.swift
 $(SRCROOT)/Shared/Utilities/MarkerPairResolver.swift
 $(SRCROOT)/Shared/Utilities/SharedConstants.swift
 $(SRCROOT)/Shared/Utilities/SharedExtensions.swift
+$(SRCROOT)/Shared/Utilities/SourcePIDNegativeCachePolicy.swift
 $(SRCROOT)/Shared/Utilities/WindowInfo.swift
 $(SRCROOT)/Thaw/Events/EventMonitor.swift
 $(SRCROOT)/Thaw/Events/EventTap.swift
@@ -41,6 +42,7 @@ $(SRCROOT)/Thaw/MenuBar/Appearance/MissionControlDetector.swift
 $(SRCROOT)/Thaw/MenuBar/ControlItem/ControlItem.swift
 $(SRCROOT)/Thaw/MenuBar/ControlItem/ControlItemImage.swift
 $(SRCROOT)/Thaw/MenuBar/ControlItem/ControlItemImageSet.swift
+$(SRCROOT)/Thaw/MenuBar/ControlItem/ControlItemOcclusion.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBar.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarColorManager.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLayout.swift
@@ -58,8 +60,8 @@ $(SRCROOT)/Thaw/MenuBar/MenuBarItems/AXItemActivator.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/ClickReactionVerifier.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/LayoutReconciler.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
-$(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItem+Ordering.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemFailureLedger.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift


### PR DESCRIPTION
# Summary

Replace the flat 60s SourcePID negative-cache TTL from #820 with a per-window backoff ladder (5s → 15s → 60s) so a low-yield cold scan after launch does not permanently bar unresolved windows for the rest of the session.

**Scope:** Focused fix in `SourcePIDCache` plus a pure policy helper in `Shared/` and unit tests. No product UI changes.

> We are on the process of migrating from XCTest to Swift Test. If you are adding new tests, please use Swift Test.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: N/A

Related to #820

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

### Problem

#820 arms a flat 60s deadline for every window a full scan leaves unresolved. Two things let that deadline outlast the window in which a retry could still help:

- the first cold scan after launch under-resolves, because other apps' accessibility trees are still warming up;
- the app front-loads its resolution requests into its startup settling window.

One low-yield cold scan therefore bars every unresolved window past the last request the app will ever make for it, and resolution never converges for the rest of the session. `applySavedLayout` and `saveSectionOrder` skip permanently, and item moves fail with "macOS prohibits ... from being moved".

Measured on the Build DMG from run 30507663412 (`1daa5d60`, Developer ID, notarized), external non-notched main with a notched built-in secondary:

```
1 scan, 3 matches, then 101 consecutive `batch response (4 resolved)` over 3+ minutes
```

Not a signing artifact — this is a notarized build. An earlier hedge that ad-hoc identity might explain it does not hold.

### Fix

Replace the flat TTL with a per-window ladder driven by a consecutive-failure count: 5s, 15s, then the existing 60s steady state. The settling window gets three scan opportunities while a better result is still likely; a chronically unresolvable window still backs off to exactly the protection #820 added.

Failure counts reset when a window resolves and are pruned alongside `negativeUntil`, so both dictionaries stay bounded. The negative entry keeps gating scan *initiation* only — a scan started for another window still retries everything unresolved, so the late-arriving-marker behaviour #820 documents is unchanged.

The ladder is a pure function in `Shared/` so it can be pinned from `ThawTests` without instantiating the service.

Review follow-up: clear negative state when a window resolves (a scan driven by any one window can resolve others; prune unconditionally and filter the carry on windows still lacking a PID).

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- Full ThawTests suite + archive (author-verified green)
- Ad-hoc branch build on same machine/topology: `scan 1: 3 matches → 5s retry → scan 2: 27 matches → settles 24/24`

## Known limitations / follow-ups

- Independent of the divider-collapse work on #795; does not touch it. Collapse still reproduces on `1daa5d60` (`hiddenSectionHasRoom` correctly refuses the save); geometry itself remains unfixed and is tracked on #795.

## Other information

- Files: `MenuBarItemService/SourcePIDCache.swift`, `Shared/Utilities/SourcePIDNegativeCachePolicy.swift` (new), `ThawTests/SourcePIDNegativeCachePolicyTests.swift` (new)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of temporarily unresolved menu bar items with progressively adjusted retry intervals.
  * Resolved items are removed from temporary negative caching promptly, improving recovery after transient failures.

* **Tests**
  * Added coverage for retry timing, progression, boundary values, and settling-window behavior.

* **Chores**
  * Updated linting inputs to include newly covered source files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->