### PR TITLE
fix(menubar): preserve order of rightOfAnchor items sharing one anchor

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutReconciler.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutReconciler.swift
@@ -372,6 +372,16 @@ nonisolated enum LayoutReconciler {
 
         // Pass 2: .newItemAnchored placements. Insert relative to
         // the anchor in desiredFiltered (left or right per relation).
+        // Track how many items have already been placed to the right of
+        // each anchor. `.leftOfAnchor` inserts *before* the anchor, which
+        // shifts the anchor right on every pass, so `firstIndex(of:)`
+        // resolves to the new position and successive leftOf items land
+        // after the previous one — preserving their unmanagedUIDs order.
+        // `.rightOfAnchor` inserts *after* the anchor, which leaves the
+        // anchor's index unchanged, so without this offset every rightOf
+        // item would re-derive the same `anchorIdx + 1` slot and reverse
+        // the group's relative order.
+        var rightOfAnchorInserted = [String: Int]()
         for uid in unmanagedUIDs {
             if case let .newItemAnchored(section, anchorUID, relation) = placements[uid] {
                 // Guards the caller invariant: see pass 1.
@@ -380,15 +390,25 @@ nonisolated enum LayoutReconciler {
                 }
                 let sectionEnd = sectionEndIndex(for: section)
                 let insertIdx: Int
+                var placedRightOfAnchor = false
                 switch relation {
                 case .leftOfAnchor, .rightOfAnchor:
                     if let anchorIdx = desiredFiltered.firstIndex(of: anchorUID) {
-                        let anchored = relation == .leftOfAnchor ? anchorIdx : anchorIdx + 1
+                        // Advance rightOf past the items already placed right
+                        // of this anchor so the group keeps its order, the way
+                        // leftOf does for free via the shifting anchor index.
+                        let offset = relation == .rightOfAnchor
+                            ? rightOfAnchorInserted[anchorUID, default: 0]
+                            : 0
+                        let anchored = relation == .leftOfAnchor
+                            ? anchorIdx
+                            : anchorIdx + 1 + offset
                         // The anchor uid is not guaranteed to live in the
                         // section this placement names, and the sectionMap
                         // entry below commits to that section regardless.
                         // Clamp so position and label cannot disagree.
                         insertIdx = min(max(anchored, sectionStartIndex(for: section)), sectionEnd)
+                        placedRightOfAnchor = (relation == .rightOfAnchor)
                     } else {
                         insertIdx = sectionEnd
                     }
@@ -399,6 +419,9 @@ nonisolated enum LayoutReconciler {
                     insertIdx = sectionEnd
                 }
                 desiredFiltered.insert(uid, at: insertIdx)
+                if placedRightOfAnchor {
+                    rightOfAnchorInserted[anchorUID, default: 0] += 1
+                }
                 sectionMap[uid] = sectionKeyString(for: section)
             }
         }

--- a/ThawTests/MenuBar/Layout/LayoutReconcilerUnmanagedPlacementTests.swift
+++ b/ThawTests/MenuBar/Layout/LayoutReconcilerUnmanagedPlacementTests.swift
@@ -232,6 +232,92 @@ struct LayoutReconcilerUnmanagedPlacementTests {
         ])
     }
 
