### PR TITLE
fix(settings): Update repository URL

### DIFF
--- a/Thaw/Resources/Info.plist
+++ b/Thaw/Resources/Info.plist
@@ -18,7 +18,7 @@
 		</dict>
 	</array>
 	<key>ThawRepositoryURL</key>
-	<string>https://github.com/stonerl/Thaw</string>
+	<string>https://github.com/thaw-app/Thaw</string>
 	<key>ThawDonateURL</key>
 	<string>https://github.com/sponsors/stonerl</string>
 	<key>ThawMenuBarItemSpacingExecutableURI</key>

--- a/docs/URI_SCHEMES.md
+++ b/docs/URI_SCHEMES.md
@@ -98,7 +98,7 @@ The following URLs are configured in `Thaw/Resources/Info.plist` for internal us
 
 | Key                                   | Value                                 | Description                          |
 | ------------------------------------- | ------------------------------------- | ------------------------------------ |
-| `ThawRepositoryURL`                   | `https://github.com/stonerl/Thaw`     | GitHub repository                    |
+| `ThawRepositoryURL`                   | `https://github.com/thaw-app/Thaw`    | GitHub repository                    |
 | `ThawDonateURL`                       | `https://github.com/sponsors/stonerl` | Sponsorship page                     |
 | `ThawMenuBarItemSpacingExecutableURI` | `file:///usr/bin/env`                 | Executable path for spacing commands |
 


### PR DESCRIPTION
# Summary

Update the repository URL in Info.plist

The old URL results in an extra hop when the Contribute button is clicked in About, and confusing behavior when Report Bug is clicked.

Closes: N/A

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

Makes the Contribute and Report Bug buttons in the About screen go to the new Github repo.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s repository link and related documentation to point to its new official location.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->