### PR TITLE
fix(menubar): repair hidden divider boundary and layout-editor drag regressions

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -357,18 +357,25 @@ final class LayoutBarContainer: NSView {
             {
                 sourceView.oldContainerInfo = (self, sourceIndex)
             }
-            // updating normally relies on the presence of other arranged views,
-            // but if the container is empty, it needs to be handled separately
-            guard !arrangedViews.filter(\.isEnabled).isEmpty else {
-                arrangedViews.insert(sourceView, at: 0)
-                return .move
-            }
             // convert dragging location from window coordinates
             let draggingLocation = convert(draggingInfo.draggingLocation, from: nil)
             // When dragging a regular item (not the badge), exclude the badge
             // from being a swap destination. The badge position should only
             // change when the user explicitly drags the badge itself.
             let excludeBadge = !sourceView.isNewItemsBadge
+            // updating normally relies on the presence of other arranged views,
+            // but if the container has no valid swap destination it needs to be
+            // handled separately. The badge must be excluded here with the same
+            // rule as the destination search below: a section whose only
+            // occupant is the new-items badge would otherwise pass this guard,
+            // fail the destination search, and never insert the dragged view —
+            // making it impossible to drop anything into an empty section that
+            // hosts the badge.
+            guard arrangedViews.contains(where: { $0.isEnabled && !(excludeBadge && $0.isNewItemsBadge) }) else {
+                let insertionIndex = arrangedViews.firstIndex { draggingLocation.x < $0.frame.midX } ?? arrangedViews.count
+                arrangedViews.insert(sourceView, at: insertionIndex)
+                return .move
+            }
             guard
                 let destinationView = arrangedView(nearestTo: draggingLocation.x, excludingBadge: excludeBadge),
                 destinationView !== sourceView,

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -679,6 +679,84 @@ nonisolated enum LayoutSolver {
         )
     }
 
