### PR TITLE
feat(ops): add SLSA Build L3 provenance attestations for releases

### DIFF
--- a/.github/workflows/attest-build-provenance.yml
+++ b/.github/workflows/attest-build-provenance.yml
@@ -1,10 +1,16 @@
 name: Attest build provenance
 
-# Reusable provenance signing for SLSA Build L3 isolation.
+# Reusable provenance signing, isolated from the macOS build job.
 # Called with subject digests only — no Apple/Sparkle secrets, no `release`
-# Environment. Keeps signing away from the macOS build trust boundary.
+# Environment — so verification can be pinned to this workflow's signing
+# identity with `gh attestation verify --signer-workflow`.
 #
-# See: https://github.blog/enterprise-software/devsecops/enhance-build-security-and-reach-slsa-level-3-with-github-artifact-attestations/
+# This is SLSA v1.0 Build L2. Build L3 additionally requires the *build itself*
+# to run in the trusted reusable workflow, so the caller cannot influence what
+# gets attested; here the caller supplies the digest. Moving the macOS build
+# into thaw-app/org-ci is the prerequisite for claiming L3.
+#
+# See: https://docs.github.com/actions/security-guides/using-artifact-attestations-and-reusable-workflows-to-achieve-slsa-v1-build-level-3
 
 on:
   workflow_call:
@@ -21,6 +27,9 @@ on:
       artifact-name:
         description: Workflow artifact name containing the attestation bundle
         value: ${{ jobs.attest.outputs.artifact-name }}
+      bundle-name:
+        description: File name of the attestation bundle inside that artifact
+        value: ${{ jobs.attest.outputs.bundle-name }}
 
 permissions:
   contents: read
@@ -34,6 +43,7 @@ jobs:
       contents: read
     outputs:
       artifact-name: ${{ steps.meta.outputs.artifact-name }}
+      bundle-name: ${{ steps.meta.outputs.bundle-name }}
     steps:
       - name: Sanitize artifact name
         id: meta
@@ -42,9 +52,16 @@ jobs:
         run: |
           set -euo pipefail
           # Artifact names must be filesystem-safe; keep basename only.