+    // MARK: - Pass 2: multiple anchored placements sharing one anchor
+    //
+    // `LayoutSolver.planUnmanagedPlacement` gives every unmanaged item that
+    // lacks a saved position the *same* `.newItemAnchored` placement — the
+    // user's configured NewItemsPlacement anchor — so several items sharing
+    // one anchor is the common case, not an edge case. These tests pin the
+    // contract that the group keeps its unmanagedUIDs relative order, which
+    // mirrors the order-preservation guarantee Pass 3 states explicitly.
+
+    @Test("Several rightOfAnchor placements sharing one anchor keep their unmanagedUIDs order")
+    func rightOfAnchorPlacementsPreserveUnmanagedOrder() {
+        // Inserting after the anchor does not shift it, so a naive rightOf
+        // pass re-derives the same `anchorIdx + 1` slot on every iteration
+        // and reverses the group ([anchor, second, first] instead of
+        // [anchor, first, second]). The pass must advance past the items
+        // already placed right of the anchor.
+        let result = apply(
+            placements: [
+                "app:first": .newItemAnchored(
+                    section: .visible,
+                    anchorUID: "app:anchor",
+                    relation: .rightOfAnchor
+                ),
+                "app:second": .newItemAnchored(
+                    section: .visible,
+                    anchorUID: "app:anchor",
+                    relation: .rightOfAnchor
+                ),
+            ],
+            unmanagedUIDs: ["app:first", "app:second"],
+            desiredFiltered: [Self.chevron, "app:anchor", Self.hiddenControl]
+        )
+
+        #expect(result.desiredFiltered == [
+            Self.chevron, "app:anchor", "app:first", "app:second", Self.hiddenControl,
+        ])
+        #expect(result.sectionMap["app:first"] == "visible")
+        #expect(result.sectionMap["app:second"] == "visible")
+    }
+
+    @Test("Three rightOfAnchor placements sharing one anchor keep their order")
+    func rightOfAnchorPreservesOrderForThreeItems() {
+        // The offset must scale with the group size, not just the pair case.
+        let result = apply(
+            placements: [
+                "app:a": .newItemAnchored(section: .visible, anchorUID: "app:anchor", relation: .rightOfAnchor),
+                "app:b": .newItemAnchored(section: .visible, anchorUID: "app:anchor", relation: .rightOfAnchor),
+                "app:c": .newItemAnchored(section: .visible, anchorUID: "app:anchor", relation: .rightOfAnchor),
+            ],
+            unmanagedUIDs: ["app:a", "app:b", "app:c"],
+            desiredFiltered: [Self.chevron, "app:anchor", Self.hiddenControl]
+        )
+
+        #expect(result.desiredFiltered == [
+            Self.chevron, "app:anchor", "app:a", "app:b", "app:c", Self.hiddenControl,
+        ])
+    }
+
+    @Test("Several leftOfAnchor placements sharing one anchor keep their unmanagedUIDs order")
+    func leftOfAnchorPlacementsPreserveUnmanagedOrder() {
+        // Mirror of the rightOf case. leftOf already preserves order
+        // because inserting before the anchor shifts it right, advancing
+        // the resolved anchor index. Pinned here so the rightOf fix cannot
+        // silently regress the leftOf path.
+        let result = apply(
+            placements: [
+                "app:first": .newItemAnchored(
+                    section: .visible,
+                    anchorUID: "app:anchor",
+                    relation: .leftOfAnchor
+                ),
+                "app:second": .newItemAnchored(
+                    section: .visible,
+                    anchorUID: "app:anchor",
+                    relation: .leftOfAnchor
+                ),
+            ],
+            unmanagedUIDs: ["app:first", "app:second"],
+            desiredFiltered: [Self.chevron, "app:anchor", Self.hiddenControl]
+        )
+
+        #expect(result.desiredFiltered == [
+            Self.chevron, "app:first", "app:second", "app:anchor", Self.hiddenControl,
+        ])
+    }
+
     @Test("An anchored placement with the sectionDefault relation ignores its anchor and lands at the section end")
     func anchoredSectionDefaultRelationLandsAtSectionEnd() {
         // .sectionDefault means "no anchor preference", so the anchor uid


### PR DESCRIPTION
Closes: N/A

Functional bug fix. See commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/919"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788899435&installation_model_id=431242&pr_number=919&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F919&signature=0bb4e279c99b9b1e98a7f3fd9ddf0a5ea41d8304212b3a03119ef250854d1e33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the ordering of unmanaged menu bar items placed to the right of the same anchor.
  - Multiple items now appear in their original input order instead of being reversed.

- **Tests**
  - Added coverage for multiple left- and right-anchored unmanaged placements sharing an anchor.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->