+    // MARK: - Hidden divider boundary
+
+    /// Where the hidden divider belongs, expressed relative to a live
+    /// anchor item so the orchestrator can resolve it against fresh
+    /// items at move time.
+    enum HiddenDividerAnchor: Equatable {
+        /// Place the hidden divider directly right of this item.
+        case rightOf(String)
+        /// Place the hidden divider directly left of this item.
+        case leftOf(String)
+    }
+
+    /// Counts the items sitting on the wrong side of the hidden divider.
+    ///
+    /// Phase 1's hidden↔always-hidden arithmetic cannot see these: both of
+    /// its tallies intersect against the currently-occupied hidden and
+    /// always-hidden sets, so a bar whose divider has drifted past every
+    /// managed item (leaving both sets empty) reports zero mismatch. The
+    /// LCS pass cannot see them either — it receives sequences with the
+    /// dividers stripped, so a divergence that is purely a divider
+    /// position leaves current equal to desired and plans no moves (#879).
+    ///
+    /// A non-zero count means one divider move fixes every listed item at
+    /// once, which is why this is measured separately from the per-item
+    /// reorder the LCS plans.
+    static nonisolated func hiddenBoundaryMismatch(
+        currentVisible: Set<String>,
+        currentHidden: Set<String>,
+        currentAlwaysHidden: Set<String>,
+        desiredVisible: Set<String>,
+        desiredHidden: Set<String>,
+        desiredAlwaysHidden: Set<String>
+    ) -> Int {
+        // Everything the profile places left of the hidden divider, in
+        // either of the two concealed sections. Which of the two an item
+        // lands in is the always-hidden divider's problem, handled by the
+        // AH_ctrl planning that follows this check.
+        let desiredConcealed = desiredHidden.union(desiredAlwaysHidden)
+        let currentConcealed = currentHidden.union(currentAlwaysHidden)
+
+        let wronglyVisible = currentVisible.intersection(desiredConcealed)
+        let wronglyConcealed = currentConcealed.intersection(desiredVisible)
+
+        return wronglyVisible.count + wronglyConcealed.count
+    }
+
+    /// Plans where to drag the hidden divider so the visible/hidden split
+    /// matches the profile.
+    ///
+    /// Section order runs right-to-left: index 0 of each ordered section
+    /// is its rightmost item, and items live to one side of their own
+    /// divider (visible right of the hidden divider, hidden left of it).
+    /// The divider therefore belongs immediately right of the rightmost
+    /// item the profile assigns to hidden, which is the same gap as
+    /// immediately left of the leftmost item it assigns to visible.
+    ///
+    /// Anchors to the hidden side first because that side is what the
+    /// profile is trying to repopulate; falls back to the visible side
+    /// when the profile's hidden section has no live members, so a
+    /// profile that empties the hidden section still parks the divider
+    /// past every visible item instead of leaving it mid-bar.
+    ///
+    /// Pure over its inputs. Returns nil when neither section has a live
+    /// movable member to anchor against.
+    static nonisolated func planHiddenDividerAnchor(
+        desiredHidden: [String],
+        desiredVisible: [String],
+        liveMovableUIDs: Set<String>
+    ) -> HiddenDividerAnchor? {
+        if let rightmostHidden = desiredHidden.first(where: liveMovableUIDs.contains) {
+            return .rightOf(rightmostHidden)
+        }
+        if let leftmostVisible = desiredVisible.last(where: liveMovableUIDs.contains) {
+            return .leftOf(leftmostVisible)
+        }
+        return nil
+    }
+
     // MARK: - LCS reorder
 
     /// Plans the LCS-anchored move sequence for items that need to move

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -308,11 +308,27 @@ final class MenuBarItemManager {
 
     /// The currently running "is any menu open" probe, reused so concurrent
     /// smart-rehide callers do not all trigger their own full menu-bar scan.
-    private var menuOpenCheckTask: Task<Bool, Never>?
+    /// Returns the window IDs of candidate menu windows owned by menu bar
+    /// item processes; persistence filtering happens on the actor.
+    private var menuOpenCheckTask: Task<Set<CGWindowID>, Never>?
 
     /// The most recent open-menu probe result and its timestamp.
     private var menuOpenCheckCachedResult: Bool?
     private var menuOpenCheckCachedAt: ContinuousClock.Instant?
+
+    /// First-seen timestamps for candidate menu windows, keyed by window ID.
+    /// A real menu is transient; a window that stays on screen longer than
+    /// ``menuWindowPersistenceThreshold`` is persistent furniture (Droppy's
+    /// shelf, notch HUDs) and must not block moves (#879 regression).
+    private var menuWindowFirstSeen: [CGWindowID: ContinuousClock.Instant] = [:]
+
+    /// Whether the open-menu probe has run at least once. Windows already
+    /// on screen at the first probe are grandfathered as persistent.
+    private var hasSeededMenuWindowProbe = false
+
+    /// How long a candidate menu window may stay on screen before it is
+    /// reclassified as persistent furniture rather than an open menu.
+    nonisolated static let menuWindowPersistenceThreshold: Duration = .seconds(30)
 
     /// Timer for lightweight periodic cache checks.
     private var cacheTickCancellable: AnyCancellable?
@@ -6287,13 +6303,13 @@ extension MenuBarItemManager {
 
         if let existingTask = menuOpenCheckTask {
             MenuBarItemManager.diagLog.debug("Menu open check: joining in-flight probe")
-            return await existingTask.value
+            return applyMenuWindowPersistenceFilter(to: await existingTask.value)
         }
 
         let cachedItems = itemCache.managedItems.filter(\.isOnScreen)
         let controlCenterBundleID = MenuBarItemTag.Namespace.controlCenter.description
 
-        let task = Task.detached(priority: .utility) { () -> Bool in
+        let task = Task.detached(priority: .utility) { () -> Set<CGWindowID> in
             // Get all on-screen windows.
             let windows = WindowInfo.createWindows(option: .onScreen)
             let potentialMenuWindows = windows.filter { window in
@@ -6313,7 +6329,7 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.debug(
                     "Menu open check: no candidate menu windows on screen"
                 )
-                return false
+                return []
             }
 
             let fastPathPIDs = Set(cachedItems.compactMap { item -> pid_t? in
@@ -6333,7 +6349,7 @@ extension MenuBarItemManager {
                 """
             )
 
-            let fastPathResult = potentialMenuWindows.contains { window in
+            let fastPathMatches = potentialMenuWindows.filter { window in
                 let isMenuOpen = fastPathPIDs.contains(window.ownerPID)
                 if isMenuOpen {
                     MenuBarItemManager.diagLog.debug(
@@ -6347,9 +6363,9 @@ extension MenuBarItemManager {
                 return isMenuOpen
             }
 
-            if fastPathResult {
-                MenuBarItemManager.diagLog.debug("Menu open check result: true (fast path)")
-                return true
+            if !fastPathMatches.isEmpty {
+                MenuBarItemManager.diagLog.debug("Menu open check: \(fastPathMatches.count) candidate windows (fast path)")
+                return Set(fastPathMatches.map(\.windowID))
             }
 
             let unresolvedWindows = WindowInfo.createWindows(
@@ -6365,8 +6381,8 @@ extension MenuBarItemManager {
             )
 
             guard !unresolvedWindows.isEmpty else {
-                MenuBarItemManager.diagLog.debug("Menu open check result: false (fast path)")
-                return false
+                MenuBarItemManager.diagLog.debug("Menu open check: no candidate windows (fast path)")
+                return []
             }
 
             MenuBarItemManager.diagLog.debug(
@@ -6376,7 +6392,7 @@ extension MenuBarItemManager {
             let resolvedPIDs = await MenuBarItemManager.resolveAllSourcePIDs(for: unresolvedWindows)
 
             let precisePIDs = fastPathPIDs.union(resolvedPIDs)
-            let result = potentialMenuWindows.contains { window in
+            let preciseMatches = potentialMenuWindows.filter { window in
                 let isMenuOpen = precisePIDs.contains(window.ownerPID)
                 if isMenuOpen {
                     MenuBarItemManager.diagLog.debug(
@@ -6391,14 +6407,15 @@ extension MenuBarItemManager {
             }
 
             MenuBarItemManager.diagLog.debug(
-                "Menu open check result: \(result) (precise fallback with \(resolvedPIDs.count) resolved PIDs)"
+                "Menu open check: \(preciseMatches.count) candidate windows (precise fallback with \(resolvedPIDs.count) resolved PIDs)"
             )
-            return result
+            return Set(preciseMatches.map(\.windowID))
         }
 
         menuOpenCheckTask = task
-        let result = await task.value
+        let matchedWindowIDs = await task.value
         menuOpenCheckTask = nil
+        let result = applyMenuWindowPersistenceFilter(to: matchedWindowIDs)
         // Cache negative results too: bulk move operations (applyProfileLayout)
         // call this guard once per move, and re-enumerating on-screen windows
         // for every move when no menu is open is the common, expensive case.
@@ -6406,6 +6423,66 @@ extension MenuBarItemManager {
         menuOpenCheckCachedResult = result
         menuOpenCheckCachedAt = .now
         return result
+    }
+
+    /// Updates first-seen tracking for the matched candidate windows and
+    /// returns whether any of them is fresh enough to be a real open menu.
+    private func applyMenuWindowPersistenceFilter(to matchedWindowIDs: Set<CGWindowID>) -> Bool {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: matchedWindowIDs,
+            firstSeen: menuWindowFirstSeen,
+            now: .now,
+            isFirstProbe: !hasSeededMenuWindowProbe,
+            threshold: MenuBarItemManager.menuWindowPersistenceThreshold
+        )
+        menuWindowFirstSeen = outcome.updatedFirstSeen
+        hasSeededMenuWindowProbe = true
+        if !outcome.ignoredPersistentWindowIDs.isEmpty {
+            MenuBarItemManager.diagLog.debug(
+                "Menu open check: ignoring \(outcome.ignoredPersistentWindowIDs.count) persistent candidate window(s) \(outcome.ignoredPersistentWindowIDs.sorted())"
+            )
+        }
+        MenuBarItemManager.diagLog.debug("Menu open check result: \(outcome.isMenuOpen)")
+        return outcome.isMenuOpen
+    }
+
+    /// Pure classification core for the open-menu probe: a candidate window
+    /// only counts as an open menu while it is young. Real menus are
+    /// transient; persistent status-level windows (Droppy's shelf, notch
+    /// HUDs) stay on screen for the app's whole lifetime and previously
+    /// deferred every move indefinitely. Windows already on screen at the
+    /// first probe are grandfathered as persistent, and entries for windows
+    /// that disappeared are pruned so a reused window ID starts fresh.
+    nonisolated static func classifyMenuWindowCandidates(
+        matchedWindowIDs: Set<CGWindowID>,
+        firstSeen: [CGWindowID: ContinuousClock.Instant],
+        now: ContinuousClock.Instant,
+        isFirstProbe: Bool,
+        threshold: Duration
+    ) -> (
+        isMenuOpen: Bool,
+        updatedFirstSeen: [CGWindowID: ContinuousClock.Instant],
+        ignoredPersistentWindowIDs: Set<CGWindowID>
+    ) {
+        var updatedFirstSeen = firstSeen.filter { matchedWindowIDs.contains($0.key) }
+        let firstSeenForNewWindows = isFirstProbe ? now - threshold : now
+        var isMenuOpen = false
+        var ignored = Set<CGWindowID>()
+        for windowID in matchedWindowIDs {
+            let firstSeenAt: ContinuousClock.Instant
+            if let existing = updatedFirstSeen[windowID] {
+                firstSeenAt = existing
+            } else {
+                firstSeenAt = firstSeenForNewWindows
+                updatedFirstSeen[windowID] = firstSeenAt
+            }
+            if firstSeenAt.duration(to: now) < threshold {
+                isMenuOpen = true
+            } else {
+                ignored.insert(windowID)
+            }
+        }
+        return (isMenuOpen, updatedFirstSeen, ignored)
     }
 
     private static nonisolated func resolveAllSourcePIDs(for windows: [WindowInfo]) async -> Set<pid_t> {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -306,11 +306,17 @@ final class MenuBarItemManager {
     /// Observes `appState.navigationState`'s @Observable properties (wave 3).
     private var navigationStateObservationTask: Task<Void, Never>?
 
+    /// A candidate menu window matched by the open-menu probe.
+    nonisolated struct MenuWindowCandidate: Sendable {
+        let windowID: CGWindowID
+        let bounds: CGRect
+    }
+
     /// The currently running "is any menu open" probe, reused so concurrent
     /// smart-rehide callers do not all trigger their own full menu-bar scan.
-    /// Returns the window IDs of candidate menu windows owned by menu bar
-    /// item processes; persistence filtering happens on the actor.
-    private var menuOpenCheckTask: Task<Set<CGWindowID>, Never>?
+    /// Returns the candidate menu windows owned by menu bar item processes;
+    /// persistence filtering happens on the actor.
+    private var menuOpenCheckTask: Task<[MenuWindowCandidate], Never>?
 
     /// The most recent open-menu probe result and its timestamp.
     private var menuOpenCheckCachedResult: Bool?
@@ -6309,7 +6315,7 @@ extension MenuBarItemManager {
         let cachedItems = itemCache.managedItems.filter(\.isOnScreen)
         let controlCenterBundleID = MenuBarItemTag.Namespace.controlCenter.description
 
-        let task = Task.detached(priority: .utility) { () -> Set<CGWindowID> in
+        let task = Task.detached(priority: .utility) { () -> [MenuWindowCandidate] in
             // Get all on-screen windows.
             let windows = WindowInfo.createWindows(option: .onScreen)
             let potentialMenuWindows = windows.filter { window in
@@ -6365,7 +6371,7 @@ extension MenuBarItemManager {
 
             if !fastPathMatches.isEmpty {
                 MenuBarItemManager.diagLog.debug("Menu open check: \(fastPathMatches.count) candidate windows (fast path)")
-                return Set(fastPathMatches.map(\.windowID))
+                return fastPathMatches.map { MenuWindowCandidate(windowID: $0.windowID, bounds: $0.bounds) }
             }
 
             let unresolvedWindows = WindowInfo.createWindows(
@@ -6409,7 +6415,7 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug(
                 "Menu open check: \(preciseMatches.count) candidate windows (precise fallback with \(resolvedPIDs.count) resolved PIDs)"
             )
-            return Set(preciseMatches.map(\.windowID))
+            return preciseMatches.map { MenuWindowCandidate(windowID: $0.windowID, bounds: $0.bounds) }
         }
 
         menuOpenCheckTask = task
@@ -6426,10 +6432,12 @@ extension MenuBarItemManager {
     }
 
     /// Updates first-seen tracking for the matched candidate windows and
-    /// returns whether any of them is fresh enough to be a real open menu.
-    private func applyMenuWindowPersistenceFilter(to matchedWindowIDs: Set<CGWindowID>) -> Bool {
+    /// returns whether any of them is fresh enough — or currently under the
+    /// pointer — to be a real open menu.
+    private func applyMenuWindowPersistenceFilter(to candidates: [MenuWindowCandidate]) -> Bool {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: matchedWindowIDs,
+            candidates: candidates,
+            pointerLocation: CGEvent(source: nil)?.location,
             firstSeen: menuWindowFirstSeen,
             now: .now,
             isFirstProbe: !hasSeededMenuWindowProbe,
@@ -6447,14 +6455,17 @@ extension MenuBarItemManager {
     }
 
     /// Pure classification core for the open-menu probe: a candidate window
-    /// only counts as an open menu while it is young. Real menus are
-    /// transient; persistent status-level windows (Droppy's shelf, notch
-    /// HUDs) stay on screen for the app's whole lifetime and previously
-    /// deferred every move indefinitely. Windows already on screen at the
-    /// first probe are grandfathered as persistent, and entries for windows
-    /// that disappeared are pruned so a reused window ID starts fresh.
+    /// counts as an open menu while it is young, or at any age while the
+    /// pointer is inside it (a user interacting with a long-open menu, or
+    /// mid-drop on a shelf). Real menus are transient; persistent
+    /// status-level windows (Droppy's shelf, notch HUDs) stay on screen for
+    /// the app's whole lifetime and previously deferred every move
+    /// indefinitely. Windows already on screen at the first probe are
+    /// grandfathered as persistent, and entries for windows that
+    /// disappeared are pruned so a reused window ID starts fresh.
     nonisolated static func classifyMenuWindowCandidates(
-        matchedWindowIDs: Set<CGWindowID>,
+        candidates: [MenuWindowCandidate],
+        pointerLocation: CGPoint?,
         firstSeen: [CGWindowID: ContinuousClock.Instant],
         now: ContinuousClock.Instant,
         isFirstProbe: Bool,
@@ -6464,22 +6475,25 @@ extension MenuBarItemManager {
         updatedFirstSeen: [CGWindowID: ContinuousClock.Instant],
         ignoredPersistentWindowIDs: Set<CGWindowID>
     ) {
+        let matchedWindowIDs = Set(candidates.map(\.windowID))
         var updatedFirstSeen = firstSeen.filter { matchedWindowIDs.contains($0.key) }
         let firstSeenForNewWindows = isFirstProbe ? now - threshold : now
         var isMenuOpen = false
         var ignored = Set<CGWindowID>()
-        for windowID in matchedWindowIDs {
+        for candidate in candidates {
             let firstSeenAt: ContinuousClock.Instant
-            if let existing = updatedFirstSeen[windowID] {
+            if let existing = updatedFirstSeen[candidate.windowID] {
                 firstSeenAt = existing
             } else {
                 firstSeenAt = firstSeenForNewWindows
-                updatedFirstSeen[windowID] = firstSeenAt
+                updatedFirstSeen[candidate.windowID] = firstSeenAt
             }
-            if firstSeenAt.duration(to: now) < threshold {
+            let isYoung = firstSeenAt.duration(to: now) < threshold
+            let isUnderPointer = pointerLocation.map(candidate.bounds.contains) ?? false
+            if isYoung || isUnderPointer {
                 isMenuOpen = true
             } else {
-                ignored.insert(windowID)
+                ignored.insert(candidate.windowID)
             }
         }
         return (isMenuOpen, updatedFirstSeen, ignored)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -7737,15 +7737,18 @@ extension MenuBarItemManager {
             // values for the same windowID if section.show()'s control-item
             // moves landed in between, which surfaces as an empty Phase 1
             // view of currently-occupied hidden / always-hidden sections.
+            var currentVisibleSet = Set<String>()
             var currentHiddenSet = Set<String>()
             var currentAHSet = Set<String>()
             for item in items where isProfileItem(item) {
                 switch sectionByWindowID[item.windowID] {
+                case .visible:
+                    currentVisibleSet.insert(item.uniqueIdentifier)
                 case .hidden:
                     currentHiddenSet.insert(item.uniqueIdentifier)
                 case .alwaysHidden:
                     currentAHSet.insert(item.uniqueIdentifier)
-                case .visible, nil:
+                case nil:
                     break
                 }
             }
@@ -7754,8 +7757,10 @@ extension MenuBarItemManager {
             let desiredAHSet = Set(itemOrder["alwaysHidden"] ?? [])
             // Logged for the log-replay harness so the desired visible set is
             // captured rather than inferred from current visible minus control
-            // items and unresolved orphans. Not consulted by Phase 1's section
-            // arithmetic, which only crosses hidden and always-hidden.
+            // items and unresolved orphans. Also feeds the hidden-divider
+            // boundary check below; the crossSectionMoves / totalSectionMismatch
+            // arithmetic that follows still only crosses hidden and
+            // always-hidden.
             let desiredVisibleSet = Set(itemOrder["visible"] ?? [])
 
             // Check if AH_ctrl needs to move: items changing between hidden↔alwaysHidden.
@@ -7776,6 +7781,25 @@ extension MenuBarItemManager {
             let needsHiddenMove = currentAHSet.intersection(desiredHiddenSet)
             let needsAHMove = currentHiddenSet.intersection(desiredAHSet)
             let totalSectionMismatch = needsHiddenMove.count + needsAHMove.count
+
+            // Items on the wrong side of H_ctrl. Both tallies above intersect
+            // against currentHiddenSet / currentAHSet, so a bar whose hidden
+            // divider has drifted past every managed item — leaving both sets
+            // empty while the profile wants a full hidden section — scores
+            // zero on both and falls through to the LCS. The LCS is blind to
+            // it too: the dividers are stripped from its sequences, so a
+            // divider-only divergence leaves current equal to desired and
+            // plans no moves, and the apply reports "all items already in
+            // correct positions" while the whole hidden section stays visible
+            // (#879). One H_ctrl move fixes every one of them.
+            let hiddenBoundaryMismatch = LayoutSolver.hiddenBoundaryMismatch(
+                currentVisible: currentVisibleSet,
+                currentHidden: currentHiddenSet,
+                currentAlwaysHidden: currentAHSet,
+                desiredVisible: desiredVisibleSet,
+                desiredHidden: desiredHiddenSet,
+                desiredAlwaysHidden: desiredAHSet
+            )
 
             // Format contract: parsed by ProfileLayoutLogReplayTests.parse(_:).
             // Changing this string breaks log-replay regression tests.
@@ -7803,6 +7827,63 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug(
                 "Profile layout Phase 1: desiredVisible=\(desiredVisibleSet.sorted())"
             )
+            // Format contract: parsed by ProfileLayoutLogReplayTests.parse(_:).
+            // Changing this string breaks log-replay regression tests.
+            MenuBarItemManager.diagLog.debug(
+                "Profile layout Phase 1: hiddenBoundaryMismatch=\(hiddenBoundaryMismatch)"
+            )
+
+            // ── Sub-phase 0: Move H_ctrl to the visible/hidden boundary ──
+            //
+            // Runs before the AH_ctrl placement so the always-hidden planning
+            // below sees a divider pair that already brackets the right set of
+            // items. Both dividers move by the same mechanism: one drag that
+            // re-sections everything it crosses, which is why neither is left
+            // to the per-item LCS pass.
+            if hiddenBoundaryMismatch > 0, !Task.isCancelled {
+                MenuBarItemManager.diagLog.debug(
+                    "Profile layout: \(hiddenBoundaryMismatch) item(s) on the wrong side of H_ctrl, moving H_ctrl to the boundary"
+                )
+
+                let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+                let liveMovableUIDs = Set(
+                    allFreshItems.lazy.filter { $0.isMovable && isProfileItem($0) }.map(\.uniqueIdentifier)
+                )
+                let anchor = LayoutSolver.planHiddenDividerAnchor(
+                    desiredHidden: itemOrder["hidden"] ?? [],
+                    desiredVisible: itemOrder["visible"] ?? [],
+                    liveMovableUIDs: liveMovableUIDs
+                )
+
+                if let hItem = allFreshItems.first(where: { $0.uniqueIdentifier == hiddenCtrlUID }),
+                   let anchor
+                {
+                    let anchorUID = switch anchor {
+                    case let .rightOf(uid), let .leftOf(uid): uid
+                    }
+                    if let anchorItem = allFreshItems.first(where: { $0.uniqueIdentifier == anchorUID }) {
+                        let dest: MoveDestination = switch anchor {
+                        case .rightOf: .rightOfItem(anchorItem)
+                        case .leftOf: .leftOfItem(anchorItem)
+                        }
+                        MenuBarItemManager.diagLog.debug("Profile layout: moving H_ctrl → \(dest.logString)")
+                        do {
+                            try await move(item: hItem, to: dest, skipInputPause: true)
+                            movedCount += 1
+                            try? await Task.sleep(for: .milliseconds(200))
+                        } catch {
+                            MenuBarItemManager.diagLog.error("Profile layout: failed to move H_ctrl: \(error)")
+                        }
+                    }
+                } else {
+                    // No live movable member on either side to anchor against;
+                    // the LCS pass below still runs against whatever ordering
+                    // divergence remains.
+                    MenuBarItemManager.diagLog.warning(
+                        "Profile layout: no anchor available for the H_ctrl boundary move"
+                    )
+                }
+            }
 
             if crossSectionMoves > 0 || totalSectionMismatch > 0, let ahCtrlUID {
                 // Moving AH_ctrl to the correct position is 1 move that

--- a/ThawTests/MenuBar/Items/MenuOpenProbePersistenceTests.swift
+++ b/ThawTests/MenuBar/Items/MenuOpenProbePersistenceTests.swift
@@ -1,0 +1,111 @@
+//
+//  MenuOpenProbePersistenceTests.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+/// Tests for the pure persistence classification behind
+/// `isAnyMenuBarItemMenuOpen()` (#879 regression): a candidate menu window
+/// only counts as an open menu while it is young. Persistent status-level
+/// windows (Droppy's shelf, notch HUDs) previously matched the probe for
+/// the app's whole lifetime and deferred every move indefinitely.
+@Suite("Menu open probe persistence classification")
+struct MenuOpenProbePersistenceTests {
+    private let threshold = MenuBarItemManager.menuWindowPersistenceThreshold
+    private let start = ContinuousClock.now
+
+    @Test("No candidates means no open menu")
+    func noCandidates() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [],
+            firstSeen: [:],
+            now: start,
+            isFirstProbe: true,
+            threshold: threshold
+        )
+        #expect(!outcome.isMenuOpen)
+        #expect(outcome.updatedFirstSeen.isEmpty)
+    }
+
+    @Test("Windows present at the first probe are grandfathered as persistent")
+    func firstProbeGrandfathers() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [50],
+            firstSeen: [:],
+            now: start,
+            isFirstProbe: true,
+            threshold: threshold
+        )
+        #expect(!outcome.isMenuOpen)
+        #expect(outcome.ignoredPersistentWindowIDs == [50])
+    }
+
+    @Test("A window appearing after the first probe is a fresh menu")
+    func freshWindowIsMenu() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [60],
+            firstSeen: [:],
+            now: start,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(outcome.isMenuOpen)
+        #expect(outcome.ignoredPersistentWindowIDs.isEmpty)
+        #expect(outcome.updatedFirstSeen[60] == start)
+    }
+
+    @Test("A tracked window becomes persistent once it outlives the threshold")
+    func trackedWindowAges() {
+        let firstSeen: [CGWindowID: ContinuousClock.Instant] = [60: start]
+
+        let young = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [60],
+            firstSeen: firstSeen,
+            now: start + threshold - .seconds(1),
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(young.isMenuOpen)
+
+        let old = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [60],
+            firstSeen: firstSeen,
+            now: start + threshold,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(!old.isMenuOpen)
+        #expect(old.ignoredPersistentWindowIDs == [60])
+    }
+
+    @Test("Entries for windows that disappeared are pruned so reused IDs start fresh")
+    func prunesClosedWindows() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [70],
+            firstSeen: [60: start - threshold, 70: start],
+            now: start,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(outcome.updatedFirstSeen[60] == nil)
+        #expect(outcome.updatedFirstSeen[70] == start)
+    }
+
+    @Test("A fresh menu alongside a persistent window still reports open")
+    func freshAndPersistentMix() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            matchedWindowIDs: [50, 90],
+            firstSeen: [50: start - threshold],
+            now: start,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(outcome.isMenuOpen)
+        #expect(outcome.ignoredPersistentWindowIDs == [50])
+    }
+}

--- a/ThawTests/MenuBar/Items/MenuOpenProbePersistenceTests.swift
+++ b/ThawTests/MenuBar/Items/MenuOpenProbePersistenceTests.swift
@@ -11,18 +11,24 @@ import Testing
 
 /// Tests for the pure persistence classification behind
 /// `isAnyMenuBarItemMenuOpen()` (#879 regression): a candidate menu window
-/// only counts as an open menu while it is young. Persistent status-level
-/// windows (Droppy's shelf, notch HUDs) previously matched the probe for
-/// the app's whole lifetime and deferred every move indefinitely.
+/// counts as an open menu while it is young, or at any age while the
+/// pointer is inside it. Persistent status-level windows (Droppy's shelf,
+/// notch HUDs) previously matched the probe for the app's whole lifetime
+/// and deferred every move indefinitely.
 @Suite("Menu open probe persistence classification")
 struct MenuOpenProbePersistenceTests {
     private let threshold = MenuBarItemManager.menuWindowPersistenceThreshold
     private let start = ContinuousClock.now
 
+    private func candidate(_ windowID: CGWindowID, x: CGFloat = 0) -> MenuBarItemManager.MenuWindowCandidate {
+        .init(windowID: windowID, bounds: CGRect(x: x, y: 0, width: 100, height: 100))
+    }
+
     @Test("No candidates means no open menu")
     func noCandidates() {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [],
+            candidates: [],
+            pointerLocation: nil,
             firstSeen: [:],
             now: start,
             isFirstProbe: true,
@@ -35,7 +41,8 @@ struct MenuOpenProbePersistenceTests {
     @Test("Windows present at the first probe are grandfathered as persistent")
     func firstProbeGrandfathers() {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [50],
+            candidates: [candidate(50)],
+            pointerLocation: nil,
             firstSeen: [:],
             now: start,
             isFirstProbe: true,
@@ -48,7 +55,8 @@ struct MenuOpenProbePersistenceTests {
     @Test("A window appearing after the first probe is a fresh menu")
     func freshWindowIsMenu() {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [60],
+            candidates: [candidate(60)],
+            pointerLocation: nil,
             firstSeen: [:],
             now: start,
             isFirstProbe: false,
@@ -64,7 +72,8 @@ struct MenuOpenProbePersistenceTests {
         let firstSeen: [CGWindowID: ContinuousClock.Instant] = [60: start]
 
         let young = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [60],
+            candidates: [candidate(60)],
+            pointerLocation: nil,
             firstSeen: firstSeen,
             now: start + threshold - .seconds(1),
             isFirstProbe: false,
@@ -73,7 +82,8 @@ struct MenuOpenProbePersistenceTests {
         #expect(young.isMenuOpen)
 
         let old = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [60],
+            candidates: [candidate(60)],
+            pointerLocation: nil,
             firstSeen: firstSeen,
             now: start + threshold,
             isFirstProbe: false,
@@ -83,10 +93,39 @@ struct MenuOpenProbePersistenceTests {
         #expect(old.ignoredPersistentWindowIDs == [60])
     }
 
+    @Test("A persistent window under the pointer still counts as an open menu")
+    func persistentWindowUnderPointerDefers() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            candidates: [candidate(60)],
+            pointerLocation: CGPoint(x: 50, y: 50),
+            firstSeen: [60: start - threshold],
+            now: start,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(outcome.isMenuOpen)
+        #expect(outcome.ignoredPersistentWindowIDs.isEmpty)
+    }
+
+    @Test("A persistent window with the pointer elsewhere is ignored")
+    func persistentWindowPointerOutsideIgnored() {
+        let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
+            candidates: [candidate(60)],
+            pointerLocation: CGPoint(x: 500, y: 500),
+            firstSeen: [60: start - threshold],
+            now: start,
+            isFirstProbe: false,
+            threshold: threshold
+        )
+        #expect(!outcome.isMenuOpen)
+        #expect(outcome.ignoredPersistentWindowIDs == [60])
+    }
+
     @Test("Entries for windows that disappeared are pruned so reused IDs start fresh")
     func prunesClosedWindows() {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [70],
+            candidates: [candidate(70)],
+            pointerLocation: nil,
             firstSeen: [60: start - threshold, 70: start],
             now: start,
             isFirstProbe: false,
@@ -99,7 +138,8 @@ struct MenuOpenProbePersistenceTests {
     @Test("A fresh menu alongside a persistent window still reports open")
     func freshAndPersistentMix() {
         let outcome = MenuBarItemManager.classifyMenuWindowCandidates(
-            matchedWindowIDs: [50, 90],
+            candidates: [candidate(50), candidate(90, x: 200)],
+            pointerLocation: nil,
             firstSeen: [50: start - threshold],
             now: start,
             isFirstProbe: false,

--- a/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
+++ b/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
@@ -1,0 +1,354 @@
+//
+//  HiddenDividerBoundaryTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Covers the hidden-divider boundary check that applyProfileLayout's
+/// Phase 1 runs before the always-hidden divider placement.
+///
+/// The boundary check exists because neither of the two mechanisms that
+/// preceded it can see a divider that has drifted past every managed item:
+///
+/// - Phase 1's `crossSectionMoves` / `totalSectionMismatch` tallies both
+///   intersect against the currently-occupied hidden and always-hidden
+///   sets, so a bar where both are empty scores zero on both.
+/// - The LCS pass receives sequences with the dividers stripped, so a
+///   divergence that is purely a divider position leaves current equal to
+///   desired and plans no moves.
+///
+/// Together those produced #879: every hidden item classified visible, and
+/// the apply reported "all items already in correct positions".
+@Suite("Hidden divider boundary")
+struct HiddenDividerBoundaryTests {
+    // MARK: - Mismatch counting
+
+    /// A bar that already matches the profile scores zero, so the divider
+    /// move never runs on a healthy layout.
+    @Test("A layout that matches the profile reports no boundary mismatch")
+    func matchingLayoutReportsNoMismatch() {
+        let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c"],
+            currentAlwaysHidden: ["d"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c"],
+            desiredAlwaysHidden: ["d"]
+        )
+
+        #expect(mismatch == 0)
+    }
+
+    /// An item the profile assigns to hidden but that currently classifies
+    /// visible is on the wrong side of the divider and must be counted.
+    @Test("An item that should be hidden but reads visible counts")
+    func itemThatShouldBeHiddenCounts() {
+        let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: ["a", "b"],
+            currentHidden: [],
+            currentAlwaysHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: ["b"],
+            desiredAlwaysHidden: []
+        )
+
+        #expect(mismatch == 1)
+    }
+
+    /// The reverse direction counts too: the divider can drift the other
+    /// way and swallow items the profile wants visible.
+    @Test("An item that should be visible but reads hidden counts")
+    func itemThatShouldBeVisibleCounts() {
+        let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: [],
+            currentHidden: ["a", "b"],
+            currentAlwaysHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: ["b"],
+            desiredAlwaysHidden: []
+        )
+
+        #expect(mismatch == 1)
+    }
+
+    /// Always-hidden counts as concealed for this check. Which of the two
+    /// concealed sections an item lands in is the always-hidden divider's
+    /// problem, handled by the AH_ctrl planning that follows; the hidden
+    /// divider only decides concealed versus visible.
+    @Test("Hidden and always-hidden are one side for this check")
+    func hiddenAndAlwaysHiddenCountAsOneSide() {
+        // Every item is concealed, and every item is meant to be
+        // concealed — they are merely in the wrong concealed section.
+        let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: [],
+            currentHidden: ["a"],
+            currentAlwaysHidden: ["b"],
+            desiredVisible: [],
+            desiredHidden: ["b"],
+            desiredAlwaysHidden: ["a"]
+        )
+
+        #expect(mismatch == 0,
+                "a hidden↔always-hidden swap is the AH_ctrl planner's job, not the hidden divider's")
+    }
+
+    /// Items the profile does not mention are unmanaged arrivals routed by
+    /// planUnmanagedPlacement, so they must not drag the divider.
+    @Test("An item absent from the profile does not count")
+    func unmanagedItemDoesNotCount() {
+        let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: ["a", "newcomer"],
+            currentHidden: [],
+            currentAlwaysHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: [],
+            desiredAlwaysHidden: []
+        )
+
+        #expect(mismatch == 0)
+    }
+
+    // MARK: - Anchor planning
+
+    /// Section order runs right-to-left, so index 0 of the hidden section
+    /// is its rightmost item and the divider belongs immediately right of
+    /// it — the gap between the hidden and visible groups.
+    @Test("The anchor is the rightmost live hidden item")
+    func anchorsToRightmostHiddenItem() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: ["h1", "h2", "h3"],
+            desiredVisible: ["v1", "v2"],
+            liveMovableUIDs: ["h1", "h2", "h3", "v1", "v2"]
+        )
+
+        #expect(anchor == .rightOf("h1"))
+    }
+
+    /// A profile lists items that are not running right now. The anchor
+    /// has to be an item actually on the bar, so the planner walks inward
+    /// from the rightmost until it finds one.
+    @Test("A hidden item that is not running is skipped as an anchor")
+    func skipsHiddenItemsThatAreNotLive() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: ["notRunning", "h2", "h3"],
+            desiredVisible: ["v1"],
+            liveMovableUIDs: ["h2", "h3", "v1"]
+        )
+
+        #expect(anchor == .rightOf("h2"))
+    }
+
+    /// With nothing live on the hidden side the divider still has to end
+    /// up left of every visible item, so it anchors to the leftmost one —
+    /// the last entry in the visible order.
+    @Test("An empty hidden side anchors left of the leftmost visible item")
+    func fallsBackToLeftmostVisibleItem() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: ["notRunning"],
+            desiredVisible: ["v1", "v2", "v3"],
+            liveMovableUIDs: ["v1", "v2", "v3"]
+        )
+
+        #expect(anchor == .leftOf("v3"))
+    }
+
+    /// Nothing live on either side leaves no anchor to drag against; the
+    /// caller logs and falls through to the LCS pass rather than guessing.
+    @Test("No live item on either side yields no anchor")
+    func noLiveItemYieldsNoAnchor() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: ["h1"],
+            desiredVisible: ["v1"],
+            liveMovableUIDs: []
+        )
+
+        #expect(anchor == nil)
+    }
+
+    // MARK: - Field replay (#879)
+
+    /// Replays the Phase 1 sets captured in the #879 field log, where the
+    /// reporter's hidden section emptied into visible after upgrading from
+    /// 2.0.0-rc.1 to rc.2 and could not be restored.
+    ///
+    /// The log's own numbers were `crossSectionMoves=0`,
+    /// `totalSectionMismatch=0`, verdict "all items already in correct
+    /// positions" — with 29 items in `desiredHidden` and none in
+    /// `currentHidden`.
+    @Suite("Issue 879 field log")
+    struct Issue879FieldLog {
+        /// The 28 items the log reported in the visible section, in the
+        /// order it reported them (index 0 rightmost).
+        static let currentVisible = [
+            "com.stonerl.Thaw:Thaw.ControlItem.Visible",
+            "com.robinlu.mac.Tooth-Fairy:Item-0",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.network",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.cpu",
+            "app.updatest.Updatest:Item-0",
+            "com.techsmith.snagit.capturehelper:Item-0",
+            "com.1password.1password:bb3cc23c-6950-4e96-8b40-850e09f46934",
+            "com.rogueamoeba.soundsource:SSMainAppMenuIcon",
+            "85C27NK92C.com.flexibits.fantastical2.mac.helper:Fantastical",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.time",
+            "com.apphousekitchen.aldente-pro:Item-0",
+            "de.kuatsu.consul:Item-0",
+            "pro.betterdisplay.BetterDisplay:Item-0",
+            "com.malwarebytes.mbam.frontend.agent:Item-0",
+            "com.onmyway133.PastePal:Item-0",
+            "com.microsoft.OneDrive-mac:Item-0",
+            "86Z3GCJ4MF.com.noodlesoft.HazelHelper:Item-0",
+            "org.amnezia.awg:Item-0",
+            "com.elgato.StreamDeck:Item-0",
+            "com.DigiDNA.iMazing2Mac.Mini:Item-0",
+            "net.ericmann.parachute:Item-0",
+            "io.robbie.HomeAssistant:Item-0",
+            "com.apple.controlcenter:WiFi",
+            "com.apple.controlcenter:Bluetooth",
+            "com.purevpn.app.mac:Item-0",
+            "com.valerijs.boguckis.gumroad.TextSniper:Item-0",
+            "com.econtechnologies.backgrounder.chronosync:Item-0",
+            "com.raycast.macos:extension_auto-quit-app_auto-quit-app-menubar__e77dadf4-2dd6-4fd8-9041-d67068b934ae",
+        ]
+
+        /// The profile's hidden section as the log printed it. The Phase 1
+        /// lines log sorted sets, so this is membership only — tests that
+        /// depend on section *order* use synthetic fixtures instead.
+        static let desiredHidden: Set<String> = [
+            "86Z3GCJ4MF.com.noodlesoft.HazelHelper:Item-0",
+            "app.loshadki.OpenIn.v4:Item-0",
+            "com.DigiDNA.iMazing2Mac.Mini:Item-0",
+            "com.Tweaking4all.ConnectMeNow4:Item-0",
+            "com.apphousekitchen.aldente-pro:Item-0",
+            "com.apple.controlcenter:Bluetooth",
+            "com.apple.controlcenter:WiFi",
+            "com.econtechnologies.backgrounder.chronosync:Item-0",
+            "com.elgato.StreamDeck:Item-0",
+            "com.expandrive.ExpanDrive:Item-0",
+            "com.logi.cp-dev-mgr:Item-0",
+            "com.malwarebytes.mbam.frontend.agent:Item-0",
+            "com.microsoft.OneDrive-mac:Item-0",
+            "com.onmyway133.PastePal:Item-0",
+            "com.openai.codex:Item-0",
+            "com.pdfeditor.pdfeditormac:Item-0",
+            "com.purevpn.app.mac:Item-0",
+            "com.raycast.macos:extension_auto-quit-app_auto-quit-app-menubar__e77dadf4-2dd6-4fd8-9041-d67068b934ae",
+            "com.tweety.MediaMate:Item-1",
+            "com.valerijs.boguckis.gumroad.TextSniper:Item-0",
+            "de.kuatsu.consul:Item-0",
+            "io.getpurge.app:Item-0",
+            "io.robbie.HomeAssistant:Item-0",
+            "net.ericmann.parachute:Item-0",
+            "nz.co.pixeleyes.AutoMounter:Item-0",
+            "org.amnezia.awg:Item-0",
+            "org.mozilla.firefox:Item-0",
+            "org.mozilla.firefox:Item-1",
+            "pro.betterdisplay.BetterDisplay:Item-0",
+        ]
+
+        /// The profile's visible section as the log printed it.
+        static let desiredVisible: Set<String> = [
+            "85C27NK92C.com.flexibits.fantastical2.mac.helper:Fantastical",
+            "app.updatest.Updatest:Item-0",
+            "com.1password.1password:bb3cc23c-6950-4e96-8b40-850e09f46934",
+            "com.apple.controlcenter:BentoBox-0",
+            "com.apple.controlcenter:Clock",
+            "com.apple.controlcenter:FocusModes",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.cpu",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.network",
+            "com.bjango.istatmenus.status:com.bjango.istatmenus.time",
+            "com.robinlu.mac.Tooth-Fairy:Item-0",
+            "com.rogueamoeba.soundsource:SSMainAppMenuIcon",
+            "com.stonerl.Thaw:Thaw.ControlItem.Visible",
+            "com.techsmith.snagit.capturehelper:Item-0",
+        ]
+
+        /// Every item on the bar belongs to exactly one of the profile's two
+        /// sections, and the bar's order already groups them: the 10 items
+        /// bound for visible occupy the rightmost 10 slots and the 18 bound
+        /// for hidden occupy the rest. Nothing is interleaved and nothing is
+        /// unmanaged. The layout is not scrambled — only the divider is in
+        /// the wrong place.
+        @Test("The bar is cleanly partitioned; only the divider is misplaced")
+        func barIsCleanlyPartitioned() {
+            let boundVisible = Self.currentVisible.filter(Self.desiredVisible.contains)
+            let boundHidden = Self.currentVisible.filter(Self.desiredHidden.contains)
+
+            #expect(boundVisible.count == 10)
+            #expect(boundHidden.count == 18)
+            #expect(boundVisible + boundHidden == Self.currentVisible,
+                    "the bar is already grouped visible-then-hidden, so only H_ctrl sits in the wrong gap")
+        }
+
+        /// The LCS pass is handed sequences with the dividers stripped. The
+        /// bar's grouping means those two sequences are identical, so the
+        /// planner returns no moves — reproducing the log's "all items
+        /// already in correct positions" verdict.
+        ///
+        /// This is a characterization test, not a regression: the fix does
+        /// not change what the LCS sees. It pins the blindness the boundary
+        /// check exists to compensate for.
+        @Test("The LCS pass plans no moves, as the field log reported")
+        func lcsPlansNoMoves() {
+            let desiredNoControls = Self.currentVisible.filter(Self.desiredVisible.contains)
+                + Self.currentVisible.filter(Self.desiredHidden.contains)
+
+            var sectionMap = [String: String]()
+            for uid in Self.desiredVisible {
+                sectionMap[uid] = "visible"
+            }
+            for uid in Self.desiredHidden {
+                sectionMap[uid] = "hidden"
+            }
+
+            let moves = LayoutSolver.planLCSMoveSequence(
+                currentNoControls: Self.currentVisible,
+                desiredNoControls: desiredNoControls,
+                sectionMap: sectionMap
+            )
+
+            #expect(moves.isEmpty,
+                    "with the dividers stripped the two sequences coincide, so the LCS sees nothing to do")
+        }
+
+        /// The boundary check does see it: 18 items the profile assigns to
+        /// hidden are classifying visible. That non-zero count is what makes
+        /// Phase 1 drag H_ctrl instead of concluding the bar is correct.
+        @Test("The boundary check counts all 18 items stranded in visible")
+        func boundaryCheckCountsStrandedItems() {
+            let mismatch = LayoutSolver.hiddenBoundaryMismatch(
+                currentVisible: Set(Self.currentVisible),
+                currentHidden: [],
+                currentAlwaysHidden: [],
+                desiredVisible: Self.desiredVisible,
+                desiredHidden: Self.desiredHidden,
+                desiredAlwaysHidden: []
+            )
+
+            #expect(mismatch == 18)
+        }
+
+        /// The reporter had no always-hidden section, so `ahCtrlUID` was nil
+        /// and Phase 1's existing repair branch — which is bound on that
+        /// optional — could not have run even had its tallies been non-zero.
+        /// The boundary move must not carry the same gate.
+        @Test("The boundary is repairable without an always-hidden divider")
+        func repairDoesNotDependOnAlwaysHiddenDivider() {
+            let live = Set(Self.currentVisible)
+            let anchor = LayoutSolver.planHiddenDividerAnchor(
+                // Profile order for the hidden section, reconstructed from the
+                // bar: the 18 stranded items in the order they sit on it.
+                desiredHidden: Self.currentVisible.filter(Self.desiredHidden.contains),
+                desiredVisible: Self.currentVisible.filter(Self.desiredVisible.contains),
+                liveMovableUIDs: live
+            )
+
+            #expect(anchor == .rightOf("com.apphousekitchen.aldente-pro:Item-0"),
+                    "H_ctrl belongs immediately right of the rightmost hidden item")
+        }
+    }
+}


### PR DESCRIPTION
# Summary

Fixes layout-editor drag-back and hidden-section boundary drift reported in #879. Repairs the visible/hidden divider when `H_ctrl` drifts before per-item moves run, allows drops into empty sections that only contain the new-items badge, and refines the open-menu deferral guard so permanent status-level windows (shelf/HUD) no longer block every move while still deferring when the user is actively interacting with a menu.

**Scope:** This PR changes one focused thing (bug fix or feature) plus minimal plumbing. Larger refactors need prior agreement in the issue.

> We are on the process of migrating from XCTest to Swift Test. If you are adding new tests, please use Swift Test.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

## Linked issue (required)

PR Metadata fails without a `Closes:` line in this exact form (keep it on its own line):

```text
Closes: #879
```

Replace `N/A` with `#<issue_number>` (e.g. `Closes: #123`) when this PR fixes/implements a specific issue.

Closes: #879

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use `bug` on issues; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- **Hidden divider repair:** Before the per-item reorder pass, measure the visible/hidden boundary and drag `H_ctrl` to the correct anchor when it has drifted. This fixes cases where `applyProfileLayout` reported "all items already in correct positions" while the whole hidden section was misplaced.
- **Empty-section drops:** The layout editor now treats the new-items badge like other non-item views when deciding whether a section is empty, so dragging into an empty hidden section no longer snaps back.
- **Open-menu deferral:** Status/popup-level windows that have been on screen longer than 30s (or were present at first probe) are treated as persistent furniture and no longer defer every move. Windows that close are pruned so reused IDs start fresh. While the pointer is inside a persistent candidate window, moves still defer so an automated reorder cannot tear down a menu the user is interacting with.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `HiddenDividerBoundaryTests`
- `MenuOpenProbePersistenceTests`

## Known limitations / follow-ups

- The 30s persistence threshold is a heuristic; apps with transient menus that stay open longer than that may no longer defer moves until the pointer enters the window bounds.

## Other information

Four commits on this branch, replaying the #879 field log as `HiddenDividerBoundaryTests`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved dragging behavior for menu sections containing only the new-items badge.
  * Menu items now remain correctly positioned around hidden-item dividers during layout updates.
  * Enhanced detection of newly opened menus while avoiding disruptions from persistent or disappearing windows.
  * Improved recovery when hidden items become stranded on the wrong side of a divider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->