### PR TITLE
fix(menubar): refuse the saved-layout bulk apply while the dividers are collapsed

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -8490,6 +8490,30 @@ extension MenuBarItemManager {
         }
 
         let trigger = windowIDsChanged ? "windowID change" : "layout divergence"
+
+        // The apply must refuse the same geometry the save path refuses to
+        // persist. When the dividers have collapsed onto one coordinate,
+        // findSection has already misread every hidden item, so the section
+        // mismatch computed below is an artifact of the collapse, not drift
+        // to correct — dispatching here drags the whole hidden section to
+        // the wrong side of the dividers with synthetic mouse events. Worse,
+        // the drags separate the dividers, so the saveSectionOrder gate that
+        // caught the collapse a cycle earlier passes on the next cycle and
+        // persists the damage (#868). Refusing keeps the bar untouched; the
+        // change gate re-fires via layout divergence once the geometry
+        // recovers, and the apply then runs against a trustworthy reading.
+        let hiddenSectionHasRoom = LayoutSolver.hiddenSectionHasRoom(
+            hiddenControlItemMinX: controlItems.hidden.bounds.minX,
+            alwaysHiddenControlItemMaxX: controlItems.alwaysHidden?.bounds.maxX,
+            savedHiddenItemCount: savedSectionOrder[sectionKey(for: .hidden)]?.count ?? 0
+        )
+        guard hiddenSectionHasRoom else {
+            MenuBarItemManager.diagLog.warning(
+                "applySavedLayout: skipping (\(trigger)); hidden section has zero width between the dividers (hidden.minX=\(controlItems.hidden.bounds.minX), alwaysHidden.maxX=\(controlItems.alwaysHidden?.bounds.maxX.description ?? "nil"))"
+            )
+            return false
+        }
+
         MenuBarItemManager.diagLog.info("applySavedLayout: dispatching bulk apply (\(trigger))")
 
         // The shared body uses itemOrder as the per-section ordered

--- a/ThawTests/MenuBar/Items/SectionGeometryGateTests.swift
+++ b/ThawTests/MenuBar/Items/SectionGeometryGateTests.swift
@@ -11,7 +11,8 @@ import Testing
 @testable import Thaw
 
 /// Covers the two section-geometry predicates that feed
-/// `LayoutSolver.shouldPersistSavedOrder`.
+/// `LayoutSolver.shouldPersistSavedOrder`. `hiddenSectionHasRoom`
+/// additionally gates `applySavedLayout`'s bulk dispatch (#868).
 ///
 /// Both exist for the same reason: `CacheContext.findSection` degrades
 /// rather than fails when the dividers cannot describe the sections, and
@@ -125,6 +126,22 @@ struct SectionGeometryGateTests {
             hiddenControlItemMinX: -4270.5,
             alwaysHiddenControlItemMaxX: -4271,
             savedHiddenItemCount: 41
+        ))
+    }
+
+    @Test("The apply-path bypass geometry has no room")
+    func applyPathBypassGeometryHasNoRoom() {
+        // The #868 field incident: dividers collapsed at -5743 with 46
+        // items saved hidden. saveSectionOrder refused this geometry, but
+        // applySavedLayout read the same collapse as an 11-item section
+        // mismatch and dispatched 21 synthetic drags — which separated the
+        // dividers, un-tripping the save gate, so the next cycle persisted
+        // the misclassification. The apply path now consults this predicate
+        // before dispatching, so both writers refuse the same reading.
+        #expect(!LayoutSolver.hiddenSectionHasRoom(
+            hiddenControlItemMinX: -5743,
+            alwaysHiddenControlItemMaxX: -5743,
+            savedHiddenItemCount: 46
         ))
     }
 


### PR DESCRIPTION
## What

`applySavedLayout` now checks `LayoutSolver.hiddenSectionHasRoom` before dispatching a bulk apply. The save path has trusted that predicate since `1daa5d60`; the apply path now refuses the same collapsed geometry it does.

## Why

The zero-width save gate holds only until an apply runs. Sequence from #868 (timestamps in the issue):

1. The dividers collapse to one coordinate. `saveSectionOrder` refuses the reading.
2. A windowID change dispatches the bulk apply. That path had no geometry check, and it read the collapse as an 11-item section mismatch.
3. The control-item remedy no-ops with `Item has correct position, cancelling move`, because both dividers sit at the same X. The per-item fallback then drags the whole hidden section with synthetic mouse events: 21 move operations, cursor seized for about 10 seconds.
4. The drags separate the dividers. The save gate passes on the next cycle and persists the misclassification. Nine items moved from hidden to always-hidden in the saved layout.

With the dispatch refused, nothing acts on the degraded reading, and the bar stays untouched while the geometry is collapsed. Once it recovers, the change gate re-fires via layout divergence and the apply restores the layout from a trustworthy reading. The refusal logs at warning level with the trigger and both divider coordinates, next to the save path's message in a grep.

A stronger variant would refuse Phase 1 whenever every hidden item classifies out of the section at once. That would also catch collapses this predicate cannot see, but it changes profile-apply behavior too, so it is not bundled here.

## Testing

- New test pins the incident geometry (-5743/-5743, 46 saved hidden items) against the predicate. The suite doc now notes the predicate feeds both gates.
- Full ThawTests suite on the branch head: 1928 tests in 247 suites, all passing.
- Running on the reporting machine now. The launch-time bulk apply dispatched normally against healthy geometry, so the gate does not block ordinary applies.
- Not exercised against a live collapse. The trigger needs a dock transition on the affected topology and does not reproduce on demand. The save-path gate fired on exactly these coordinates one minute before the apply dispatched, which is the field validation of the predicate; the refusal wiring will be observable in the log on the next natural occurrence.

Closes: #868


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented saved menu bar layouts from being applied when the hidden section lacks usable space.
  * Improved handling of collapsed menu bar sections with invalid divider geometry.

* **Tests**
  * Added regression coverage for rejecting saved layouts when hidden sections have insufficient room.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->