### PR TITLE
fix(settings): include leftAligned/rightAligned in iceBarLocation valid values

### DIFF
--- a/Thaw/Utilities/SettingsURIHandler.swift
+++ b/Thaw/Utilities/SettingsURIHandler.swift
@@ -952,7 +952,13 @@ enum SettingsURIHandler {
     }
 
     /// Gets a single setting value with metadata.
-    private static func getSettingValue(key: String, displayUUID: String?) -> [String: Any]? {
+    ///
+    /// `internal` rather than `private` so the test suite can pin the
+    /// `validValues` maps a `thaw://get` advertises. The function is a read
+    /// with no delivery side effects, so calling it directly never opens a
+    /// callback URL or posts a distributed notification — the two actions the
+    /// get suite otherwise avoids.
+    static func getSettingValue(key: String, displayUUID: String?) -> [String: Any]? {
         // Handle per-display keys specially (not in keyMapping)
         if perDisplayKeys.contains(key) {
             // Validate display UUID if provided
@@ -972,7 +978,7 @@ enum SettingsURIHandler {
                     "value": String(describing: config.iceBarLocation),
                     "rawValue": config.iceBarLocation.rawValue,
                     "type": "enum",
-                    "validValues": ["dynamic": 0, "mousePointer": 1, "iceIcon": 2],
+                    "validValues": ["dynamic": 0, "mousePointer": 1, "iceIcon": 2, "leftAligned": 3, "rightAligned": 4],
                 ]
             case "alwaysShowHiddenItems":
                 return [

--- a/ThawTests/Settings/URI/SettingsURIHandlerGetTests.swift
+++ b/ThawTests/Settings/URI/SettingsURIHandlerGetTests.swift
@@ -22,21 +22,28 @@ import Testing
 /// handler would accept, precisely so the suite never opens a URL or launches
 /// another app.
 ///
-/// Two shapes of assertion appear below:
+/// Three shapes of assertion appear below:
 ///
 /// - the Boolean the handler returns, which is its contract with the URL
-///   dispatcher, and
+///   dispatcher,
 /// - the in-process notification the per-display lookups post, whose `userInfo`
-///   carries the scope and value the handler resolved.
+///   carries the scope and value the handler resolved, and
+/// - a direct call into `getSettingValue`, used once to pin the `validValues`
+///   map a `thaw://get?key=iceBarLocation` advertises after it silently
+///   dropped two enum cases.
 ///
-/// The response *body* is deliberately not asserted, because it is not
-/// observable: the full payload only ever travels down a callback URL — which
-/// would mean opening a URL and launching another app — and the broadcast
-/// alternative goes out through `distnoted`, which does not deliver back into
-/// the test host. What is asserted instead is the Boolean: a broadcast request
-/// reports success only when it produced data, the same way a callback request
-/// does, and no response, however shaped, talks its way past callback
-/// validation.
+/// The response *body* is not asserted through its delivery channels, because
+/// it is not observable that way: the full payload only ever travels down a
+/// callback URL — which would mean opening a URL and launching another app —
+/// and the broadcast alternative goes out through `distnoted`, which does not
+/// deliver back into the test host. The one body-level assertion, the
+/// `iceBarLocation valid values` test, calls `getSettingValue` directly
+/// instead: that function is a read with no delivery side effects, so pinning
+/// its return advertises the map without ever opening a URL or posting a
+/// distributed notification. Everywhere else, what is asserted is the Boolean:
+/// a broadcast request reports success only when it produced data, the same way
+/// a callback request does, and no response, however shaped, talks its way past
+/// callback validation.
 ///
 /// Every test body runs inside `withScratchDefaults`, so the handler's reads
 /// and writes go to a throwaway store rather than the real `com.stonerl.Thaw`
@@ -408,6 +415,35 @@ struct SettingsURIHandlerGetTests {
                     "\(key)"
                 )
             }
+        }
+    }
+
+    // MARK: iceBarLocation valid values
+
+    @Test("iceBarLocation advertises every IceBarLocation case, including leftAligned and rightAligned")
+    func iceBarLocationGetListsAllValidValues() throws {
+        try withScratchDefaults { _ in
+            let uuid = UUID().uuidString
+            try persistConfiguration(.defaultConfiguration, forUUID: uuid)
+
+            // The validValues map drifted to three entries when IceBarLocation
+            // grew from three to five cases, so leftAligned and rightAligned
+            // could no longer be discovered through thaw://get. Drive the
+            // expectation from IceBarLocation itself so a future case can never
+            // silently drop out of the advertised set the way these two did.
+            let value = try #require(
+                SettingsURIHandler.getSettingValue(key: "iceBarLocation", displayUUID: uuid)
+            )
+            let validValues = try #require(value["validValues"] as? [String: Int])
+
+            #expect(validValues.count == IceBarLocation.allCases.count)
+            for location in IceBarLocation.allCases {
+                #expect(validValues[String(describing: location)] == location.rawValue, "\(location)")
+            }
+
+            // Pin the two cases that were missing before the fix in plain terms.
+            #expect(validValues["leftAligned"] == 3)
+            #expect(validValues["rightAligned"] == 4)
         }
     }
 


### PR DESCRIPTION
## Summary
- `thaw://get?key=iceBarLocation` now advertises all five `IceBarLocation` cases, not three.
- `leftAligned` (3) and `rightAligned` (4) were silently dropped from the `validValues` map, so they were undiscoverable and unsettable through the URL `get` API — even though the `set` path already accepted them (`IceBarLocation.fromString` handles all five).

## Linked issue (required)

Closes: N/A

Self-found defect; no issue is filed. Happy to open one first if you'd prefer that order.

## Root cause
`SettingsURIHandler.getSettingValue` builds a hand-written `validValues` dictionary for `iceBarLocation`. It was never updated when `IceBarLocation` grew from 3 cases (`dynamic`, `mousePointer`, `iceIcon`) to 5 (`leftAligned`, `rightAligned` added), so the `get` response listed only the original three — an asymmetry with the `set` path.

## Changes
- `Thaw/Utilities/SettingsURIHandler.swift` — add `leftAligned: 3` and `rightAligned: 4` to the `iceBarLocation` `validValues` map (raw values verbatim from `IceBarLocation`). `getSettingValue` is widened from `private` to `internal` so the read can be asserted directly from the test module (`@testable import` does not reach `private`); it is a pure read with no side effects.
- `ThawTests/Settings/URI/SettingsURIHandlerGetTests.swift` — a Swift Testing case that drives its expectations from `IceBarLocation.allCases`: asserts the map has the same count as the enum, that each case's raw value matches, and explicitly pins `leftAligned == 3` / `rightAligned == 4`. RED before (count 3 ≠ 5, missing keys) / GREEN after; this also guards future drift if the enum grows again.

Other `validValues` maps (`IceBarLayout`, `RehideStrategy`) were verified unchanged and not drifted.

## Test plan
- [x] `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO` — **1953 tests, all green**.
- [x] `swiftlint lint --strict` — **0 violations**.

## PR Type
- [x] Bug fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/911"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788822934&installation_model_id=431242&pr_number=911&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F911&signature=ee7419e1ae0c39e5819d3b90e07ed895bb40d654ea709e3ef79c29ab788e5098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Settings metadata now recognizes the left-aligned and right-aligned ice bar locations.
  * Settings value retrieval and broadcast behavior continue to provide accurate results and callbacks.

* **Tests**
  * Expanded coverage for Boolean, notification, direct-value, and ice bar location settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