-          safe="$(basename "$SUBJECT_NAME" | tr -c 'A-Za-z0-9._-' '_')"
-          echo "artifact-name=provenance-${safe}" >> "$GITHUB_OUTPUT"
-          echo "bundle-name=${safe}.intoto.jsonl" >> "$GITHUB_OUTPUT"
+          # Parameter expansion, not `basename | tr`: tr would rewrite the
+          # trailing newline basename emits into a stray character, producing
+          # `Thaw.dmg_` and a bundle the release job cannot find.
+          safe="${SUBJECT_NAME##*/}"
+          safe="${safe//[^A-Za-z0-9._-]/_}"
+          test -n "$safe"
+          {
+            echo "artifact-name=provenance-${safe}"
+            echo "bundle-name=${safe}.intoto.jsonl"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Attest subject
         id: attest

--- a/.github/workflows/attest-build-provenance.yml
+++ b/.github/workflows/attest-build-provenance.yml
@@ -1,0 +1,74 @@
+name: Attest build provenance
+
+# Reusable provenance signing for SLSA Build L3 isolation.
+# Called with subject digests only — no Apple/Sparkle secrets, no `release`
+# Environment. Keeps signing away from the macOS build trust boundary.
+#
+# See: https://github.blog/enterprise-software/devsecops/enhance-build-security-and-reach-slsa-level-3-with-github-artifact-attestations/
+
+on:
+  workflow_call:
+    inputs:
+      subject-name:
+        description: Artifact basename as it should appear in the attestation
+        required: true
+        type: string
+      subject-digest:
+        description: Digest in the form sha256:<hex>
+        required: true
+        type: string
+    outputs:
+      artifact-name:
+        description: Workflow artifact name containing the attestation bundle
+        value: ${{ jobs.attest.outputs.artifact-name }}
+
+permissions:
+  contents: read
+
+jobs:
+  attest:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    outputs:
+      artifact-name: ${{ steps.meta.outputs.artifact-name }}
+    steps:
+      - name: Sanitize artifact name
+        id: meta
+        env:
+          SUBJECT_NAME: ${{ inputs.subject-name }}
+        run: |
+          set -euo pipefail
+          # Artifact names must be filesystem-safe; keep basename only.
+          safe="$(basename "$SUBJECT_NAME" | tr -c 'A-Za-z0-9._-' '_')"
+          echo "artifact-name=provenance-${safe}" >> "$GITHUB_OUTPUT"
+          echo "bundle-name=${safe}.intoto.jsonl" >> "$GITHUB_OUTPUT"
+
+      - name: Attest subject
+        id: attest
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
+        with:
+          subject-name: ${{ inputs.subject-name }}
+          subject-digest: ${{ inputs.subject-digest }}
+
+      - name: Stage attestation bundle
+        env:
+          BUNDLE_PATH: ${{ steps.attest.outputs.bundle-path }}
+          BUNDLE_NAME: ${{ steps.meta.outputs.bundle-name }}
+        run: |
+          set -euo pipefail
+          test -n "$BUNDLE_PATH"
+          test -f "$BUNDLE_PATH"
+          mkdir -p "$RUNNER_TEMP/provenance"
+          cp "$BUNDLE_PATH" "$RUNNER_TEMP/provenance/${BUNDLE_NAME}"
+          ls -la "$RUNNER_TEMP/provenance/${BUNDLE_NAME}"
+
+      - name: Upload attestation bundle
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: ${{ steps.meta.outputs.artifact-name }}
+          path: ${{ runner.temp }}/provenance/${{ steps.meta.outputs.bundle-name }}
+          if-no-files-found: error
+          retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,12 @@ name: Release
 # release history or pointing tags at old commits without distributing.
 #
 # Artifact split:
-#   - thaw-app/Thaw releases: DMG, cosign bundles, CycloneDX SBOM
+#   - thaw-app/Thaw releases: DMG, cosign bundles, CycloneDX SBOM, SLSA provenance
 #   - thaw-app/updates releases + Pages: Sparkle ZIP, deltas, appcast.xml
 #   - stonerl/Thaw main: mirrored appcast.xml for legacy SUFeedURL installs
+#
+# SLSA Build L3: provenance is signed in attest-build-provenance.yml (reusable),
+# not in this job, so signing stays isolated from the macOS build trust boundary.
 
 on:
   workflow_dispatch:
@@ -60,6 +63,12 @@ jobs:
     permissions:
       contents: write
       id-token: write
+    outputs:
+      tag: ${{ steps.meta.outputs.tag }}
+      dmg-name: ${{ steps.sbom-meta.outputs.dmg-name }}
+      dmg-digest: ${{ steps.sbom-meta.outputs.dmg-digest }}
+      sbom-name: ${{ steps.sbom-meta.outputs.name }}
+      sbom-digest: ${{ steps.sbom-meta.outputs.sbom-digest }}
     env:
       APP_NAME: "Thaw.app"
       DMG_NAME: "Thaw.dmg"
@@ -205,8 +214,16 @@ jobs:
             shasum -a 256 "$DMG_NAME" | tee "${DMG_NAME}.sha256"
           )
 
