### PR TITLE
fix(menubar): stop provisional identities from scrambling saved layout

### DIFF
--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -268,8 +268,15 @@ nonisolated enum HostedItemOwnership {
         guard let title, !title.isEmpty else { return false }
         let titleParts = title.lowercased().split(separator: ".", omittingEmptySubsequences: false)
         let bundleParts = bundleID.lowercased().split(separator: ".", omittingEmptySubsequences: false)
-        // A bundle id has at least two components.
-        guard bundleParts.count >= 2 else { return false }
+        // A bundle id has at least two components. Empty components are
+        // rejected outright: split(omittingEmptySubsequences: false) keeps a
+        // trailing empty component, and "" is a prefix of every string, so a
+        // malformed vendor-only title (pl.maketheweb.) would otherwise clear
+        // the prefix test against any app from that vendor.
+        guard bundleParts.count >= 2,
+              titleParts.allSatisfy({ !$0.isEmpty }),
+              bundleParts.allSatisfy({ !$0.isEmpty })
+        else { return false }
 
         // A title with no reverse-DNS shape at all still identifies the app when
         // it *is* the app's name: BetterTouchTool's slot titles itself

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -106,7 +106,7 @@ nonisolated enum MarkerPairResolver {
 
         var result = [Resolution]()
         for icon in candidates {
-            guard candidatesPerWidth[icon.size.width] == 1 else { continue }
+        guard candidatesPerWidth[icon.size.width] == 1 else { continue }
 
         for icon in candidates {
             // Match by width only, not exact size. The on-screen icon
@@ -248,7 +248,21 @@ nonisolated enum HostedItemOwnership {
         // A reverse-DNS-shaped title has at least three components; a bundle
         // id at least two. Demanding three on the title keeps two-component
         // or generic titles out.
-        guard titleParts.count >= 3, bundleParts.count >= 2 else { return false }
+        guard bundleParts.count >= 2 else { return false }
+
+        // A title with no reverse-DNS shape at all still identifies the app when
+        // it *is* the app's name: BetterTouchTool's slot titles itself
+        // "BetterTouchTool" and belongs to com.hegenberg.BetterTouchTool. Only the
+        // final component qualifies — a vendor component (apple, maketheweb) names
+        // a publisher, not an app, and matching on it would hand every widget that
+        // vendor ships to whichever of its apps happened to be checked first.
+        if titleParts.count == 1, let appComponent = bundleParts.last  {
+            return titleParts[0] == appComponent
+        }
+
+        // Two component titles are neither shape: too short to be a reverse-DNS title and too long to be a bare app name.
+        guard titleParts.count >= 3 else { return false }
+
         let shared = zip(titleParts, bundleParts).prefix { $0 == $1 }.count
         // Require agreement on at least the vendor plus one component so a
         // bare vendor prefix (com.apple, pl.maketheweb) is never enough.

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -154,6 +154,7 @@ nonisolated enum MarkerPairResolver {
                 }
                 if let pid = bundleIDToPID(marker.title),
                    let bundleID = pidToBundleID(pid),
+                   bundleID != ccBundleID,
                    bundleID != thawBundleID
                 {
                     return pid

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -93,12 +93,22 @@ nonisolated enum MarkerPairResolver {
         pidToBundleID: (pid_t) -> String?,
         bundleIDToPID: (String) -> pid_t?
     ) -> [Resolution] {
-        var result = [Resolution]()
-        for icon in unresolvedIcons {
-            if let title = icon.title, title.contains(".") {
-                continue
-            }
+        let candidates = unresolvedIcons.filter { icon in
+            guard let title = icon.title else { return true }
+            return !title.contains(".")
+        }
 
+        var candidatesPerWidth: [CFGFloat: Int]()
+
+        for icon in candidates {
+            candidatesPerWidth[icon.size.width, default: 0] += 1
+        }
+
+        var result = [Resolution]()
+        for icon in candidates {
+            guard candidatesPerWidth[icon.size.width] == 1 else { continue }
+
+        for icon in candidates {
             // Match by width only, not exact size. The on-screen icon
             // and its off-screen marker share width (the widget's
             // intrinsic icon width), but heights differ: the icon

--- a/Shared/Utilities/MarkerPairResolver.swift
+++ b/Shared/Utilities/MarkerPairResolver.swift
@@ -61,11 +61,23 @@ nonisolated enum MarkerPairResolver {
     }
 
     /// Pairs unresolved icons with same-size marker windows and
-    /// resolves each icon to a sourcePID via the marker. Multi-match
-    /// cases (two unresolved icons sharing a size with two markers)
-    /// are skipped to prevent misattribution. Thaw and Control Center
-    /// are excluded from the resolution paths so a marker hosted by
-    /// either does not collapse the resolution back to those PIDs.
+    /// resolves each icon to a sourcePID via the marker. The pairing
+    /// must be unique in *both* directions: a width matching more than
+    /// one marker is ambiguous, and so is a width shared by more than
+    /// one unresolved icon. Thaw and Control Center are excluded from
+    /// the resolution paths so a marker hosted by either does not
+    /// collapse the resolution back to those PIDs.
+    ///
+    /// Both halves of that rule are load-bearing. Checking only the
+    /// marker side lets a single marker be claimed by every unresolved
+    /// icon that happens to share its width: a field log (2.0.0-rc.2,
+    /// a bar with 24 items) shows one marker resolving five distinct
+    /// icons to the same PID, which stamped Control Center's own Sound
+    /// and Wi-Fi modules with a third-party bundle identifier. A wrong
+    /// PID is worse than none — it renames the item, so its saved
+    /// position stops matching, and it slips past the unresolved-
+    /// sourcePID gates that keep a degraded snapshot from being acted
+    /// on or persisted.
     ///
     /// - Parameters:
     ///   - unresolvedIcons: candidate on-screen icons. Icons whose own
@@ -93,22 +105,28 @@ nonisolated enum MarkerPairResolver {
         pidToBundleID: (pid_t) -> String?,
         bundleIDToPID: (String) -> pid_t?
     ) -> [Resolution] {
+        // Icons whose own title is bundle-ID-shaped are markers, not
+        // candidates; dropping them up front keeps them out of the
+        // per-width candidate census below as well as out of the
+        // pairing loop.
         let candidates = unresolvedIcons.filter { icon in
             guard let title = icon.title else { return true }
             return !title.contains(".")
         }
 
-        var candidatesPerWidth: [CFGFloat: Int]()
-
+        // How many candidate icons share each width. A marker may be
+        // claimed by exactly one of them; when several compete for the
+        // same width there is no evidence saying which one owns it, so
+        // none resolve.
+        var candidatesPerWidth = [CGFloat: Int]()
         for icon in candidates {
             candidatesPerWidth[icon.size.width, default: 0] += 1
         }
 
         var result = [Resolution]()
         for icon in candidates {
-        guard candidatesPerWidth[icon.size.width] == 1 else { continue }
+            guard candidatesPerWidth[icon.size.width] == 1 else { continue }
 
-        for icon in candidates {
             // Match by width only, not exact size. The on-screen icon
             // and its off-screen marker share width (the widget's
             // intrinsic icon width), but heights differ: the icon
@@ -117,9 +135,10 @@ nonisolated enum MarkerPairResolver {
             // the marker carries a default placeholder height
             // (33pt observed in field logs). Exact size matching
             // rejected legitimate pairs whose widths agreed but whose
-            // heights drifted by 3pt. The uniqueness check on
-            // matching.count == 1 still prevents misattribution when
-            // multiple markers happen to share a width.
+            // heights drifted by 3pt. The two uniqueness checks — one
+            // candidate icon per width above, one marker per width
+            // here — still prevent misattribution when several windows
+            // happen to share a width.
             let matching = markers.filter {
                 $0.windowID != icon.windowID && $0.size.width == icon.size.width
             }
@@ -239,15 +258,17 @@ nonisolated enum HostedItemOwnership {
     /// rejecting same-vendor different-app pairs such as
     /// pl.maketheweb.pixelsnap2 vs pl.maketheweb.cleanshotx and unrelated
     /// neighbors such as com.wireguard.macos vs app.updatest.Updatest.
-    /// Comparison is case-insensitive. Generic titles without a reverse-DNS
-    /// shape (Item-0, empty) never qualify.
+    /// Comparison is case-insensitive.
+    ///
+    /// A title with no reverse-DNS shape at all qualifies only when it is
+    /// exactly the bundle's final component — BetterTouchTool's slot titles
+    /// itself "BetterTouchTool" and belongs to com.hegenberg.BetterTouchTool.
+    /// Vendor components and generic titles (Item-0, empty) never qualify.
     static func titleIndicatesOwner(_ title: String?, bundleID: String) -> Bool {
         guard let title, !title.isEmpty else { return false }
         let titleParts = title.lowercased().split(separator: ".", omittingEmptySubsequences: false)
         let bundleParts = bundleID.lowercased().split(separator: ".", omittingEmptySubsequences: false)
-        // A reverse-DNS-shaped title has at least three components; a bundle
-        // id at least two. Demanding three on the title keeps two-component
-        // or generic titles out.
+        // A bundle id has at least two components.
         guard bundleParts.count >= 2 else { return false }
 
         // A title with no reverse-DNS shape at all still identifies the app when
@@ -256,11 +277,13 @@ nonisolated enum HostedItemOwnership {
         // final component qualifies — a vendor component (apple, maketheweb) names
         // a publisher, not an app, and matching on it would hand every widget that
         // vendor ships to whichever of its apps happened to be checked first.
-        if titleParts.count == 1, let appComponent = bundleParts.last  {
+        if titleParts.count == 1, let appComponent = bundleParts.last {
             return titleParts[0] == appComponent
         }
 
-        // Two component titles are neither shape: too short to be a reverse-DNS title and too long to be a bare app name.
+        // Two-component titles are neither shape: too short to carry a
+        // distinctive component pair, too long to be a bare app name.
+        // A reverse-DNS-shaped title has at least three components.
         guard titleParts.count >= 3 else { return false }
 
         let shared = zip(titleParts, bundleParts).prefix { $0 == $1 }.count

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -230,15 +230,19 @@ nonisolated enum LayoutSolver {
         hiddenCtrlUID: String?,
         ahCtrlUID: String?,
         visibleCtrlUID: String?,
-        unresolvedGenericCCUIDs: Set<String>
+        provisionalIdentityUIDs: Set<String>
     ) -> [String] {
         currentFlat.filter { uid in
             !desiredUIDs.contains(uid)
                 && uid != hiddenCtrlUID
                 && uid != ahCtrlUID
                 && uid != visibleCtrlUID
-                && !unresolvedGenericCCUIDs.contains(uid)
+                && !provisionalIdentityUIDs.contains(uid)
         }
+    }
+
+    static nonisolated func provisionalIdentityUIDs(items: [MenuBarItem]) -> Set<String> {
+        Set(items.filter(\.hasProvisionalIdentity).map(\.uniqueIdentifier))
     }
 
     // MARK: - Leftmost relocation

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -53,6 +53,16 @@ nonisolated struct MenuBarItem: CustomStringConvertible {
         tag.isControlCenterGenericItem && sourcePID != nil
     }
 
+    /// A Boolean value that indicates whether this item's identifier is only
+    /// provisional: its source PID never resolved, so the namespace fell back
+    /// to the owner of the window — Control Center, which on macOS 26 owns the
+    /// window of every hosted status item. The same item is named after its
+    /// real app on the next cycle that resolves it, so nothing keyed by the
+    /// identifier (a saved position, a section assignment) can be trusted.
+    var hasProvisionalIdentity: Bool {
+        sourcePID == nil && tag.namespace == .controlCenter
+    }
+
     /// A Boolean value that indicates whether this item is one of Ice's
     /// control items.
     var isControlItem: Bool {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -797,7 +797,7 @@ final class MenuBarItemManager {
                 // ambiguous CC identifiers by an XPC resolution failure
                 // (#784) — neither is a stable identity worth persisting.
                 guard !item.isTransientControlCenterItem,
-                      !(item.tag.isControlCenterGenericItem && item.sourcePID == nil)
+                      !item.hasProvisionalIdentity
                 else { continue }
                 allCurrentIdentifiers.insert(item.uniqueIdentifier)
             }
@@ -810,7 +810,7 @@ final class MenuBarItemManager {
                 .filter {
                     isPersistable($0) &&
                         !$0.isTransientControlCenterItem &&
-                        !($0.tag.isControlCenterGenericItem && $0.sourcePID == nil) &&
+                        !$0.hasProvisionalIdentity &&
                         !pendingRehideTagIDs.contains($0.tag.tagIdentifier) &&
                         !ejectedStillInHidden.contains($0.uniqueIdentifier)
                 }
@@ -7354,18 +7354,14 @@ extension MenuBarItemManager {
         // marker window appears). They fall back to the com.apple.controlcenter
         // namespace, never match a profile entry, and so would be relocated as
         // unmanaged arrivals on every cycle. Exclude them until they resolve.
-        let unresolvedGenericCCUIDs = Set(
-            items
-                .filter { $0.tag.isControlCenterGenericItem && $0.sourcePID == nil }
-                .map(\.uniqueIdentifier)
-        )
+        let provisionalIdentityUIDs = LayoutSolver.provisionalIdentityUIDs(items: items)
         let unmanagedUIDs = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: currentFlat,
             desiredUIDs: desiredSet,
             hiddenCtrlUID: hiddenCtrlUID,
             ahCtrlUID: ahCtrlUID,
             visibleCtrlUID: visibleCtrlUID,
-            unresolvedGenericCCUIDs: unresolvedGenericCCUIDs
+            provisionalIdentityUIDs: provisionalIdentityUIDs
         )
         if !unmanagedUIDs.isEmpty {
             // Build a DesiredLayout for the profile-apply context: the

--- a/ThawTests/MenuBar/Items/PartitionUnmanagedUIDsTests.swift
+++ b/ThawTests/MenuBar/Items/PartitionUnmanagedUIDsTests.swift
@@ -46,7 +46,7 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: hidden,
             ahCtrlUID: ah,
             visibleCtrlUID: visible,
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result == [app])
@@ -69,7 +69,7 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: hidden,
             ahCtrlUID: nil,
             visibleCtrlUID: visible,
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result == [unsaved])
@@ -90,19 +90,19 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: nil,
             ahCtrlUID: nil,
             visibleCtrlUID: nil,
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result == [unsaved])
     }
 
-    /// Items passed in unresolvedGenericCCUIDs are excluded even though they
+    /// Items passed in provisionalIdentityUIDs are excluded even though they
     /// are absent from desiredUIDs and are not control items. This is the
     /// Little Snitch orphan case: a Control-Center-hosted widget with no
     /// resolved source PID must not be treated as an unmanaged arrival and
     /// relocated.
-    @Test("Unresolved generic Control Center UIDs are excluded")
-    func unresolvedGenericCCUIDsAreExcluded() {
+    @Test("Provisional-identity UIDs are excluded")
+    func provisionalIdentityUIDsAreExcluded() {
         let orphan = "com.apple.controlcenter:Item-0"
         let app = "com.example.app:Item-0"
 
@@ -112,7 +112,7 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: nil,
             ahCtrlUID: nil,
             visibleCtrlUID: nil,
-            unresolvedGenericCCUIDs: [orphan]
+            provisionalIdentityUIDs: [orphan]
         )
 
         #expect(result == [app])
@@ -134,7 +134,7 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: nil,
             ahCtrlUID: nil,
             visibleCtrlUID: nil,
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result == [c, a, b])
@@ -150,7 +150,7 @@ struct PartitionUnmanagedUIDsTests {
             hiddenCtrlUID: "h",
             ahCtrlUID: "ah",
             visibleCtrlUID: "v",
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result.isEmpty)

--- a/ThawTests/MenuBar/Items/ProvisionalIdentityTests.swift
+++ b/ThawTests/MenuBar/Items/ProvisionalIdentityTests.swift
@@ -1,0 +1,166 @@
+//
+//  ProvisionalIdentityTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+/// Tests for the provisional-identity predicate and the UID set derived from
+/// it, the pair that keeps an item whose source PID never resolved from being
+/// read as a new arrival and relocated.
+///
+/// An item is provisionally named when its source PID is unresolved: the
+/// namespace then falls back to the process that owns the window, which on
+/// macOS 26 is Control Center for every hosted status item. The same item is
+/// named after its real app on the next cycle that resolves it, so no
+/// identifier-keyed decision (saved position, section assignment) can be
+/// trusted for it.
+///
+/// The truth table is pinned in both directions because each half has been a
+/// field bug: treating a resolved Control Center module as provisional would
+/// strand Apple's own items, and treating an unresolved third-party item as
+/// settled is what dragged BetterTouchTool across sections daily.
+@Suite("Provisional identity")
+struct ProvisionalIdentityTests {
+    private func ccItem(
+        title: String,
+        windowID: CGWindowID,
+        sourcePID: pid_t?
+    ) -> MenuBarItem {
+        MenuBarItem.fixture(
+            tag: MenuBarItemTag(
+                namespace: .controlCenter,
+                title: title,
+                windowID: windowID
+            ),
+            windowID: windowID,
+            sourcePID: sourcePID
+        )
+    }
+
+    // MARK: - hasProvisionalIdentity
+
+    /// The generic Control Center slot with no resolved PID: the original
+    /// Little Snitch shape.
+    @Test("An unresolved generic Control Center slot is provisional")
+    func unresolvedGenericControlCenterSlotIsProvisional() {
+        #expect(ccItem(title: "Item-0", windowID: 1, sourcePID: nil).hasProvisionalIdentity)
+    }
+
+    /// The widening this predicate exists for: a hosted item that publishes a
+    /// name of its own is renamed by the same fallback, and was relocated for
+    /// it in the field (com.apple.controlcenter:BetterTouchTool while
+    /// unresolved, com.hegenberg.BetterTouchTool:BetterTouchTool once
+    /// attributed).
+    @Test("An unresolved named Control Center item is provisional")
+    func unresolvedNamedControlCenterItemIsProvisional() {
+        #expect(ccItem(title: "BetterTouchTool", windowID: 2, sourcePID: nil).hasProvisionalIdentity)
+    }
+
+    /// Control Center's own modules resolve to Control Center's PID through
+    /// the spatial pass, so their namespace is an identity rather than a
+    /// fallback and they must stay manageable.
+    @Test("A resolved Control Center module is not provisional")
+    func resolvedControlCenterModuleIsNotProvisional() {
+        #expect(!ccItem(title: "Bluetooth", windowID: 3, sourcePID: 1117).hasProvisionalIdentity)
+    }
+
+    /// An unresolved item owned by its own app keeps a stable namespace, so
+    /// the fallback never applies and it is not provisional.
+    @Test("An unresolved non-Control-Center item is not provisional")
+    func unresolvedNonControlCenterItemIsNotProvisional() {
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.app", title: "Item-0"),
+            windowID: 4,
+            sourcePID: nil
+        )
+        #expect(!item.hasProvisionalIdentity)
+    }
+
+    @Test("A fully resolved third-party item is not provisional")
+    func resolvedThirdPartyItemIsNotProvisional() {
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.app", title: "Item-0"),
+            windowID: 5,
+            sourcePID: 900
+        )
+        #expect(!item.hasProvisionalIdentity)
+    }
+
+    // MARK: - LayoutSolver.provisionalIdentityUIDs
+
+    /// Only the provisional items contribute, and they contribute the same
+    /// uniqueIdentifier the partitioner filters on.
+    @Test("Only provisional items reach the UID set")
+    func onlyProvisionalItemsReachTheUIDSet() {
+        let items = [
+            ccItem(title: "Item-0", windowID: 10, sourcePID: nil),
+            ccItem(title: "BetterTouchTool", windowID: 11, sourcePID: nil),
+            ccItem(title: "Bluetooth", windowID: 12, sourcePID: 1117),
+            MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.example.app", title: "Item-0"),
+                windowID: 13,
+                sourcePID: nil
+            ),
+        ]
+
+        #expect(
+            LayoutSolver.provisionalIdentityUIDs(items: items) == [
+                "com.apple.controlcenter:Item-0",
+                "com.apple.controlcenter:BetterTouchTool",
+            ]
+        )
+    }
+
+    /// The instance index is part of the identifier, so two same-titled
+    /// provisional slots stay distinguishable rather than collapsing to one
+    /// entry.
+    @Test("The instance index is carried into the UID set")
+    func instanceIndexIsCarriedIntoTheUIDSet() {
+        let items = [
+            ccItem(title: "Item-0", windowID: 20, sourcePID: nil),
+            MenuBarItem.fixture(
+                tag: MenuBarItemTag(
+                    namespace: .controlCenter,
+                    title: "Item-0",
+                    windowID: 21,
+                    instanceIndex: 1
+                ),
+                windowID: 21,
+                sourcePID: nil
+            ),
+        ]
+
+        #expect(
+            LayoutSolver.provisionalIdentityUIDs(items: items) == [
+                "com.apple.controlcenter:Item-0",
+                "com.apple.controlcenter:Item-0:1",
+            ]
+        )
+    }
+
+    @Test("No items yields an empty set")
+    func noItemsYieldsAnEmptySet() {
+        #expect(LayoutSolver.provisionalIdentityUIDs(items: []).isEmpty)
+    }
+
+    /// A bar where nothing failed attribution produces no exclusions, so a
+    /// healthy cycle is never quietly narrowed.
+    @Test("A fully resolved bar yields an empty set")
+    func fullyResolvedBarYieldsAnEmptySet() {
+        let items = [
+            ccItem(title: "Bluetooth", windowID: 30, sourcePID: 1117),
+            MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.example.app", title: "Item-0"),
+                windowID: 31,
+                sourcePID: 900
+            ),
+        ]
+        #expect(LayoutSolver.provisionalIdentityUIDs(items: items).isEmpty)
+    }
+}

--- a/ThawTests/Settings/Models/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/Settings/Models/ProfileLayoutLogReplayTests.swift
@@ -28,8 +28,8 @@ import Testing
 /// is treated as an unmanaged new arrival and relocated every cycle until
 /// marker-pair resolution finally identifies it ~46 minutes in.
 ///
-/// The Layer-1 fix excludes unresolved generic Control Center orphans from the
-/// unmanaged set inside the live partitioner. Two tests pin it down:
+/// The Layer-1 fix excludes provisional-identity orphans from the unmanaged
+/// set inside the live partitioner. Two tests pin it down:
 /// testWithoutExclusionTheOrphanWouldBeUnmanaged documents the bug mechanism
 /// (with no exclusion the orphan is classified unmanaged, matching the field
 /// log), and testBuggyCycleDoesNotPlanMoveForUnresolvedOrphan is the regression
@@ -116,7 +116,7 @@ struct ProfileLayoutLogReplayTests {
 
     // MARK: Bug mechanism (documents what the exclusion is responsible for)
 
-    /// With no orphan exclusion (unresolvedGenericCCUIDs empty), replaying the
+    /// With no orphan exclusion (provisionalIdentityUIDs empty), replaying the
     /// buggy cycle through the real partitioner reproduces the field verdict
     /// exactly: the unresolved Little Snitch orphan is the sole item routed to
     /// planUnmanagedPlacement, which is what dragged it on every cycle. The
@@ -129,7 +129,7 @@ struct ProfileLayoutLogReplayTests {
         let buggy = try #require(parsed.cycles.first)
         let inputs = buggy.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
 
-        #expect(inputs.unresolvedGenericCCOrphans == [orphanUID])
+        #expect(inputs.provisionalIdentityOrphans == [orphanUID])
 
         let result = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: inputs.currentFlat,
@@ -137,7 +137,7 @@ struct ProfileLayoutLogReplayTests {
             hiddenCtrlUID: inputs.hiddenCtrlUID,
             ahCtrlUID: inputs.ahCtrlUID,
             visibleCtrlUID: inputs.visibleCtrlUID,
-            unresolvedGenericCCUIDs: []
+            provisionalIdentityUIDs: []
         )
 
         #expect(result == buggy.loggedUnmanagedUIDs)
@@ -150,7 +150,7 @@ struct ProfileLayoutLogReplayTests {
     /// orphan set the orchestrator now computes, the unresolved Little Snitch
     /// orphan is no longer classified unmanaged, so no unmanaged placement (and
     /// therefore no move) is planned for it. This fails before Layer 1 applies
-    /// unresolvedGenericCCUIDs and passes once it does.
+    /// provisionalIdentityUIDs and passes once it does.
     @Test("The buggy cycle plans no move for the unresolved orphan")
     func buggyCycleDoesNotPlanMoveForUnresolvedOrphan() throws {
         let parsed = ProfileLayoutLogReplay.parse(LittleSnitchOrphanLog.text)
@@ -159,7 +159,7 @@ struct ProfileLayoutLogReplayTests {
 
         // The field log confirms this orphan WAS classified unmanaged and moved.
         #expect(buggy.loggedUnmanagedUIDs.contains(orphanUID))
-        #expect(inputs.unresolvedGenericCCOrphans == [orphanUID])
+        #expect(inputs.provisionalIdentityOrphans == [orphanUID])
 
         let result = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: inputs.currentFlat,
@@ -167,7 +167,7 @@ struct ProfileLayoutLogReplayTests {
             hiddenCtrlUID: inputs.hiddenCtrlUID,
             ahCtrlUID: inputs.ahCtrlUID,
             visibleCtrlUID: inputs.visibleCtrlUID,
-            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+            provisionalIdentityUIDs: inputs.provisionalIdentityOrphans
         )
 
         #expect(
@@ -189,7 +189,7 @@ struct ProfileLayoutLogReplayTests {
         let clean = try #require(parsed.cycles.last)
         let inputs = clean.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
 
-        #expect(inputs.unresolvedGenericCCOrphans.isEmpty)
+        #expect(inputs.provisionalIdentityOrphans.isEmpty)
 
         let result = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: inputs.currentFlat,
@@ -197,7 +197,7 @@ struct ProfileLayoutLogReplayTests {
             hiddenCtrlUID: inputs.hiddenCtrlUID,
             ahCtrlUID: inputs.ahCtrlUID,
             visibleCtrlUID: inputs.visibleCtrlUID,
-            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+            provisionalIdentityUIDs: inputs.provisionalIdentityOrphans
         )
 
         #expect(result == clean.loggedUnmanagedUIDs)
@@ -252,7 +252,7 @@ struct ProfileLayoutLogReplayTests {
         #expect(cycle.desiredVisible == ["com.rogueamoeba.soundsource:SSMainAppMenuIcon"])
 
         let inputs = cycle.partitionInputs(unresolvedSourcePIDBaseUIDs: parsed.unresolvedSourcePIDBaseUIDs)
-        #expect(inputs.unresolvedGenericCCOrphans.isEmpty)
+        #expect(inputs.provisionalIdentityOrphans.isEmpty)
 
         let result = LayoutSolver.partitionUnmanagedUIDs(
             currentFlat: inputs.currentFlat,
@@ -260,7 +260,7 @@ struct ProfileLayoutLogReplayTests {
             hiddenCtrlUID: inputs.hiddenCtrlUID,
             ahCtrlUID: inputs.ahCtrlUID,
             visibleCtrlUID: inputs.visibleCtrlUID,
-            unresolvedGenericCCUIDs: inputs.unresolvedGenericCCOrphans
+            provisionalIdentityUIDs: inputs.provisionalIdentityOrphans
         )
 
         #expect(result == ["com.example.extra:Item-0"])
@@ -447,9 +447,10 @@ enum ProfileLayoutLogReplay {
         let hiddenCtrlUID: String?
         let ahCtrlUID: String?
         let visibleCtrlUID: String?
-        /// Unresolved generic Control Center items present this cycle (nil
-        /// sourcePID, Item-N title). These are what the proposed fix excludes.
-        let unresolvedGenericCCOrphans: Set<String>
+        /// Items present this cycle whose identifier is only provisional
+        /// (nil sourcePID, Control Center namespace). These are what the fix
+        /// excludes.
+        let provisionalIdentityOrphans: Set<String>
     }
 
     private static let visibleCtrlUID = "com.stonerl.Thaw:Thaw.ControlItem.Visible"
@@ -606,10 +607,9 @@ extension ProfileLayoutLogReplay.Cycle {
     /// it), that captured set is used verbatim, so nothing about the desired
     /// layout is inferred. For older captures that predate the line, the
     /// visible desired set is reconstructed as the current visible items that
-    /// are neither control items nor unresolved generic Control Center
-    /// orphans, which is sound for those fixtures because the field log
-    /// confirmed the orphan was the only visible item the profile did not
-    /// cover.
+    /// are neither control items nor provisional-identity orphans, which is
+    /// sound for those fixtures because the field log confirmed the orphan was
+    /// the only visible item the profile did not cover.
     func partitionInputs(unresolvedSourcePIDBaseUIDs: Set<String>) -> ProfileLayoutLogReplay.PartitionInputs {
         // Control identifiers come from the live control-item tags, not
         // hardcoded strings, so a change to control-item identity is caught.
@@ -619,7 +619,7 @@ extension ProfileLayoutLogReplay.Cycle {
 
         // Live items for the current bar, per section; everything below is
         // derived from them through live Thaw code (uniqueIdentifier,
-        // isControlCenterGenericItem) rather than from string heuristics.
+        // hasProvisionalIdentity) rather than from string heuristics.
         let visibleItems = ProfileLayoutLogReplay.makeCurrentItems(
             sectionOrderedUIDs: currentVisible,
             unresolvedSourcePIDBaseUIDs: unresolvedSourcePIDBaseUIDs,
@@ -646,12 +646,13 @@ extension ProfileLayoutLogReplay.Cycle {
             ahCtrlUID: ahCtrl
         )
 
-        // The exact condition the Layer-1 fix will exclude: a generic Control
-        // Center item (Item-N title) with no resolved source PID. Computed with
-        // the live predicate so the harness tracks the production predicate.
+        // The exact condition the Layer-1 fix excludes: an item left with a
+        // provisional identifier because its source PID never resolved.
+        // Computed with the live predicate so the harness tracks the
+        // production predicate.
         let orphans = Set(
             (visibleItems + hiddenItems + ahItems)
-                .filter { $0.tag.isControlCenterGenericItem && $0.sourcePID == nil }
+                .filter(\.hasProvisionalIdentity)
                 .map(\.uniqueIdentifier)
         )
 
@@ -669,7 +670,7 @@ extension ProfileLayoutLogReplay.Cycle {
             hiddenCtrlUID: hiddenCtrl,
             ahCtrlUID: ahCtrl,
             visibleCtrlUID: visibleCtrl,
-            unresolvedGenericCCOrphans: orphans
+            provisionalIdentityOrphans: orphans
         )
     }
 }

--- a/ThawTests/Shared/MarkerPairResolverTests.swift
+++ b/ThawTests/Shared/MarkerPairResolverTests.swift
@@ -562,4 +562,23 @@ struct HostedItemOwnershipTests {
         #expect(!HostedItemOwnership.titleIndicatesOwner(nil, bundleID: "codes.rambo.AirBuddyHelper"))
         #expect(!HostedItemOwnership.titleIndicatesOwner("", bundleID: "codes.rambo.AirBuddyHelper"))
     }
+
+    @Test("A bare app-name title matches its bundle's last component")
+    func bareAppNameMatchesLastComponent() {
+        // windowID 3511 in the rc2 log: title "BetterTouchTool", AX child 15pt
+        // // away in com.hegenberg.BetterTouchTool, refused for lack of shape.
+        #expect(HostedItemOwnership.titleIndicatesOwner("BetterTouchTool", bundleID: "com.hegenberg.BetterTouchTool"))
+        }
+
+    @Test("A bare vendor component never matches")
+    func bareVendorComponentNeverMatches() {
+            #expect(!HostedItemOwnership.titleIndicatesOwner("hegenberg", bundleID: "com.hegenberg.BetterTouchTool"))
+    }
+
+    @Test("A bare title must equal the app component exactly")
+    func bareTitleMustEqualAppComponentExactly() {
+        // Substring agreement is not enough — "Clock" is a Control Center module.
+        #expect(!HostedItemOwnership.titleIndicatesOwner("Clock", bundleID: "com.fabriceleyne.theclock"))
+        #expect(!HostedItemOwnership.titleIndicatesOwner("Sound", bundleID: "com.rogueamoeba.soundsource"))
+    }
 }

--- a/ThawTests/Shared/MarkerPairResolverTests.swift
+++ b/ThawTests/Shared/MarkerPairResolverTests.swift
@@ -202,6 +202,26 @@ struct MarkerPairResolverTests {
         #expect(result == [])
     }
 
+    /// A marker titled with Control Center's own bundle identifier must not
+    /// resolve an icon to Control Center. The owning-PID path already rejects
+    /// it; the title-lookup path must too, or the icon gets a *resolved* CC
+    /// PID, reads as a transient CC widget (canBeHidden false), and drops out
+    /// of profile management — past every unresolved-sourcePID gate.
+    @Test("A Control-Center-titled marker resolves nothing")
+    func controlCenterTitledMarkerResolvesNothing() {
+        let icons = [icon(windowID: 1, title: "Item-0")]
+        let markers = [marker(windowID: 2, title: "com.apple.controlcenter", owningPID: 1117)]
+        let result = MarkerPairResolver.resolve(
+            unresolvedIcons: icons,
+            markers: markers,
+            thawBundleID: thawBundleID,
+            ccBundleID: ccBundleID,
+            pidToBundleID: { _ in self.ccBundleID },
+            bundleIDToPID: { $0 == self.ccBundleID ? 1117 : nil }
+        )
+        #expect(result == [])
+    }
+
     /// Two unresolved icons share the same size and there are two
     /// markers of that size: the ambiguity is unresolvable, so no
     /// pairings emit. Prevents the cross-attribution where an icon

--- a/ThawTests/Shared/MarkerPairResolverTests.swift
+++ b/ThawTests/Shared/MarkerPairResolverTests.swift
@@ -235,6 +235,33 @@ struct MarkerPairResolverTests {
         #expect(result == [])
     }
 
+    /// One marker cannot be claimed by several same-size icons: the
+    /// first icon to claim the marker wins, the others are rejected.
+    @Test("One marker cannot be claimed by several same-width icons")
+    func oneMarkerCannotBeClaimedBySeveralIcons() {
+        let size = CGSize(width: 38, height: 30)
+        let icons = [
+            icon(windowID: 34, title: "Sound", size: size),
+            icon(windowID: 90, title: "WiFi", size: size),
+            icon(windowID: 243, title: "Item-0", size: size),
+        ]
+        let markers = [marker(
+            windowID: 3059,
+            title: "com.sindresorhus.Pure-Paste",
+            size: CGSize(width: 38, height: 33),
+            owningPID: 1117 // Control Center
+        )]
+        let result = MarkerPairResolver.resolve(
+            unresolvedIcons: icons,
+            markers: markers,
+            thawBundleID: thawBundleID,
+            ccBundleID: ccBundleID,
+            pidToBundleID: { pid in pid == 1117 ? self.ccBundleID : "com.sindresorhus.Pure-Paste" },
+            bundleIDToPID: { $0 == "com.sindresorhus.Pure-Paste" ? 1877 : nil }
+        )
+        #expect(result == [])
+    }
+
     /// Icon whose own title is bundle-ID-shaped is not a candidate:
     /// it's a marker, not an icon. This prevents two markers from
     /// pairing with each other. The generic-titled icon resolves

--- a/ThawTests/Shared/MarkerPairResolverTests.swift
+++ b/ThawTests/Shared/MarkerPairResolverTests.swift
@@ -521,6 +521,14 @@ struct HostedItemOwnershipTests {
         )
     }
 
+    @Test("A malformed vendor-only title never matches")
+    func malformedVendorOnlyTitleNeverMatches() {
+        // "pl.maketheweb." splits to ["pl", "maketheweb", ""], clearing the
+        // three-component guard. Without the empty-component rejection the
+        // trailing "" is a prefix of "cleanshotx" and the pair matches.
+        #expect(!HostedItemOwnership.titleIndicatesOwner("pl.maketheweb.", bundleID: "pl.maketheweb.cleanshotx"))
+    }
+
     // MARK: - Reject: unrelated neighbors that sat within the radius
 
     @Test("WireGuard does not match Updatest")


### PR DESCRIPTION
# Summary

Stop menu bar items from rearranging themselves when Control Center–hosted status items briefly lack a real `sourcePID`. Formalize that state as a provisional identity and keep it out of saved-layout identity sets, and tighten marker pairing so same-width icons cannot steal each other’s markers (including bare app-name titles like BetterTouchTool).

**Scope:** Focused bug fix for layout identity / marker resolution, plus Swift Testing coverage for the new matching rules.

> We are on the process of migrating from XCTest to Swift Test. If you are adding new tests, please use Swift Test.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

Closes: #863

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- **Provisional identity:** `MenuBarItem.hasProvisionalIdentity` (`sourcePID == nil` + Control Center namespace) replaces the previous ad-hoc `isControlCenterGenericItem && sourcePID == nil` checks. Those items are excluded from “current identifier” / unmanaged partition sets so a later real-app naming cycle cannot rewrite saved section positions.
- **LayoutSolver:** `partitionUnmanagedUIDs` takes `provisionalIdentityUIDs` (via `LayoutSolver.provisionalIdentityUIDs(items:)`).
- **Marker pairing:** only unique-width unresolved icons may claim a same-width marker (no first-come multi-claim). `HostedItemOwnership` accepts a bare app-name title when it equals the bundle’s last component (e.g. `BetterTouchTool` ↔ `com.hegenberg.BetterTouchTool`), without matching vendor-only components.
- **Tests:** Swift Testing coverage for one-marker-many-icons rejection and bare app-name / vendor / exact-match ownership rules.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- (CI on this PR)

## Known limitations / follow-ups

- Does not claim to fix every multi-display scramble path; this targets provisional Control Center identity churn and ambiguous same-width marker claims seen in the #863 / rc1 logs.
- Still worth validating on multi-monitor macOS 26 with third-party hosted items (BTT, etc.) after merge.

## Other information

- Head: `fix/items-rearrangement-bug` (2 commits, DCO signed)
- Related reporter context: daily reorder on 2.0.0-rc1 / macOS 26.6 multi-monitor ([#863](https://github.com/thaw-app/Thaw/issues/863))

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar item identification to prevent temporary or ambiguous items from being saved or incorrectly assigned to profiles.
  * Prevented duplicate icon assignments when multiple icons share the same size.
  * Improved app-name and icon matching, including stricter handling of incomplete or inaccurate names.
  * Enhanced handling of Control Center items whose identities cannot yet be fully resolved.
* **Tests**
  * Added coverage for icon assignment, app-name matching, and provisional menu bar item handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->