### PR TITLE
fix(ui): round averageColor alpha threshold up to honor the >= contract

### DIFF
--- a/Thaw/Utilities/Extensions.swift
+++ b/Thaw/Utilities/Extensions.swift
@@ -139,8 +139,13 @@ nonisolated extension CGImage {
             return nil
         }
 
-        // Convert the alpha threshold to a valid component for comparison.
-        let alphaThreshold = UInt64((alphaThreshold.clamped(to: 0 ... 1) * 255).rounded(.toNearestOrAwayFromZero))
+        // Convert the normalised [0, 1] threshold to an 8-bit component for the
+        // byte-wise comparison below. A pixel contributes when its alpha is
+        // greater than or equal to the threshold, so the smallest byte that can
+        // satisfy `byte >= 255 * threshold` is its ceiling; rounding to nearest
+        // would drop the boundary pixel whenever the fractional part of
+        // `255 * threshold` is below one half.
+        let alphaThreshold = UInt64((alphaThreshold.clamped(to: 0 ... 1) * 255).rounded(.up))
 
         var count = UInt64(width * height)
         var totals: (r: UInt64, g: UInt64, b: UInt64, a: UInt64) = (0, 0, 0, 0)

--- a/ThawTests/Utilities/CGImageAnalysisTests.swift
+++ b/ThawTests/Utilities/CGImageAnalysisTests.swift
@@ -106,6 +106,26 @@ struct CGImageAnalysisTests {
         #expect(image.averageColor(alphaThreshold: 0) != nil)
     }
 
+    @Test("A pixel just below the alpha threshold is excluded (round up, not to nearest)")
+    func pixelJustBelowThresholdIsExcluded() throws {
+        // A fill alpha of 0.334 quantises to the alpha byte round(0.334 * 255) = 85,
+        // i.e. a normalised alpha of 85 / 255 ≈ 0.3333 — strictly below 0.334.
+        let image = try makeCanvas(width: 4, height: 4) { context in
+            context.setFillColor(red: 1, green: 0, blue: 0, alpha: 0.334)
+            context.fill(CGRect(x: 0, y: 0, width: 4, height: 4))
+        }
+
+        // By the documented contract — "pixels with an alpha component greater
+        // than or equal to this value contribute" — every pixel is below the
+        // threshold, so the average must be nil. The byte threshold is therefore
+        // ceil(0.334 * 255) = 86; rounding to nearest would give 85 and wrongly
+        // admit these pixels, returning a spurious non-nil color.
+        #expect(image.averageColor(alphaThreshold: 0.334) == nil)
+
+        // Control: the pixels really do exist — a threshold of 0 admits them.
+        #expect(image.averageColor(alphaThreshold: 0) != nil)
+    }
+
     @Test("An explicit RGB color space is honored")
     func explicitColorSpaceIsUsed() throws {
         let image = try makeCanvas(width: 4, height: 4) { context in


### PR DESCRIPTION
Closes: N/A

Functional bug fix. See commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788899424&installation_model_id=431242&pr_number=917&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F917&signature=45d54886c68643dcbcb8fea6d1bf80e0940280792081d7586167a229057896fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image color analysis at alpha thresholds.
  * Pixels exactly matching the configured threshold are now handled consistently, including low-opacity values.

* **Tests**
  * Added regression coverage for threshold behavior at zero and fractional alpha values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->