### PR TITLE
fix(ui): guard IceGradient.averageColor against an all-nil sample count

### DIFF
--- a/Thaw/UI/Utilities/IceGradient.swift
+++ b/Thaw/UI/Utilities/IceGradient.swift
@@ -157,6 +157,16 @@ nonisolated struct IceGradient: Codable, Hashable {
             count += 1
         }
 
+        // No sample contributed components — for example, a gradient whose
+        // stops cannot be interpolated into an NSGradient — so there is
+        // nothing to average. Dividing by the zero count below would hand
+        // back a CGColor whose components are all NaN, which reads as a
+        // valid color to every caller and poisons whatever it is blended
+        // into. Mirrors the same guard in ``CGImage.averageColor``.
+        guard count > 0 else {
+            return nil
+        }
+
         var components: [CGFloat] = [
             totals.red / count,
             totals.green / count,

--- a/ThawTests/Utilities/IceGradientAverageColorTests.swift
+++ b/ThawTests/Utilities/IceGradientAverageColorTests.swift
@@ -1,0 +1,72 @@
+//
+//  IceGradientAverageColorTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Covers `IceGradient.averageColor(using:option:)`.
+///
+/// The averaging loop divides the summed RGBA components by the number of
+/// samples that contributed components. The empty-count guard added next to
+/// that division mirrors the one already present in
+/// ``CGImage.averageColor``: dividing by a zero count yields a `CGColor`
+/// whose components are all `NaN`, which reads as a valid color to every
+/// caller and poisons whatever it is blended into.
+///
+/// That guard is defensive depth. On macOS the samples are produced by
+/// interpolating an `NSGradient`, and once the gradient is non-empty the
+/// interpolation always returns a color with usable components, so the count
+/// is never zero in practice. The cases below therefore lock the two
+/// reachable contracts — an empty gradient averages to `nil`, and a
+/// non-empty gradient averages to a color with no `NaN`/infinite components
+/// — which is the user-visible behavior the guard exists to preserve.
+@Suite("IceGradient average color")
+@MainActor
+struct IceGradientAverageColorTests {
+    // MARK: Empty gradient
+
+    @Test("An empty gradient averages to nil")
+    func emptyGradientReturnsNil() {
+        #expect(IceGradient(stops: []).averageColor() == nil)
+    }
+
+    // MARK: Non-empty gradient
+
+    @Test("A non-empty gradient averages to a color with finite components")
+    func nonEmptyGradientReturnsFiniteColor() {
+        let gradient = IceGradient(stops: [
+            .white(location: 0),
+            .black(location: 1),
+        ])
+
+        let average = gradient.averageColor()
+        let components = average?.components ?? []
+
+        // The averaged color must never carry NaN or infinite components,
+        // which is the exact failure mode the empty-count guard prevents.
+        #expect(average != nil)
+        #expect(!components.isEmpty)
+        for component in components {
+            #expect(component.isFinite)
+        }
+    }
+
+    @Test("A single-stop gradient still averages to a finite color")
+    func singleStopGradientReturnsFiniteColor() {
+        let gradient = IceGradient(stops: [.white(location: 0)])
+
+        let average = gradient.averageColor()
+        let components = average?.components ?? []
+
+        #expect(average != nil)
+        #expect(!components.isEmpty)
+        for component in components {
+            #expect(component.isFinite)
+        }
+    }
+}


### PR DESCRIPTION
# Summary

`IceGradient.averageColor(using:option:)` divides its summed RGBA components by a `count` that could
be `0`, which would return a non-nil `CGColor` whose components are all `NaN`. This adds the same
`guard count > 0 else { return nil }` that the sibling `CGImage.averageColor` already has (with the
same explanatory comment), plus the first Swift Testing suite for `IceGradient`.

**Scope:** one guard in `Thaw/UI/Utilities/IceGradient.swift` + a new test file. No sampling or
`color(at:)` logic changes.

## Linked issue (required)

Closes: N/A

Self-found latent-defect hardening that mirrors an already-merged sibling guard (`CGImage.averageColor`
in `Thaw/Utilities/Extensions.swift`). No issue is filed; opening/linking one is the maintainer's call
(see *Known limitations*).

## PR Type

- [x] Bug fix

## Area

- [x] appearance

(`IceGradient.averageColor` feeds the menu bar item tint at `MenuBarItemContainer.swift:91`. The
file lives under `UI/Utilities`; `appearance` is the closest product surface.)

## Does this PR introduce a breaking change?

- [x] No

## What is the new behavior?

**Before.** The averaging loop summed RGBA components into `count`-weighted totals, then built the
result with `totals.x / count`. If no sample contributed components — `count == 0` — the division
produced `NaN`, yet a non-nil color was returned. A `NaN` color reads as valid to every caller and
poisons whatever it is blended into. The identical mechanism was already fixed for `CGImage.averageColor`
(transparent images drop every pixel below the alpha threshold), which carries this comment:

> Dividing by the zero count below would hand back a CGColor whose components are all NaN, which
> reads as a valid color to every caller and poisons whatever it is blended into.

**After.** A `guard count > 0 else { return nil }` sits immediately before the component-averaging
construction, with a comment mirroring the sibling's:

```swift
// No sample contributed components — for example, a gradient whose
// stops cannot be interpolated into an NSGradient — so there is
// nothing to average. Dividing by the zero count below would hand
// back a CGColor whose components are all NaN, which reads as a
// valid color to every caller and poisons whatever it is blended
// into. Mirrors the same guard in ``CGImage.averageColor``.
guard count > 0 else {
    return nil
}
```

The only caller (`MenuBarItemContainer.tintGradient.averageColor()`) is unaffected for every
reachable input: the `count > 0` branch is byte-for-byte unchanged, so the returned tint color is
identical to before.

**Honest reachability note.** On macOS, `averageColor` always resolves a valid RGB working space and
the samples come from interpolating an `NSGradient`, whose `interpolatedColor(atLocation:)` always
returns a color with usable components. Probed exhaustively against the linked `AppKit`/`CoreGraphics`
SDK: `NSGradient(colors:atLocations:colorSpace:)` never returns `nil` (even for empty colors or
NaN/out-of-range/duplicate locations), `NSColor(cgColor:)` accepts every constructible color, and
`NSColorSpace(cgColorSpace:)` accepts every constructible RGB space. So `count` is never `0` for any
`IceGradient` built from public inputs — this is a latent divide-by-zero, not a practically
triggerable crash. The guard is defensive depth that removes the footgun and keeps the two averaging
paths consistent.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
      *(Built via `xcodebuild` and exercised through the test suite; the GUI app was **not** launched.
      The change has no effect on any reachable input, so a GUI run would not observe a difference.)*
- [x] I've run `swiftformat .` to keep the code style consistent. *(Run on the two touched files only;
      pre-existing drift on untouched files was not staged, per the contribution guide.)*