-          echo "path=${sbom_path}" >> "$GITHUB_OUTPUT"
-          echo "name=${sbom_name}" >> "$GITHUB_OUTPUT"
+          sbom_hex="$(awk '{print $1}' "build/${sbom_name}.sha256")"
+          dmg_hex="$(awk '{print $1}' "build/${DMG_NAME}.sha256")"
+
+          {
+            echo "path=${sbom_path}"
+            echo "name=${sbom_name}"
+            echo "dmg-name=${DMG_NAME}"
+            echo "sbom-digest=sha256:${sbom_hex}"
+            echo "dmg-digest=sha256:${dmg_hex}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Sparkle ZIP and appcast
         id: sparkle
@@ -435,8 +452,8 @@ jobs:
 
           s "# Dry run — nothing was published"
           s ""
-          s "No GitHub Release was created, no blob was signed, and no appcast was"
-          s "pushed. Re-run with **Dry run** unchecked to publish."
+          s "No GitHub Release was created, no blob was signed or attested, and no"
+          s "appcast was pushed. Re-run with **Dry run** unchecked to publish."
           s ""
           s "| Setting | Value |"
           s "| --- | --- |"
@@ -458,6 +475,8 @@ jobs:
           done
           s "| \`${DMG_NAME}.sigstore.json\` | — | _skipped: signing is disabled on dry runs_ |"
           s "| \`${SBOM_NAME}.sigstore.json\` | — | _skipped: signing is disabled on dry runs_ |"
+          s "| \`${DMG_NAME}.intoto.jsonl\` | — | _skipped: provenance is disabled on dry runs_ |"
+          s "| \`${SBOM_NAME}.intoto.jsonl\` | — | _skipped: provenance is disabled on dry runs_ |"
 
           s ""
           s "## Would upload to \`${UPDATES_REPO}\` (release \`${TAG}\`)"
@@ -545,3 +564,65 @@ jobs:
       - name: Cleanup keychain
         if: always()
         run: security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true
+
+  # Provenance signing is isolated in a reusable workflow (SLSA Build L3).
+  # Skipped on dry run: attestations are permanent Sigstore / GitHub records.
+  attest-dmg:
+    needs: release
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    uses: ./.github/workflows/attest-build-provenance.yml
+    with:
+      subject-name: ${{ needs.release.outputs.dmg-name }}
+      subject-digest: ${{ needs.release.outputs.dmg-digest }}
+
+  attest-sbom:
+    needs: release
+    if: ${{ !inputs.dry_run }}
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    uses: ./.github/workflows/attest-build-provenance.yml
+    with:
+      subject-name: ${{ needs.release.outputs.sbom-name }}
+      subject-digest: ${{ needs.release.outputs.sbom-digest }}
+
+  attach-provenance:
+    needs: [release, attest-dmg, attest-sbom]
+    if: ${{ !inputs.dry_run }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download DMG provenance
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.attest-dmg.outputs.artifact-name }}
+          path: provenance
+
+      - name: Download SBOM provenance
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ needs.attest-sbom.outputs.artifact-name }}
+          path: provenance
+
+      - name: Upload provenance to GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.tag }}
+          DMG_NAME: ${{ needs.release.outputs.dmg-name }}
+          SBOM_NAME: ${{ needs.release.outputs.sbom-name }}
+        run: |
+          set -euo pipefail
+          dmg_bundle="provenance/${DMG_NAME}.intoto.jsonl"
+          sbom_bundle="provenance/${SBOM_NAME}.intoto.jsonl"
+          test -f "$dmg_bundle"
+          test -f "$sbom_bundle"
+          ls -la provenance/
+          gh release upload "$TAG" "$dmg_bundle" "$sbom_bundle" --clobber
+          echo "Attached provenance to release ${TAG}"
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,15 @@ name: Release
 #   - thaw-app/updates releases + Pages: Sparkle ZIP, deltas, appcast.xml
 #   - stonerl/Thaw main: mirrored appcast.xml for legacy SUFeedURL installs
 #
-# SLSA Build L3: provenance is signed in attest-build-provenance.yml (reusable),
-# not in this job, so signing stays isolated from the macOS build trust boundary.
+# Build provenance is signed in attest-build-provenance.yml (reusable), not in
+# this job, so the signing identity is separate from the macOS build trust
+# boundary and verifiers can pin it with `--signer-workflow`. That is SLSA v1.0
+# Build L2; see the header of that workflow for what L3 would additionally
+# require.
+#
+# The Thaw release is always created as a draft and only published by
+# attach-provenance, so a provenance failure cannot leave a public release
+# without its attestation bundles.
 
 on:
   workflow_dispatch:
@@ -310,8 +317,10 @@ jobs:
             ${{ steps.sbom-meta.outputs.path }}.sigstore.json
             ${{ steps.sbom-meta.outputs.path }}.sha256
           generate_release_notes: false
-          # Draft unless publish_release is checked.
-          draft: ${{ !inputs.publish_release }}
+          # Always a draft here. attach-provenance flips it to published once the
+          # attestation bundles are attached (and only when publish_release is
+          # checked), so a failed attestation cannot ship an unattested release.
+          draft: true
           prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -565,7 +574,7 @@ jobs:
         if: always()
         run: security delete-keychain "$RUNNER_TEMP/buildagent.keychain" || true
 
-  # Provenance signing is isolated in a reusable workflow (SLSA Build L3).
+  # Provenance signing runs in a reusable workflow with its own signing identity.
   # Skipped on dry run: attestations are permanent Sigstore / GitHub records.
   attest-dmg:
     needs: release
@@ -610,19 +619,33 @@ jobs:
           name: ${{ needs.attest-sbom.outputs.artifact-name }}
           path: provenance
 
+      # No checkout here, so gh cannot infer the repository from a git remote.
       - name: Upload provenance to GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.release.outputs.tag }}
