### PR TITLE
fix(search): correct inverted title/keywords weights in settings search

### DIFF
--- a/Thaw/Settings/Search/SearchRanker.swift
+++ b/Thaw/Settings/Search/SearchRanker.swift
@@ -10,8 +10,10 @@
 
 /// Field weights for a fuzzy-search `Searchable` conformance.
 ///
-/// Fuse's diff score gets *worse* (higher) as weight increases, so a lower
-/// weight value means a match in that field ranks the result higher. Not
+/// Fuse scales a field's diff score by `(1 - weight)` (a weight of `1`
+/// leaves it unchanged), and a lower diff score ranks the result higher —
+/// so a *higher* weight value means a match in that field ranks the result
+/// higher. Not
 /// every search surface has all three fields — menu bar item search, for
 /// example, has no keywords or description — so callers simply omit the
 /// `FuseProp` for any field they don't have.
@@ -23,7 +25,7 @@ nonisolated struct SearchWeights {
     /// The weighting used by the settings sidebar search
     /// (``SearchModel``): a title match ranks above a keywords
     /// match, which ranks above a description match.
-    static let settings = SearchWeights(title: 0.3, keywords: 0.6, description: 1.0)
+    static let settings = SearchWeights(title: 0.6, keywords: 0.3, description: 1.0)
 
     /// The weighting used by menu bar item search (``MenuBarSearchPanel``),
     /// which only matches on the item's display name. `1.0` is Ifrit's

--- a/ThawTests/Settings/Search/SearchRankerTests.swift
+++ b/ThawTests/Settings/Search/SearchRankerTests.swift
@@ -1,0 +1,48 @@
+//
+//  SearchRankerTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+//
+
+import Testing
+@testable import Thaw
+
+@Suite("Search ranker")
+struct SearchRankerTests {
+    // MARK: - Settings Weights
+
+    /// Ifrit scales a field's diff score by `(1 - weight)` (a weight of `1`
+    /// is a no-op), and a lower diff score ranks the result higher. A field
+    /// therefore ranks higher the *larger* its weight is.
+    ///
+    /// The regression these tests pin: `SearchWeights.settings` used to hand
+    /// the smaller weight to `title` and the larger one to `keywords`, which
+    /// — under Ifrit's "higher weight ranks higher" contract — made a keyword
+    /// match outrank a title match: the opposite of the documented intent
+    /// ("a title match ranks above a keywords match, which ranks above a
+    /// description match"). The factor is derived here rather than read from
+    /// Fuse so this stays a pure, Ifrit-free unit test.
+    private static func rankingFactor(forWeight weight: Double) -> Double {
+        weight == 1 ? 1 : 1 - weight
+    }
+
+    @Test("Settings weights rank a title match above a keywords match")
+    func settingsWeightsRankTitleAboveKeywords() {
+        let weights = SearchWeights.settings
+        let titleFactor = Self.rankingFactor(forWeight: weights.title)
+        let keywordsFactor = Self.rankingFactor(forWeight: weights.keywords)
+        // A smaller factor → a lower diff score → a higher rank.
+        #expect(titleFactor < keywordsFactor, "title must rank above keywords")
+    }
+
+    @Test("Settings weights rank a keywords match above a description match")
+    func settingsWeightsRankKeywordsAboveDescription() {
+        let weights = SearchWeights.settings
+        let keywordsFactor = Self.rankingFactor(forWeight: weights.keywords)
+        let descriptionFactor = Self.rankingFactor(forWeight: weights.description)
+        #expect(keywordsFactor < descriptionFactor, "keywords must rank above description")
+    }
+}


### PR DESCRIPTION
Closes: N/A

Functional bug fix. See commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788899429&installation_model_id=431242&pr_number=918&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F918&signature=d6efdaf8ee660a8558c028523ba1666abc812e186d838d545e8fc6bac5d05b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved Settings search relevance so title matches rank highest, followed by keyword and description matches.

* **Tests**
  * Added coverage to verify the expected search ranking order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->