- [x] I've run the smallest relevant test commands (list 1–2 below).
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers. *(Guard carries a mechanism comment.)*
- [ ] I've updated documentation as needed. *(N/A — no user-facing docs.)*
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles … *(N/A — no deps changed.)*

Test commands run:

- `swiftlint lint --strict` → 0 violations in 167 files.
- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -derivedDataPath Build/ -destination 'platform=macOS' CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO` → `** TEST SUCCEEDED **`, 1955 tests in 252 suites passed (0 failures).

## Known limitations / follow-ups

- **No textbook RED test.** Because `count == 0` is not reachable from public inputs on macOS, a
  RED-then-GREEN test (NaN at HEAD → nil after) cannot be honestly produced. The new suite instead
  locks the two reachable contracts: an empty gradient averages to `nil`, and a non-empty gradient
  averages to a color with **no** `NaN`/infinite components (white→black, and the single-stop edge).
  Faking a RED would over-claim verification, which this repo rejects.
- **Issue link.** Filed as `Closes: N/A`; maintainer may prefer a tracking issue for this and the
  sibling guard (or may consider it not worth a PR since the path is unreachable — happy to drop if so).
- GUI not exercised (see checklist caveat).

## Other information

- First test coverage for `IceGradient` (`ThawTests/Utilities/IceGradientAverageColorTests.swift`,
  Swift Testing, `@MainActor`, 3 tests). The suite's doc comment records that the `count > 0` guard is
  defensive depth and why it is not input-reachable, so a future reader does not hunt for a trigger.
- DCO-signed (`Signed-off-by`); `Co-Authored-By: Claude` trailer added (AI-assisted, transparent,
  does not affect DCO).
- Verified the code defect at HEAD and the fix against the merged sibling guard in
  `CGImage.averageColor`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/914"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788832491&installation_model_id=431242&pr_number=914&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F914&signature=b12aa16bc15d35a6f873c226901d8e2ca8d7d858466f499f50dafcacac5dd297"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved color averaging for empty gradients by returning no color instead of an invalid result.
  * Preserved accurate color results for single-stop and multi-stop gradients.

* **Tests**
  * Added coverage for empty, single-stop, and two-stop gradients.
  * Verified returned color components are valid and finite.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->