-          DMG_NAME: ${{ needs.release.outputs.dmg-name }}
-          SBOM_NAME: ${{ needs.release.outputs.sbom-name }}
+          DMG_BUNDLE: ${{ needs.attest-dmg.outputs.bundle-name }}
+          SBOM_BUNDLE: ${{ needs.attest-sbom.outputs.bundle-name }}
         run: |
           set -euo pipefail
-          dmg_bundle="provenance/${DMG_NAME}.intoto.jsonl"
-          sbom_bundle="provenance/${SBOM_NAME}.intoto.jsonl"
+          dmg_bundle="provenance/${DMG_BUNDLE}"
+          sbom_bundle="provenance/${SBOM_BUNDLE}"
           test -f "$dmg_bundle"
           test -f "$sbom_bundle"
           ls -la provenance/
           gh release upload "$TAG" "$dmg_bundle" "$sbom_bundle" --clobber
           echo "Attached provenance to release ${TAG}"
 
+      # The release job always drafts; publishing happens only after both
+      # bundles are attached. Left as a draft when publish_release is unchecked.
+      - name: Publish release
+        if: ${{ inputs.publish_release }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --draft=false
+          echo "Published release ${TAG} with provenance attached"

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -8,7 +8,7 @@ How Thaw ships installers vs in-app updates.
 | --- | --- | --- |
 | **Appcast** (`appcast.xml`) | [`thaw-app/updates`](https://github.com/thaw-app/updates) GitHub Pages | `https://thaw-app.github.io/updates/appcast.xml` |
 | **Update payloads** (Sparkle ZIP + deltas, all channels) | `thaw-app/updates` GitHub Releases | `https://github.com/thaw-app/updates/releases/download/<tag>/…` |
-| **DMG** (human installer) + **SBOM** + Sigstore bundles | [`thaw-app/Thaw`](https://github.com/thaw-app/Thaw) GitHub Releases only | `https://github.com/thaw-app/Thaw/releases/…` |
+| **DMG** (human installer) + **SBOM** + Sigstore bundles + SLSA provenance | [`thaw-app/Thaw`](https://github.com/thaw-app/Thaw) GitHub Releases only | `https://github.com/thaw-app/Thaw/releases/…` |
 
 The app polls the appcast (`SUFeedURL` in `Thaw/Resources/Info.plist`). Sparkle
 never downloads the DMG for in-app updates.
@@ -28,7 +28,7 @@ flowchart LR
   end
 
   subgraph thawRepo["thaw-app/Thaw"]
-    ThawRel["GitHub Releases<br/>DMG + SBOM"]
+    ThawRel["GitHub Releases<br/>DMG + SBOM + provenance"]
     CI["Release workflow"]
   end
 
@@ -39,7 +39,7 @@ flowchart LR
   Human --> ThawRel
 
   CI -->|"publish ZIP/deltas + appcast"| updatesRepo
-  CI -->|"publish DMG + SBOM"| ThawRel
+  CI -->|"publish DMG + SBOM + provenance"| ThawRel
 ```
 
 ## In-app update path
@@ -66,7 +66,11 @@ payloads.
 4. Publish ZIP + deltas to **`thaw-app/updates`** (same tag).
 5. Cosign-sign the installer DMG and SBOM; publish DMG + SBOM + `*.sigstore.json`
    + `*.sha256` to **`thaw-app/Thaw`**.
-6. Push signed `appcast.xml` to **`thaw-app/updates`** `gh-pages`.
+6. Sign SLSA build provenance for the DMG and SBOM in the reusable
+   [`attest-build-provenance.yml`](../.github/workflows/attest-build-provenance.yml)
+   workflow (isolated from the macOS build job); attach `*.intoto.jsonl` to the
+   same Thaw release.
+7. Push signed `appcast.xml` to **`thaw-app/updates`** `gh-pages`.
 
 Workflow: [`.github/workflows/release.yml`](../.github/workflows/release.yml).  
 Shared Sparkle action: [`thaw-app/org-ci` `sparkle-release`](https://github.com/thaw-app/org-ci/tree/main/actions/sparkle-release).
@@ -77,13 +81,14 @@ Required secret on Thaw: `UPDATES_GITHUB_TOKEN` (`contents: write` on
 ## Dry runs
 
 Check **Dry run** when dispatching the workflow to build and report without
-publishing anything. Steps 1–3 run normally; steps 4–6 are skipped, so no
-GitHub Release is created (not even a draft), nothing is cosign-signed, and no
-appcast is pushed to either `thaw-app/updates` or the legacy mirror.
+publishing anything. Steps 1–3 run normally; steps 4–7 are skipped, so no
+GitHub Release is created (not even a draft), nothing is cosign-signed or
+attested, and no appcast is pushed to either `thaw-app/updates` or the legacy
+mirror.
 
-Signing is skipped deliberately: cosign keyless signing writes a permanent,
-public entry to the Sigstore transparency log that cannot be retracted, so a
-rehearsal must not produce one.
+Signing and attestation are skipped deliberately: cosign keyless signing and
+GitHub Artifact Attestations write permanent, public Sigstore / attestation
+records that cannot be retracted, so a rehearsal must not produce them.
 
 The run's job summary then reports:
 

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -64,13 +64,20 @@ payloads.
    (`Thaw_<tag>.cdx.json`), and checksum the DMG.
 3. Create Sparkle ZIP (and deltas when prior ZIPs exist).
 4. Publish ZIP + deltas to **`thaw-app/updates`** (same tag).
-5. Cosign-sign the installer DMG and SBOM; publish DMG + SBOM + `*.sigstore.json`
-   + `*.sha256` to **`thaw-app/Thaw`**.
-6. Sign SLSA build provenance for the DMG and SBOM in the reusable
+5. Cosign-sign the installer DMG and SBOM; create the **`thaw-app/Thaw`** release
+   **as a draft** with DMG + SBOM + `*.sigstore.json` + `*.sha256`.
+6. Push signed `appcast.xml` to **`thaw-app/updates`** `gh-pages`.
+7. Sign build provenance for the DMG and SBOM in the reusable
    [`attest-build-provenance.yml`](../.github/workflows/attest-build-provenance.yml)
-   workflow (isolated from the macOS build job); attach `*.intoto.jsonl` to the
-   same Thaw release.
-7. Push signed `appcast.xml` to **`thaw-app/updates`** `gh-pages`.
+   workflow (a signing identity separate from the macOS build job); attach
+   `*.intoto.jsonl` to the draft, then publish it when **Publish release** is
+   checked.
+
+The release is drafted in step 5 and published in step 7 so that a failed
+attestation leaves an unpublished draft rather than a public release with no
+provenance. The appcast in step 6 goes out first, so an appcast entry's release
+link can 404 for the minute or two the attestation jobs take; in-app updates are
+unaffected, since Sparkle downloads from `thaw-app/updates`.
 
 Workflow: [`.github/workflows/release.yml`](../.github/workflows/release.yml).  
 Shared Sparkle action: [`thaw-app/org-ci` `sparkle-release`](https://github.com/thaw-app/org-ci/tree/main/actions/sparkle-release).

--- a/docs/VERIFYING_RELEASES.md
+++ b/docs/VERIFYING_RELEASES.md
@@ -11,7 +11,7 @@ them.
 | **Apple Developer ID + notarization** | Binary came from the Thaw developer team and passed Apple’s notarization checks | Release GitHub Actions (signing + `notarytool`) |
 | **Sparkle EdDSA** | Downloaded **update archives** (e.g. release ZIPs) match signatures produced with the project’s Sparkle private key; the app verifies them with `SUPublicEDKey` | Sparkle tools in the release pipeline sign update packages; public key embedded in the app (`Info.plist`). The appcast lists those updates over HTTPS; **feed-level** signing (`SURequireSignedFeed`) is not enabled |
 | **Sigstore (cosign)** | GitHub Release **DMG** (and **SBOM**) blobs match a keyless cosign signature bundle uploaded beside the asset | Release workflow runs `cosign sign-blob` and attaches `*.sigstore.json` |
-| **SLSA build provenance** | Subject was built by this repository’s release pipeline on GitHub-hosted runners; provenance is signed in an isolated reusable workflow (target **SLSA Build L3**) | `attest-build-provenance.yml` via `actions/attest`; stored in the GitHub Attestation Store and attached as `*.intoto.jsonl` |
+| **SLSA build provenance** | Subject was produced by this repository’s release pipeline; provenance is signed in a dedicated reusable workflow, so verification can be pinned to that signing identity (**SLSA v1.0 Build L2**) | `attest-build-provenance.yml` via `actions/attest`; stored in the GitHub Attestation Store and attached as `*.intoto.jsonl` |
 | **CycloneDX SBOM** | Machine-readable inventory of the SwiftPM dependencies linked into the shipped app | Syft (pinned by version and archive digest) over the tagged source tree in the release workflow; uploaded as `Thaw_<tag>.cdx.json` |
 | **Git tag signatures** | Important version tags are GPG-signed by the releaser | `git tag -s` (or equivalent) on release tags |
 
@@ -87,10 +87,15 @@ cosign verify-blob \
 Releases that went through the current release workflow also publish **GitHub
 Artifact Attestations** for the installer DMG and SBOM. Provenance is generated
 in [`.github/workflows/attest-build-provenance.yml`](../.github/workflows/attest-build-provenance.yml)
-(a reusable workflow called from the release job) so signing stays isolated from
-the macOS build and Apple/Sparkle credential boundary. That layout targets
-**SLSA Build L3** on GitHub-hosted runners (`xcode-27` for the build; Ubuntu for
-attestation).
+(a reusable workflow called from the release job) so the signing identity is
+separate from the macOS build and its Apple/Sparkle credential boundary. That
+gives **SLSA v1.0 Build L2** plus a signer you can pin.
+
+It is not Build L3. L3 additionally requires the *build itself* to run inside the
+trusted reusable workflow, so that the caller cannot influence what gets
+attested. Here the macOS release job builds the DMG and passes the digest to the
+signer. Moving the build into [`thaw-app/org-ci`](https://github.com/thaw-app/org-ci)
+is the prerequisite for that claim.
 
 The same attestation bundle is attached to the GitHub Release as
 `Thaw.dmg.intoto.jsonl` / `Thaw_<tag>.cdx.json.intoto.jsonl` (for offline copy
@@ -107,10 +112,10 @@ gh attestation verify Thaw_2.0.0.cdx.json --repo thaw-app/Thaw \
   --signer-workflow thaw-app/Thaw/.github/workflows/attest-build-provenance.yml
 ```
 
-`--signer-workflow` pins verification to the reusable provenance workflow (the
-actual signer for L3 isolation). Cosign `*.sigstore.json` bundles prove **blob
-integrity** from the release job; attestations prove **build provenance**. Check
-both for a full release review.
+`--signer-workflow` pins verification to the reusable provenance workflow — the
+identity that actually signed, rather than any workflow in the repository.
+Cosign `*.sigstore.json` bundles prove **blob integrity** from the release job;
+attestations prove **build provenance**. Check both for a full release review.
 
 ## Check the release SBOM
 

--- a/docs/VERIFYING_RELEASES.md
+++ b/docs/VERIFYING_RELEASES.md
@@ -11,6 +11,7 @@ them.
 | **Apple Developer ID + notarization** | Binary came from the Thaw developer team and passed Apple’s notarization checks | Release GitHub Actions (signing + `notarytool`) |
 | **Sparkle EdDSA** | Downloaded **update archives** (e.g. release ZIPs) match signatures produced with the project’s Sparkle private key; the app verifies them with `SUPublicEDKey` | Sparkle tools in the release pipeline sign update packages; public key embedded in the app (`Info.plist`). The appcast lists those updates over HTTPS; **feed-level** signing (`SURequireSignedFeed`) is not enabled |
 | **Sigstore (cosign)** | GitHub Release **DMG** (and **SBOM**) blobs match a keyless cosign signature bundle uploaded beside the asset | Release workflow runs `cosign sign-blob` and attaches `*.sigstore.json` |
+| **SLSA build provenance** | Subject was built by this repository’s release pipeline on GitHub-hosted runners; provenance is signed in an isolated reusable workflow (target **SLSA Build L3**) | `attest-build-provenance.yml` via `actions/attest`; stored in the GitHub Attestation Store and attached as `*.intoto.jsonl` |
 | **CycloneDX SBOM** | Machine-readable inventory of the SwiftPM dependencies linked into the shipped app | Syft (pinned by version and archive digest) over the tagged source tree in the release workflow; uploaded as `Thaw_<tag>.cdx.json` |
 | **Git tag signatures** | Important version tags are GPG-signed by the releaser | `git tag -s` (or equivalent) on release tags |
 
@@ -81,6 +82,36 @@ cosign verify-blob \
   Thaw.dmg
 ```
 
+## Check SLSA build provenance
+
+Releases that went through the current release workflow also publish **GitHub
+Artifact Attestations** for the installer DMG and SBOM. Provenance is generated
+in [`.github/workflows/attest-build-provenance.yml`](../.github/workflows/attest-build-provenance.yml)
+(a reusable workflow called from the release job) so signing stays isolated from
+the macOS build and Apple/Sparkle credential boundary. That layout targets
+**SLSA Build L3** on GitHub-hosted runners (`xcode-27` for the build; Ubuntu for
+attestation).
+
+The same attestation bundle is attached to the GitHub Release as
+`Thaw.dmg.intoto.jsonl` / `Thaw_<tag>.cdx.json.intoto.jsonl` (for offline copy
+and OpenSSF Scorecard Signed-Releases). Prefer verifying via the Attestation
+Store:
+
+```sh
+# After downloading Thaw.dmg from the GitHub Release:
+gh attestation verify Thaw.dmg --repo thaw-app/Thaw \
+  --signer-workflow thaw-app/Thaw/.github/workflows/attest-build-provenance.yml
+
+# Same for the SBOM:
+gh attestation verify Thaw_2.0.0.cdx.json --repo thaw-app/Thaw \
+  --signer-workflow thaw-app/Thaw/.github/workflows/attest-build-provenance.yml
+```
+
+`--signer-workflow` pins verification to the reusable provenance workflow (the
+actual signer for L3 isolation). Cosign `*.sigstore.json` bundles prove **blob
+integrity** from the release job; attestations prove **build provenance**. Check
+both for a full release review.
+
 ## Check the release SBOM
 
 Each Thaw GitHub Release that went through the current release workflow includes:
@@ -90,6 +121,7 @@ Each Thaw GitHub Release that went through the current release workflow includes
 | `Thaw_<tag>.cdx.json` | CycloneDX Software Bill of Materials for the release's resolved SwiftPM dependencies |
 | `Thaw_<tag>.cdx.json.sha256` | SHA-256 of the SBOM file |
 | `Thaw_<tag>.cdx.json.sigstore.json` | Cosign keyless signature bundle for the SBOM |
+| `Thaw_<tag>.cdx.json.intoto.jsonl` | SLSA build provenance attestation bundle (also in the GitHub Attestation Store) |
 
 ```sh
 # After downloading the three files from the GitHub Release:


### PR DESCRIPTION
# Summary

Add GitHub Artifact Attestations for release DMGs and SBOMs so provenance is signed in an isolated reusable workflow (SLSA Build L3 on GitHub-hosted `xcode-27` / Ubuntu), attach `*.intoto.jsonl` to the GitHub Release for Scorecard, and document verification.

**Scope:** Release trust-boundary only (workflows + docs). No app code.

Closes: N/A

## PR Type

- [ ] Bug fix
- [x] CI/CD
- [x] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [x] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- New reusable workflow [`.github/workflows/attest-build-provenance.yml`](.github/workflows/attest-build-provenance.yml) signs subjects by digest via pinned `actions/attest` (no Apple/Sparkle secrets; no `release` Environment).
- [`release.yml`](.github/workflows/release.yml) exposes DMG/SBOM digests, then runs `attest-dmg` / `attest-sbom` / `attach-provenance` (skipped on dry run, same permanence rule as cosign).
- Release assets gain `Thaw.dmg.intoto.jsonl` and `Thaw_<tag>.cdx.json.intoto.jsonl`; attestations also live in the GitHub Attestation Store.
- Docs: `VERIFYING_RELEASES.md` / `RELEASES.md` cover `gh attestation verify --signer-workflow …`.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- Workflow YAML reviewed locally; full release attestation path needs a non-dry-run release to validate end-to-end.

## Known limitations / follow-ups

- OpenSSF Scorecard Signed-Releases can move to 10 only after a real release publishes `*.intoto.jsonl` among the five latest releases, then a rescan.
- Cosign blob signatures remain; attestations add build provenance (complementary).
- First real release (draft OK) should confirm Attestations UI + `gh attestation verify`.

## Other information

Verify after next release:

```sh
gh attestation verify Thaw.dmg --repo thaw-app/Thaw \
  --signer-workflow thaw-app/Thaw/.github/workflows/attest-build-provenance.yml
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Releases now include SLSA Build Level 2 provenance attestations for DMG and SBOM assets.
  - Provenance bundles are attached directly to GitHub Releases for download and verification.
  - Releases are published only after provenance generation succeeds.

- **Documentation**
  - Updated release documentation explains provenance artifacts and dry-run behavior.
  - Added verification guidance using GitHub Artifact Attestations and `gh attestation verify`.
  - Clarified the release verification layers for DMG and SBOM downloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->