### PR TITLE
fix(icebar): anchor rehide to a neighbor in the item's own section

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -117,6 +117,15 @@ nonisolated enum LayoutSolver {
         )
     }
 
+    /// The nearest eligible neighbors on either side of an item, as
+    /// indices into the item list the search ran over.
+    struct ReturnAnchors: Equatable {
+        /// The neighbor to the right, preferred as the anchor.
+        let successor: Int?
+        /// The neighbor to the left, used when there is no successor.
+        let predecessor: Int?
+    }
+
     /// A position within the saved section order: a section and the
     /// zero-based index of the item within that section's saved array.
     struct SavedPosition: Equatable {
@@ -1004,6 +1013,35 @@ nonisolated enum LayoutSolver {
         }
         // No anchors → section boundary.
         return .sectionBoundary(section)
+    }
+
+    /// Finds the nearest eligible neighbors on either side of the item at
+    /// `index`.
+    ///
+    /// Used to anchor a temporarily shown item when it is returned to its
+    /// section. Callers decide eligibility; only neighbors that share the
+    /// item's section qualify, because anchoring against an item from
+    /// another section returns the item into *that* section instead.
+    ///
+    /// Forward-first for the same reason as
+    /// ``anchorDestination(forSavedIndex:inSection:savedSequence:currentUIDsInSection:)``:
+    /// the successor's position is the more reliable signal of where the
+    /// item belongs.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func returnAnchors(
+        forIndex index: Int,
+        itemCount: Int,
+        eligibleIndices: Set<Int>
+    ) -> ReturnAnchors {
+        guard index >= 0, index < itemCount else {
+            return ReturnAnchors(successor: nil, predecessor: nil)
+        }
+        let successor = ((index + 1) ..< itemCount).first { eligibleIndices.contains($0) }
+        let predecessor = index > 0
+            ? stride(from: index - 1, through: 0, by: -1).first { eligibleIndices.contains($0) }
+            : nil
+        return ReturnAnchors(successor: successor, predecessor: predecessor)
     }
 
     // MARK: - Saved-section rebuild

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -5145,30 +5145,75 @@ extension MenuBarItemManager {
     /// Gets the destination to return the given item to after it is
     /// temporarily shown, along with the tag and PID of the neighbor on the
     /// opposite side (if any) for fallback ordering.
+    ///
+    /// Only neighbors that share `section` are considered. An item from
+    /// another section is not a usable anchor: moving next to it returns the
+    /// item into *that* section, and once macOS persists the position the
+    /// item stays there across relaunches. Items that can never be hidden are
+    /// the common case — Control Center modules such as `AudioVideoModule`
+    /// come and go as the mic or camera is used, and since the item list is
+    /// in Window Server order rather than left-to-right order, a freshly
+    /// created window can land next to one from anywhere in the bar.
     private func getReturnDestination(
         for item: MenuBarItem,
-        in items: [MenuBarItem]
+        in items: [MenuBarItem],
+        section: MenuBarSection.Name
     ) -> (destination: MoveDestination, fallbackNeighbor: (tag: MenuBarItemTag, pid: pid_t)?)? {
         guard let index = items.firstIndex(matching: item.tag) else {
             return nil
         }
-        // Prefer anchoring to the item on the right (lower index = further
-        // right in macOS menu bar coordinates). The fallback is the item on
-        // the opposite side.
-        if items.indices.contains(index + 1) {
-            let neighbor = items[index + 1]
-            let fallback: (MenuBarItemTag, pid_t)? = if items.indices.contains(index - 1) {
-                (items[index - 1].tag, items[index - 1].sourcePID ?? items[index - 1].ownerPID)
-            } else {
-                nil
+
+        let eligibleIndices = Set(items.indices.filter { candidateIndex in
+            let candidate = items[candidateIndex]
+            guard candidate.canBeHidden else {
+                return false
             }
-            return (.leftOfItem(neighbor), fallback)
+            return itemCache.address(for: candidate.tag)?.section == section
+        })
+
+        let anchors = LayoutSolver.returnAnchors(
+            forIndex: index,
+            itemCount: items.count,
+            eligibleIndices: eligibleIndices
+        )
+
+        // Prefer anchoring to the neighbor on the right. The fallback is the
+        // nearest eligible neighbor on the opposite side.
+        if let successor = anchors.successor {
+            let fallback: (MenuBarItemTag, pid_t)? = anchors.predecessor.map { predecessor in
+                let neighbor = items[predecessor]
+                return (neighbor.tag, neighbor.sourcePID ?? neighbor.ownerPID)
+            }
+            return (.leftOfItem(items[successor]), fallback)
         }
-        if items.indices.contains(index - 1) {
-            let neighbor = items[index - 1]
-            return (.rightOfItem(neighbor), nil)
+        if let predecessor = anchors.predecessor {
+            return (.rightOfItem(items[predecessor]), nil)
         }
-        return nil
+
+        // The section holds no other item to anchor against, so aim at the
+        // section itself. Ordering within the section is not preserved, but
+        // the item lands in the correct section.
+        return sectionDestination(for: section, in: items).map { ($0, nil) }
+    }
+
+    /// Gets the destination that returns an item to the given section's
+    /// boundary, used when no neighbor is available to preserve ordering.
+    private func sectionDestination(
+        for section: MenuBarSection.Name,
+        in items: [MenuBarItem]
+    ) -> MoveDestination? {
+        switch section {
+        case .hidden:
+            items.first(matching: .hiddenControlItem).map { .leftOfItem($0) }
+        case .alwaysHidden:
+            // If the always-hidden section was disabled, fall back to hidden.
+            (items.first(matching: .alwaysHiddenControlItem) ?? items.first(matching: .hiddenControlItem))
+                .map { .leftOfItem($0) }
+        case .visible:
+            // Should not happen (we don't temporarily show items that are
+            // already visible), but handle it gracefully.
+            nil
+        }
     }
 
     /// Waits for a menu bar item's position to stabilize after a move.
@@ -5344,7 +5389,7 @@ extension MenuBarItemManager {
         // Fetch items specifically for the display where the item lives.
         let items = await MenuBarItem.getMenuBarItems(on: resolvedDisplayID, option: .activeSpace)
 
-        guard let returnInfo = getReturnDestination(for: item, in: items) else {
+        guard let returnInfo = getReturnDestination(for: item, in: items, section: originalSection) else {
             MenuBarItemManager.diagLog.error("No return destination for \(item.logString) on display \(resolvedDisplayID)")
             return .showFailed
         }
@@ -5620,27 +5665,16 @@ extension MenuBarItemManager {
             falling back to section-level destination for \(context.originalSection.logString)
             """
         )
-        switch context.originalSection {
-        case .hidden:
-            if let controlItem = items.first(matching: .hiddenControlItem) {
-                return .leftOfItem(controlItem)
-            }
-        case .alwaysHidden:
-            if let controlItem = items.first(matching: .alwaysHiddenControlItem) {
-                return .leftOfItem(controlItem)
-            }
-            // If the always-hidden section was disabled, fall back to hidden.
-            if let controlItem = items.first(matching: .hiddenControlItem) {
-                return .leftOfItem(controlItem)
-            }
-        case .visible:
-            // Should not happen (we don't temporarily show items that are
-            // already visible), but handle it gracefully.
+        guard let destination = sectionDestination(for: context.originalSection, in: items) else {
+            MenuBarItemManager.diagLog.error(
+                """
+                No section destination to resolve return destination for \
+                \(context.tag) in \(context.originalSection.logString)
+                """
+            )
             return nil
         }
-
-        MenuBarItemManager.diagLog.error("No control items found to resolve return destination for \(context.tag)")
-        return nil
+        return destination
     }
 
     /// Rehides all temporarily shown items.

--- a/ThawTests/ReturnAnchorsTests.swift
+++ b/ThawTests/ReturnAnchorsTests.swift
@@ -1,0 +1,135 @@
+//
+//  ReturnAnchorsTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Covers `LayoutSolver.returnAnchors`, which picks the neighbors a
+/// temporarily shown item is anchored against when it is returned to its
+/// section.
+///
+/// The eligibility set is the whole point. The item list arrives in Window
+/// Server order rather than left-to-right order, so a freshly created window
+/// can sit next to an item from anywhere in the bar — including one that can
+/// never be hidden. Anchoring to such a neighbor returns the item into that
+/// neighbor's section and strands it there, which is the #859 failure. The
+/// scan therefore has to walk past ineligible neighbors rather than trust
+/// adjacency, while still preferring the nearest eligible one so ordering
+/// within the section survives.
+@Suite("Return anchor selection")
+struct ReturnAnchorsTests {
+    // MARK: - Neighbor preference
+
+    @Test("Both sides eligible yields the immediate neighbors")
+    func immediateNeighborsOnBothSides() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 2,
+            itemCount: 5,
+            eligibleIndices: [0, 1, 3, 4]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: 3, predecessor: 1))
+    }
+
+    @Test("The first position has no predecessor")
+    func firstIndexHasNoPredecessor() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 0,
+            itemCount: 3,
+            eligibleIndices: [0, 1, 2]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: 1, predecessor: nil))
+    }
+
+    @Test("The last position has no successor")
+    func lastIndexHasNoSuccessor() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 2,
+            itemCount: 3,
+            eligibleIndices: [0, 1, 2]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: 1))
+    }
+
+    // MARK: - Ineligible neighbors (#859)
+
+    @Test("An ineligible successor is skipped, not used as the anchor")
+    func skipsIneligibleSuccessor() {
+        // The #859 state: the adjacent item is a Control Center module that
+        // can never be hidden, so the scan has to continue outward instead
+        // of returning the item into the visible section.
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 0,
+            itemCount: 4,
+            eligibleIndices: [2, 3]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: 2, predecessor: nil))
+    }
+
+    @Test("An ineligible predecessor is skipped the same way")
+    func skipsIneligiblePredecessor() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 3,
+            itemCount: 4,
+            eligibleIndices: [0]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: 0))
+    }
+
+    @Test("No eligible neighbor on either side yields no anchors")
+    func noEligibleNeighbors() {
+        // Sends the caller to the section boundary instead.
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 1,
+            itemCount: 3,
+            eligibleIndices: []
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: nil))
+    }
+
+    @Test("The item is never its own anchor")
+    func itemIsNotItsOwnAnchor() {
+        // The moving item is in its section, so it is in the eligible set.
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 1,
+            itemCount: 3,
+            eligibleIndices: [1]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: nil))
+    }
+
+    // MARK: - Bounds
+
+    @Test("An out-of-bounds index yields no anchors instead of trapping")
+    func outOfBoundsIndexYieldsNoAnchors() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 7,
+            itemCount: 3,
+            eligibleIndices: [0, 1, 2]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: nil))
+    }
+
+    @Test("A single-item list has no neighbors at all")
+    func singleItemList() {
+        let result = LayoutSolver.returnAnchors(
+            forIndex: 0,
+            itemCount: 1,
+            eligibleIndices: [0]
+        )
+
+        #expect(result == LayoutSolver.ReturnAnchors(successor: nil, predecessor: nil))
+    }
+}


### PR DESCRIPTION
# Summary

Restricts the anchor used to return a temporarily shown menu bar item to neighbours in the same section, so an item is no longer rehidden into the visible section.

Closes: #859

## PR Type

- [x] Bugfix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [x] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

`getReturnDestination` previously took `items[index ± 1]` as the anchor without checking which section that neighbour was in. Since `getMenuBarItemWindows` builds the list from `rawWindowIDs.reversed()`, list adjacency does not imply geometric adjacency — a status item whose window was just recreated can be listed next to an item from anywhere in the bar. When that neighbour is a Control Center module such as `AudioVideoModule` (already in `MenuBarItemTag.nonHideableItems`, so it can never leave the visible section), the rehide moves the item into the visible section, and macOS then persists the position in the owning app's `NSStatusItem` preferences — so it stays visible across relaunches.

The three-tier fallback from eb129b9f does not cover this: the neighbour *is* found, so `resolveReturnDestination` never falls through to the section-level tier. The wrong anchor is chosen earlier, at show time.

Changes:

- `getReturnDestination(for:in:section:)` now filters anchor candidates to items that are `canBeHidden` **and** that `itemCache` places in the same section, scanning outward to the nearest eligible neighbour on either side rather than giving up at `index ± 1`. Scanning outward preserves ordering within the section when the immediate neighbour is ineligible.
- When the section holds no other item, it falls back to the section's control item via a new `sectionDestination(for:in:)` helper. That helper also replaces the duplicated tier-3 block in `resolveReturnDestination`, so both paths resolve section boundaries the same way.
- `LayoutSolver.returnAnchors(forIndex:itemCount:eligibleIndices:)` holds the scan as a pure function, mirroring the existing `anchorDestination` (forward-first, backward fallback) so it sits in the same testable seam.

This is symmetric with `temporarilyShow`, which already filters its *show* anchor with `!$0.isControlItem && $0.canBeHidden`; the return path simply wasn't applying the same rule.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected. — **intentionally unticked, see Known limitations**
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below).
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed. (No user-facing docs affected.)
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS'` → **TEST SUCCEEDED**; Swift Testing 415 tests in 41 suites passed, XCTest 948 tests / 0 failures, including the 9 in the `Return anchor selection` suite.
- `swiftlint lint --strict` → 0 violations.

## Known limitations / follow-ups

- **Not verified against a live reproduction.** The build and full test suite pass, but I have not reproduced the original failure and confirmed the fix against it at runtime: that needs a transient Control Center module present at the moment a just-recreated status item window is temporarily shown, which I have not been able to stage deterministically. The diagnosis comes from a diagnostic log capturing the whole failure (attached to #859), not from a live repro of the fix. Flagging rather than ticking the box, since this is a sensitive area.
- **Secondary finding, out of scope here.** The same log shows two hot loops around the failed rehide: 1,762 `createWindows: 1 IDs -> 0 descriptions` within one second, and 12,462 `Running rehide timer for interval` / `rehideTemporarilyShownItems` pairs across 24 seconds (~500 rehide passes/sec while the item is stuck). Together ~39,300 of 39,644 log lines in that window. Documented in #859; happy to split into its own issue if you'd prefer.
- **`swiftformat` version drift.** Run with SwiftFormat 0.62.1, which applies `wrapIfStatementBodies` and expands `if x { return }` across many files the repo currently keeps inline — apparently a difference from whatever produced the committed formatting. I reverted all of that unrelated churn and kept the diff to this change only; `swiftformat --lint` reports nothing inside the modified regions. Happy to reformat to whatever version you standardise on.

## Other information

**Alternative considered.** Instead of scanning outward past ineligible neighbours, the simpler option is to bail straight to the section control item as soon as the immediate neighbour is ineligible. That is less code but loses the item's position within its section. I went with the outward scan since preserving relative order is the whole purpose of the neighbour mechanism, but I'm happy to switch if you'd prefer the simpler behaviour.

**Tests.** `ThawTests/ReturnAnchorsTests.swift` adds 9 characterization tests for the anchor scan, written with Swift Testing (`@Suite` / `@Test` / `#expect`) per @diazdesandi's review. "An ineligible successor is skipped, not used as the anchor" is the regression case for #859.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved temporary-show behavior so items return to the nearest eligible neighboring item within their original section.
  - Skips unavailable or non-hideable items when determining the return destination.
  - Added reliable fallback behavior for section boundaries and cases where no eligible neighbor exists.
  - Improved handling for edge cases, including single-item sections and items at the beginning or end of a section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->