### PR TITLE
fix(ui): guard IceBar color sample against full-screen divide-by-zero

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -222,6 +222,25 @@ final class IceBarColorManager {
         windowImage = image
     }
 
+    /// The horizontal position (`0...1`) of the bar's center within the screen,
+    /// used to sample the wallpaper/menu-bar color at the matching offset.
+    ///
+    /// `insetScreenFrame` is the screen inset by half the bar width on each
+    /// side, so its width collapses to zero when a horizontal bar overflows to
+    /// the full screen width — a state the bar itself detects at
+    /// `frame.width == screen.frame.width` (see `IceBar.swift`). Dividing by
+    /// that zero width yields `NaN`, which then drives `cropRect.x` and makes
+    /// the color sample at a garbage offset (or stop updating) instead of the
+    /// bar's actual center. The guard falls back to the panel's middle so the
+    /// degenerate case still samples a sensible color.
+    static func colorSamplePercentage(frame: CGRect, screenFrame: CGRect) -> CGFloat {
+        let insetScreenFrame = screenFrame.insetBy(dx: frame.width / 2, dy: 0)
+        guard insetScreenFrame.width > 0 else {
+            return 0.5
+        }
+        return ((frame.midX - insetScreenFrame.minX) / insetScreenFrame.width).clamped(to: 0 ... 1)
+    }
+
     private func updateColorInfo(with frame: CGRect, screen: NSScreen) {
         guard let image = windowImage else {
             return
@@ -229,8 +248,7 @@ final class IceBarColorManager {
 
         let imageBounds = CGRect(x: 0, y: 0, width: image.width, height: image.height)
 
-        let insetScreenFrame = screen.frame.insetBy(dx: frame.width / 2, dy: 0)
-        let percentage = ((frame.midX - insetScreenFrame.minX) / insetScreenFrame.width).clamped(to: 0 ... 1)
+        let percentage = Self.colorSamplePercentage(frame: frame, screenFrame: screen.frame)
 
         let cropRect = CGRect(x: imageBounds.width * percentage, y: 0, width: 0, height: 1)
             .insetBy(dx: -150, dy: 0)

--- a/ThawTests/IceBar/IceBarColorManagerTests.swift
+++ b/ThawTests/IceBar/IceBarColorManagerTests.swift
@@ -1,0 +1,97 @@
+//
+//  IceBarColorManagerTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+/// Covers `IceBarColorManager.colorSamplePercentage(frame:screenFrame:)`.
+///
+/// The percentage maps the bar's horizontal center onto the screen so the
+/// wallpaper/menu-bar color is sampled at the matching offset. The math
+/// divides by the width of the screen frame inset by half the bar width on
+/// each side. When a horizontal IceBar overflows to the full screen width —
+/// a state the bar itself detects at `frame.width == screen.frame.width`
+/// (see `IceBar.swift`) — that inset frame collapses to zero width and the
+/// division is by zero. The resulting `NaN` flows into `cropRect.x`, so the
+/// color is sampled at a garbage offset (or stops updating) instead of the
+/// bar's actual center. The guard falls back to `0.5` (the panel's middle)
+/// in that degenerate case, which is what these tests lock in.
+@Suite("IceBar color sample percentage")
+@MainActor
+struct IceBarColorManagerTests {
+    // MARK: Full-width overflow (regression)
+
+    @Test("A full-width bar samples the panel middle instead of dividing by zero")
+    func fullWidthBarSamplesMiddle() {
+        let screenWidth: CGFloat = 1920
+        let screenFrame = CGRect(x: 0, y: 0, width: screenWidth, height: 1080)
+
+        // The bar has overflowed to span the entire screen: this is the exact
+        // state that collapses the inset frame to zero width and previously
+        // divided by zero.
+        let fullWidthFrame = CGRect(x: 0, y: 0, width: screenWidth, height: 28)
+
+        let percentage = IceBarColorManager.colorSamplePercentage(
+            frame: fullWidthFrame,
+            screenFrame: screenFrame
+        )
+
+        // No NaN/infinity, and the panel's middle is sampled.
+        #expect(percentage.isFinite)
+        #expect(percentage == 0.5)
+    }
+
+    // MARK: Normal (non-degenerate) positioning
+
+    @Test("A centered bar samples the screen middle")
+    func centeredBarSamplesMiddle() {
+        let screenWidth: CGFloat = 1920
+        let screenFrame = CGRect(x: 0, y: 0, width: screenWidth, height: 1080)
+
+        // A 600pt bar centered horizontally on the screen.
+        let barWidth: CGFloat = 600
+        let centeredFrame = CGRect(
+            x: (screenWidth - barWidth) / 2,
+            y: 0,
+            width: barWidth,
+            height: 28
+        )
+
+        let percentage = IceBarColorManager.colorSamplePercentage(
+            frame: centeredFrame,
+            screenFrame: screenFrame
+        )
+
+        #expect(percentage.isFinite)
+        #expect(percentage == 0.5)
+    }
+
+    @Test("A bar at the right edge samples toward the right")
+    func rightEdgeBarSamplesRight() {
+        let screenWidth: CGFloat = 1920
+        let screenFrame = CGRect(x: 0, y: 0, width: screenWidth, height: 1080)
+
+        let barWidth: CGFloat = 600
+        let rightFrame = CGRect(
+            x: screenWidth - barWidth,
+            y: 0,
+            width: barWidth,
+            height: 28
+        )
+
+        let percentage = IceBarColorManager.colorSamplePercentage(
+            frame: rightFrame,
+            screenFrame: screenFrame
+        )
+
+        #expect(percentage.isFinite)
+        #expect(percentage > 0.5)
+        #expect(percentage <= 1)
+    }
+}


### PR DESCRIPTION
# Summary

Guard IceBar adaptive/tint color sampling against divide-by-zero when a horizontal IceBar overflows to full screen width. Extract the percentage math into a testable helper that falls back to `0.5` (panel center) when the inset screen frame collapses to zero width, and add Swift Testing coverage for the full-width boundary plus normal centered/right-edge positioning.

**Scope:** This PR changes one focused thing (bug fix) plus minimal plumbing. Larger refactors need prior agreement in the issue.

> We are on the process of migrating from XCTest to Swift Test. If you are adding new tests, please use Swift Test.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

## Linked issue (required)

PR Metadata fails without a `Closes:` line in this exact form (keep it on its own line):

```text
Closes: N/A
```

Replace `N/A` with `#<issue_number>` (e.g. `Closes: #123`) when this PR fixes/implements a specific issue.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use the `Bug` Issue type; bug *fixes* use `Fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config — not a product surface.

- [ ] menubar
- [x] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

`IceBarColorManager.updateColorInfo(with:screen:)` maps the bar’s horizontal center onto the screen to sample wallpaper/menu-bar color. It divided by the width of the screen frame inset by half the bar width on each side. When a horizontal IceBar overflows to full screen width (`frame.width == screen.frame.width` — the same state that enables scroll mode), that inset frame is zero wide, so the division yields `NaN` and color sampling lands at a garbage offset (or stops updating).

This change extracts the percentage math into `colorSamplePercentage(frame:screenFrame:)`, guards the zero-width case with a `0.5` fallback (geometrically correct for a full-width bar), and leaves the non-degenerate path equivalent to the original expression. New Swift Testing suite covers the full-width regression plus centered and right-edge positioning.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild -scheme Thaw -destination 'platform=macOS' build CODE_SIGNING_ALLOWED=NO`
- `xcodebuild -scheme Thaw -destination 'platform=macOS' test -only-testing:ThawTests/IceBarColorManagerTests CODE_SIGNING_ALLOWED=NO`

## Known limitations / follow-ups

- Only `IceBarColorManager`’s percentage math and its tests were touched — no changes to `IceGradient.averageColor`, `MenuBarItems`, `Events`, `LayoutSolver`, or color thresholds.
- Bare `xcodebuild … build` without `CODE_SIGNING_ALLOWED=NO` may fail locally when no Mac Development signing identity is present; that is an environment constraint, not a code defect.

## Other information

Files changed:

- `Thaw/MenuBar/IceBar/IceBarColorManager.swift` — extracted `colorSamplePercentage(frame:screenFrame:)` with the zero-width guard
- `ThawTests/IceBar/IceBarColorManagerTests.swift` — new Swift Testing suite (3 cases)