### PR TITLE
fix(settings): reset every persisted AdvancedSettings boolean

### DIFF
--- a/Thaw/Settings/Models/SettingsResetter.swift
+++ b/Thaw/Settings/Models/SettingsResetter.swift
@@ -52,16 +52,23 @@ extension AppSettings {
     /// Resets Advanced settings to their default values.
     func resetAdvanced() {
         advanced.enableAlwaysHiddenSection = Defaults.DefaultValue.enableAlwaysHiddenSection
+        advanced.useOptionClickToShowAlwaysHiddenSection = Defaults.DefaultValue.useOptionClickToShowAlwaysHiddenSection
+        advanced.useDoubleClickToShowAlwaysHiddenSection = Defaults.DefaultValue.useDoubleClickToShowAlwaysHiddenSection
         advanced.showAllSectionsOnUserDrag = Defaults.DefaultValue.showAllSectionsOnUserDrag
         appState?.itemManager.updateNewItemsPlacement(section: .hidden, arrangedViews: [])
         advanced.sectionDividerStyle = Defaults.DefaultValue.sectionDividerStyle
         advanced.hideApplicationMenus = Defaults.DefaultValue.hideApplicationMenus
         advanced.enableSecondaryContextMenu = Defaults.DefaultValue.enableSecondaryContextMenu
+        advanced.enableSecondaryContextMenuQuit = Defaults.DefaultValue.enableSecondaryContextMenuQuit
         advanced.showOnHoverDelay = Defaults.DefaultValue.showOnHoverDelay
         advanced.tooltipDelay = Defaults.DefaultValue.tooltipDelay
         advanced.showMenuBarTooltips = Defaults.DefaultValue.showMenuBarTooltips
         advanced.iconRefreshInterval = Defaults.DefaultValue.iconRefreshInterval
         advanced.enableDiagnosticLogging = Defaults.DefaultValue.enableDiagnosticLogging
+        advanced.useLCSSortingOnNotchedDisplays = Defaults.DefaultValue.useLCSSortingOnNotchedDisplays
+        advanced.enableMenuBarItemOverflow = Defaults.DefaultValue.enableMenuBarItemOverflow
+        advanced.useThawBarOnNotchOverflow = Defaults.DefaultValue.useThawBarOnNotchOverflow
+        advanced.useAXClickDelivery = Defaults.DefaultValue.useAXClickDelivery
         advanced.searchSectionOrder = AdvancedSettings.sanitizedSearchSectionOrder(
             from: Defaults.DefaultValue.searchSectionOrder
         )

--- a/ThawTests/Settings/Models/SettingsResetterTests.swift
+++ b/ThawTests/Settings/Models/SettingsResetterTests.swift
@@ -105,6 +105,41 @@ struct SettingsResetterTests {
         }
     }
 
+    /// Regression: `resetAdvanced()` used to omit seven persisted
+    /// `AdvancedSettings` booleans, so a reset silently left them at whatever
+    /// the user had toggled them to. Each previously-omitted boolean is flipped
+    /// off its default, reset, then checked back to `Defaults.DefaultValue`.
+    /// `hideApplicationMenus` and `showMenuBarTooltips` stay in as controls —
+    /// they already reset before the fix and must keep doing so.
+    @Test("Resetting Advanced restores every persisted boolean")
+    func resetAdvancedRestoresEveryBoolean() throws {
+        try withSettings { settings in
+            // Previously-omitted booleans — flip each off its default.
+            settings.advanced.useOptionClickToShowAlwaysHiddenSection = !Defaults.DefaultValue.useOptionClickToShowAlwaysHiddenSection
+            settings.advanced.useDoubleClickToShowAlwaysHiddenSection = !Defaults.DefaultValue.useDoubleClickToShowAlwaysHiddenSection
+            settings.advanced.enableSecondaryContextMenuQuit = !Defaults.DefaultValue.enableSecondaryContextMenuQuit
+            settings.advanced.useLCSSortingOnNotchedDisplays = !Defaults.DefaultValue.useLCSSortingOnNotchedDisplays
+            settings.advanced.enableMenuBarItemOverflow = !Defaults.DefaultValue.enableMenuBarItemOverflow
+            settings.advanced.useThawBarOnNotchOverflow = !Defaults.DefaultValue.useThawBarOnNotchOverflow
+            settings.advanced.useAXClickDelivery = !Defaults.DefaultValue.useAXClickDelivery
+            // Controls — already reset before the fix; keep them covered.
+            settings.advanced.hideApplicationMenus = !Defaults.DefaultValue.hideApplicationMenus
+            settings.advanced.showMenuBarTooltips = !Defaults.DefaultValue.showMenuBarTooltips
+
+            settings.resetAdvanced()
+
+            #expect(settings.advanced.useOptionClickToShowAlwaysHiddenSection == Defaults.DefaultValue.useOptionClickToShowAlwaysHiddenSection)
+            #expect(settings.advanced.useDoubleClickToShowAlwaysHiddenSection == Defaults.DefaultValue.useDoubleClickToShowAlwaysHiddenSection)
+            #expect(settings.advanced.enableSecondaryContextMenuQuit == Defaults.DefaultValue.enableSecondaryContextMenuQuit)
+            #expect(settings.advanced.useLCSSortingOnNotchedDisplays == Defaults.DefaultValue.useLCSSortingOnNotchedDisplays)
+            #expect(settings.advanced.enableMenuBarItemOverflow == Defaults.DefaultValue.enableMenuBarItemOverflow)
+            #expect(settings.advanced.useThawBarOnNotchOverflow == Defaults.DefaultValue.useThawBarOnNotchOverflow)
+            #expect(settings.advanced.useAXClickDelivery == Defaults.DefaultValue.useAXClickDelivery)
+            #expect(settings.advanced.hideApplicationMenus == Defaults.DefaultValue.hideApplicationMenus)
+            #expect(settings.advanced.showMenuBarTooltips == Defaults.DefaultValue.showMenuBarTooltips)
+        }
+    }
+
     // MARK: Hotkeys
 
     @Test("Resetting Hotkeys clears every binding")


### PR DESCRIPTION
## Summary
- "Reset all settings" (AdvancedSettingsPane → `resetAllSettingsToDefaults()` → `resetAdvanced()`) now reverts **every** persisted `AdvancedSettings` property, not 14 of 21.
- Seven persisted booleans were previously omitted, so toggling any of them off its default and resetting silently left it changed.

## Linked issue (required)

Closes: N/A

Self-found defect; no issue is filed. Happy to open one first if you'd prefer that order.

## Root cause
`AdvancedSettings` persists 21 properties (each with a `didSet` writing to `Defaults`). `SettingsResetter.resetAdvanced()` reset only 14 of them; the other seven — `useOptionClickToShowAlwaysHiddenSection`, `useDoubleClickToShowAlwaysHiddenSection`, `enableSecondaryContextMenuQuit`, `useLCSSortingOnNotchedDisplays`, `enableMenuBarItemOverflow`, `useThawBarOnNotchOverflow`, `useAXClickClickDelivery` — were never restored, so the reset button no-op'd for exactly those flags.

## Changes
- `Thaw/Settings/Models/SettingsResetter.swift` — add the seven missing one-line resets, grouped thematically next to their neighbours, each reading from `Defaults.DefaultValue.<key>` (no hardcoded literals → no drift if a default changes).
- `ThawTests/Settings/Models/SettingsResetterTests.swift` — `resetAdvancedRestoresEveryBoolean`: flips all seven previously-omitted booleans off-default (plus two already-reset controls proving `resetAdvanced()` actually ran), calls `resetAdvanced()`, and asserts each reverts to its default. RED before / GREEN after; pure model logic over a scratch `Defaults` store, no UI.

## Test plan
- [x] `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — **1953 tests, all green** (full suite passes).
- [x] `swiftlint lint --strict` — **0 violations**.
- [x] Verified by enumeration that all 21 persisted `AdvancedSettings` properties are now covered by `resetAdvanced()` (14 prior + 7 added), no duplicates, no transient properties touched.

## PR Type
- [x] Bug fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/910"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788822786&installation_model_id=431242&pr_number=910&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F910&signature=8ced732e8602e309c1f255d8b77ea6296c90aec6f8aaf671a7cb80df70edf01e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resetting advanced settings now correctly restores all advanced options to their defaults, including menu bar behavior, display sorting, context-menu quitting, and accessibility click delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
