### PR TITLE
fix(menubar): exclude parked items from the display-spread gate

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -473,17 +473,25 @@ nonisolated enum LayoutSolver {
     /// Each center is matched to the screen frame that contains it. Frames and
     /// centers are expected in the global CoreGraphics coordinate space
     /// (top-left origin), so a secondary display above the main one has a
-    /// negative y origin. Centers that fall on no screen are intentionally
-    /// parked off-screen hidden items (the control item shoves them thousands
-    /// of points to the left) and are ignored. When the remaining on-screen
-    /// items resolve to more than one distinct screen the active menu bar is
-    /// relocating between displays: macOS migrates the status item windows
-    /// asynchronously, so for a window of time some items sit on the old screen
-    /// and some on the new one. A bulk apply dispatched then resolves each
-    /// move against a different display and cannot converge, leaving items
-    /// stranded where they read as un-hidden; a section order persisted then
-    /// bakes that transition artifact into the saved layout. Both callers defer
-    /// until the items collapse back onto a single display.
+    /// negative y origin. When the centers resolve to more than one distinct
+    /// screen the active menu bar is relocating between displays: macOS
+    /// migrates the status item windows asynchronously, so for a window of time
+    /// some items sit on the old screen and some on the new one. A bulk apply
+    /// dispatched then resolves each move against a different display and
+    /// cannot converge, leaving items stranded where they read as un-hidden; a
+    /// section order persisted then bakes that transition artifact into the
+    /// saved layout. Every caller defers until the items collapse back onto a
+    /// single display.
+    ///
+    /// Callers must pass only unparked items. Parked hidden and always-hidden
+    /// items are shoved left of the menu bar and land at arbitrary negative x,
+    /// which is a real display's coordinate space whenever the user has a
+    /// screen positioned to the left of the main one. Feeding those centers in
+    /// makes the predicate report a spread on a perfectly settled layout, and
+    /// it never recovers: the persist gate then blocks every write to
+    /// savedSectionOrder for as long as that arrangement is connected. Centers
+    /// that land on no screen are still ignored, but that is a fallback, not
+    /// the filter; do not rely on it to exclude parked items.
     static nonisolated func itemsSpanMultipleDisplays(
         itemCenters: [CGPoint],
         screenFrames: [CGRect]

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -2408,20 +2408,28 @@ extension MenuBarItemManager {
             // capturing the section order now would bake those un-hidden items
             // into the saved layout as if the user wanted them visible. Wait for
             // the items to collapse back onto a single display.
+            //
+            // Only the visible section feeds the gate. Hidden and always-hidden
+            // items are parked left of the menu bar at arbitrary negative x, and
+            // a display positioned to the left of the main one owns that
+            // coordinate range, so parked items read as a second screen on a
+            // settled layout and this branch never stops firing. The visible
+            // section is never parked, and a genuine relocation splits it across
+            // screens just the same, so narrowing the input keeps the protection.
             let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-            let itemCenters = MenuBarSection.Name.allCases.flatMap { section in
-                context.cache[section].map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) }
+            let itemCenters = context.cache[.visible].map {
+                CGPoint(x: $0.bounds.midX, y: $0.bounds.midY)
             }
             let spansDisplays = LayoutSolver.itemsSpanMultipleDisplays(
                 itemCenters: itemCenters,
                 screenFrames: screenFrames
             )
             if hasBlockedItems {
-                MenuBarItemManager.diagLog.debug(
+                MenuBarItemManager.diagLog.warning(
                     "Skipping saveSectionOrder; blocked items detected (x=-1), will retry on next cache tick"
                 )
             } else if spansDisplays {
-                MenuBarItemManager.diagLog.debug(
+                MenuBarItemManager.diagLog.warning(
                     "Skipping saveSectionOrder; menu bar items span multiple displays (relocation in progress)"
                 )
             } else {
@@ -8716,6 +8724,34 @@ extension MenuBarItemManager {
             return false
         }
 
+        // Display-spread gate. While the active menu bar relocates to another
+        // display macOS migrates the status item windows between screens
+        // asynchronously, so the items transiently straddle two displays. A
+        // bulk apply dispatched now resolves each item's move against whichever
+        // display its window currently occupies and cannot converge, stranding
+        // items on the wrong screen where they read as un-hidden. Skip; a later
+        // tick retries once the items collapse back onto the active display.
+        // Frames come from CGDisplayBounds so they share the top-left origin
+        // coordinate space of the item bounds.
+        //
+        // Only items right of the hidden divider feed the gate. Parked hidden
+        // and always-hidden items sit at arbitrary negative x, which belongs to
+        // a display positioned left of the main one, and including them reports
+        // a spread on a settled layout for as long as that display is
+        // connected. This gate and the saveSectionOrder one are a pair: both
+        // must judge the same geometry, or the layout gets applied from an
+        // order that can no longer be saved.
+        let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+        let unparkedCenters = items
+            .filter { $0.bounds.minX >= controlItems.hidden.bounds.minX }
+            .map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) }
+        if LayoutSolver.itemsSpanMultipleDisplays(itemCenters: unparkedCenters, screenFrames: screenFrames) {
+            MenuBarItemManager.diagLog.warning(
+                "applySavedLayout: skipping (\(trigger)); menu bar items span multiple displays (relocation in progress)"
+            )
+            return false
+        }
+
         MenuBarItemManager.diagLog.info("applySavedLayout: dispatching bulk apply (\(trigger))")
 
         // The shared body uses itemOrder as the per-section ordered
@@ -8970,10 +9006,28 @@ extension MenuBarItemManager {
         else { return }
 
         // Mid-relocation between displays the item bounds straddle two screens
-        // and the budget cannot be trusted. Same guard the profile apply uses.
+        // and the budget cannot be trusted. Same guard the persist path uses,
+        // and the same input rule: only unparked items may feed it. Items left
+        // of the hidden divider are parked at arbitrary negative x, which lands
+        // inside a display positioned to the left of the main one and reads as
+        // a permanent spread. Without a hidden control item to measure against
+        // nothing can be classified, so leave the items unfiltered rather than
+        // guess.
+        //
+        // Frames come from CGDisplayBounds, not NSScreen.frame, for the same
+        // reason as the other two call sites: item bounds are CoreGraphics
+        // (top-left origin, y growing downward) while NSScreen.frame is AppKit
+        // (bottom-left origin, y growing upward). Mixing them made every
+        // containment test wrong off the main display, which on a vertically
+        // stacked arrangement reads as no spread when the items really do
+        // straddle two screens.
+        var unparkedItems = items
+        if let hiddenControlItemMinX = items.first(where: { $0.tag == .hiddenControlItem })?.bounds.minX {
+            unparkedItems = items.filter { $0.bounds.minX >= hiddenControlItemMinX }
+        }
         guard !LayoutSolver.itemsSpanMultipleDisplays(
-            itemCenters: items.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) },
-            screenFrames: NSScreen.screens.map(\.frame)
+            itemCenters: unparkedItems.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) },
+            screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) }
         ) else { return }
 
         // A profile apply is the better tool: it re-runs this same planner and

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager.swift
@@ -599,7 +599,7 @@ final class MenuBarItemManager {
     }
 
     /// When the last continuous notch-overflow rebalance ejected items. Used
-    /// only for the cooldown in ``rebalanceNotchOverflowIfNeeded(items:)``.
+    /// only for the cooldown in rebalanceNotchOverflowIfNeeded(items:controlItems:).
     private var lastNotchRebalanceTimestamp: Date?
     /// Placement preference for newly detected menu bar items.
     private(set) var newItemsPlacement = NewItemsPlacement.defaultValue
@@ -3112,7 +3112,7 @@ extension MenuBarItemManager {
         // Keep the visible row inside the beside-notch budget regardless of
         // whether a profile is active. Runs last so it sees the settled cache,
         // and self-gates on every in-flight mover.
-        await rebalanceNotchOverflowIfNeeded(items: items)
+        await rebalanceNotchOverflowIfNeeded(items: items, controlItems: controlItems)
     }
 
     /// Caches the current menu bar items, if the items have changed
@@ -8976,7 +8976,7 @@ extension MenuBarItemManager {
     /// When a profile *is* active the pass defers to
     /// ``scheduleProfileResort()``: a full apply re-runs the same planner while
     /// also honouring the saved order, so ejecting here would fight it.
-    func rebalanceNotchOverflowIfNeeded(items: [MenuBarItem]) async {
+    func rebalanceNotchOverflowIfNeeded(items: [MenuBarItem], controlItems: ControlItemPair) async {
         guard let appState else { return }
         guard appState.settings.advanced.enableMenuBarItemOverflow else { return }
 
@@ -9010,9 +9010,14 @@ extension MenuBarItemManager {
         // and the same input rule: only unparked items may feed it. Items left
         // of the hidden divider are parked at arbitrary negative x, which lands
         // inside a display positioned to the left of the main one and reads as
-        // a permanent spread. Without a hidden control item to measure against
-        // nothing can be classified, so leave the items unfiltered rather than
-        // guess.
+        // a permanent spread.
+        //
+        // The divider comes from the caller's ControlItemPair rather than a
+        // lookup in items. Building that pair strips the hidden and
+        // always-hidden control items out of the array it is given, and the
+        // caller hands us that same stripped array, so searching it for
+        // .hiddenControlItem finds nothing and the filter would silently pass
+        // every parked item straight through.
         //
         // Frames come from CGDisplayBounds, not NSScreen.frame, for the same
         // reason as the other two call sites: item bounds are CoreGraphics
@@ -9021,10 +9026,8 @@ extension MenuBarItemManager {
         // containment test wrong off the main display, which on a vertically
         // stacked arrangement reads as no spread when the items really do
         // straddle two screens.
-        var unparkedItems = items
-        if let hiddenControlItemMinX = items.first(where: { $0.tag == .hiddenControlItem })?.bounds.minX {
-            unparkedItems = items.filter { $0.bounds.minX >= hiddenControlItemMinX }
-        }
+        let hiddenControlItemMinX = controlItems.hidden.bounds.minX
+        let unparkedItems = items.filter { $0.bounds.minX >= hiddenControlItemMinX }
         guard !LayoutSolver.itemsSpanMultipleDisplays(
             itemCenters: unparkedItems.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) },
             screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) }
@@ -9043,8 +9046,6 @@ extension MenuBarItemManager {
             return
         }
 
-        var itemsCopy = items
-        guard let controlItems = ControlItemPair(items: &itemsCopy) else { return }
         let hiddenCtrlUID = controlItems.hidden.uniqueIdentifier
         let ahCtrlUID = controlItems.alwaysHidden?.uniqueIdentifier
 

--- a/ThawTests/MenuBar/Items/DisplaySpreadGateTests.swift
+++ b/ThawTests/MenuBar/Items/DisplaySpreadGateTests.swift
@@ -68,10 +68,12 @@ struct DisplaySpreadGateTests {
         )
     }
 
-    /// Items on one screen plus intentionally off-screen parked hidden items
-    /// (the control item shoves them ~10000px left, onto no display). The
-    /// parked points must be ignored so a normal hidden layout does not read
-    /// as spread.
+    /// Items on one screen plus parked hidden items that happen to land on no
+    /// display at all, because no screen occupies that coordinate range. The
+    /// unmatched points must be ignored so a normal hidden layout does not read
+    /// as spread. Note this is the lucky arrangement: see
+    /// parkedItemInsideLeftDisplayReadsAsSpread for the case where a screen
+    /// does own the parked coordinates.
     @Test("Parked off-screen items are ignored")
     func offScreenParkedItemsAreIgnored() {
         #expect(
@@ -119,6 +121,73 @@ struct DisplaySpreadGateTests {
     func emptyItemsDoesNotSpread() {
         #expect(
             !LayoutSolver.itemsSpanMultipleDisplays(itemCenters: [], screenFrames: [main, above])
+        )
+    }
+
+    // MARK: - Displays to the left of the main one
+
+    // The arrangement from the field log: an ultrawide main display with a
+    // second screen to its right and a third to its left. The left screen owns
+    // the negative x range that parked hidden items are shoved into, so the
+    // "parked items land on no display" assumption the rest of this suite was
+    // written against does not hold here.
+
+    private let fieldMain = CGRect(x: 0, y: 0, width: 3440, height: 1440)
+    private let fieldRight = CGRect(x: 3440, y: 0, width: 2560, height: 1440)
+    private let fieldLeft = CGRect(x: -2560, y: 0, width: 2560, height: 1440)
+
+    private var fieldScreens: [CGRect] {
+        [fieldMain, fieldRight, fieldLeft]
+    }
+
+    /// A parked hidden item shoved to x ≈ -2450 lands inside the left display,
+    /// so the predicate honestly reports a spread. This is not a bug in the
+    /// predicate; it is why callers must exclude parked items before calling
+    /// it. Feeding every section in made both gates fire forever: the persist
+    /// gate then blocked every write to savedSectionOrder, the saved layout
+    /// stopped tracking the user's arrangement, and each window-ID change
+    /// re-imposed the stale order.
+    @Test("A parked item inside a left-positioned display reads as a spread")
+    func parkedItemInsideLeftDisplayReadsAsSpread() {
+        #expect(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [
+                    CGPoint(x: 2846, y: 15), // visible item on the main display
+                    CGPoint(x: -2450, y: 15), // parked hidden item, inside fieldLeft
+                ],
+                screenFrames: fieldScreens
+            )
+        )
+    }
+
+    /// The same settled arrangement with the parked items excluded, which is
+    /// what the callers now pass. Must not defer.
+    @Test("Unparked centers alone do not spread on a left-positioned arrangement")
+    func unparkedCentersDoNotSpreadOnFieldArrangement() {
+        #expect(
+            !LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [
+                    CGPoint(x: 2846, y: 15),
+                    CGPoint(x: 3201, y: 15),
+                    CGPoint(x: 3247, y: 15),
+                ],
+                screenFrames: fieldScreens
+            )
+        )
+    }
+
+    /// A real relocation still has to be caught on this arrangement: the
+    /// unparked items themselves straddle the main and right displays.
+    @Test("A relocation across a left-positioned arrangement is still a spread")
+    func relocationStillSpreadsOnFieldArrangement() {
+        #expect(
+            LayoutSolver.itemsSpanMultipleDisplays(
+                itemCenters: [
+                    CGPoint(x: 2846, y: 15), // still on the main display
+                    CGPoint(x: 4200, y: 15), // already migrated to the right display
+                ],
+                screenFrames: fieldScreens
+            )
         )
     }
 }


### PR DESCRIPTION
# Summary

`LayoutSolver.itemsSpanMultipleDisplays` assumed parked hidden items land on no display, which is false whenever a screen sits to the left of the main one. The predicate then reported a spread on a settled layout, permanently, and the persist gate it feeds stopped `saveSectionOrder` from ever running. Callers now exclude parked items before consulting it.

**Scope:** This PR changes one focused thing (bug fix or feature) plus minimal plumbing. Larger refactors need prior agreement in the issue.

## Linked issue (required)

Closes: N/A

Reported directly against `2.0.0-rc.2.1` with diagnostic logs rather than through the tracker. Not a duplicate of #927, which reports a similar symptom on a **single monitor**, where this predicate short-circuits at `guard screenFrames.count > 1`.

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

`itemsSpanMultipleDisplays` was documented as ignoring parked hidden items because the control item shoves them "thousands of points to the left", onto no display. That assumption only holds when no screen occupies negative x. On the reporter's arrangement (main at `x=0` 3440 wide, a second display at `x=3440`, and a third at `x=-2560`) the hidden section parks at `x ≈ -2400` to `-2570`, which is inside the third display's frame. The predicate matched two distinct screens and returned `true` on a completely settled layout, for as long as that display stayed connected.

Both consumers then fired continuously. The persist gate skipped `saveSectionOrder` on every cache cycle: one field log covering a single day recorded **1088 skips and zero successful writes**, and `MenuBarItemManager.savedSectionOrder` on disk was three empty arrays. Everything the user saw came from the active display profile's frozen snapshot, because `armProfileState` overwrites the in-memory copy at startup while `ProfileManager.captureCurrentLayout` reads the empty persisted one.

With the saved order unable to advance, any item moved into always-hidden stayed absent from `desiredAH`, so `partitionUnmanagedUIDs` kept it and `planUnmanagedPlacement` classified it as a new item bound for the new-items section. Quitting any app changed the window-ID set, which dispatched a bulk apply, which dragged the item back to visible. From the reporter's log:

```text
:42  cacheItemsIfNeeded: window IDs changed (30 cached vs 29 current)
:59  applySavedLayout: dispatching bulk apply (windowID change)
:73  current always-hidden section: [OneDrive, cisco, cortex, wdav, beyondtrust]
:81  desiredAH = [beyondtrust, cisco, wdav]
:74  planUnmanagedPlacement com.paloaltonetworks.cortex.agent:Item-0 -> newItemDefault(section=visible section)
:442 Skipping saveSectionOrder; menu bar items span multiple displays (relocation in progress)
```

The log corroborates the geometry independently: the hidden section captured cleanly at those coordinates while the always-hidden items at `x ≈ -7660` produced `captureWindowsImageSCK: no display intersects`. Hidden items were on a real display; always-hidden ones were not.

### What changed

Callers exclude parked items rather than relying on them falling outside every screen frame. The persist path passes visible-section centers only; `applySavedLayout` and `rebalanceNotchOverflowIfNeeded` filter to items at or right of the hidden divider's `minX`. A real relocation still splits those items across screens, so deferring on mid-migration geometry is unchanged.

Two related repairs travel with it:

- `applySavedLayout` regains the display-spread guard that `d2824fa4` dropped while leaving the persist-side guard in place. Both halves landed together in `4c04159e`; the asymmetry is what made this visible rather than merely inert, because applies kept running against an order that could no longer be saved.
- `rebalanceNotchOverflowIfNeeded` derives its screen frames from `CGDisplayBounds` instead of `NSScreen.frame`, so the rectangles share the top-left origin space of the item bounds they are tested against rather than mixing it with AppKit's bottom-left origin.

The persist-side skip is logged at `warning` rather than `debug`, matching the sibling branches around it. A run of these means the saved layout has stopped tracking the user's arrangement, and the symptom that surfaces gives no hint that persistence is the cause.

### Regression range

`4c04159e` (2026-06-24) introduced the predicate and both gates. `2.0.0-rc.1` is dated 2026-06-16, so this regressed inside the rc.1 to rc.2 window and shipped in `2.0.0-rc.2` and `2.0.0-rc.2.1`.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -only-testing:ThawTests/DisplaySpreadGateTests`
- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS'` (full suite: 1993 tests in 257 suites)
- `swiftformat` was run against the touched files only.
- `swiftlint` is clean on all three touched files.

### Verified on the reporting machine

Debug build run against the three-display arrangement that reproduces the bug:

| Signal | Before | After |
| --- | --- | --- |
| `span multiple displays` skips | 1088 | 0 |
| `Saved section order:` writes | 0 | 1, six seconds after launch |
| `planUnmanagedPlacement` for the affected item | every window-ID change | 0 |

`MenuBarItemManager.savedSectionOrder` went from three empty arrays to a populated dict with the affected item present in `alwaysHidden`, which is the condition that stops `partitionUnmanagedUIDs` from picking it up at all.

## Other information

The predicate keeps its signature and its behaviour of ignoring centers that match no screen. That fallback is still useful, but its doc comment now states plainly that it is not the filter and that callers own the exclusion, so the next caller does not re-derive the same assumption.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/930"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788996355&installation_model_id=431242&pr_number=930&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F930&signature=940af407be4e400b21c59565e61290d8bb369e0e06c0959e92b31ed52c9047a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar item placement across multiple displays.
  * Prevented hidden or parked items from incorrectly triggering layout changes, cache updates, or notch-overflow rebalancing.
  * Improved handling of display coordinates to avoid false cross-display relocation detection.

* **Documentation**
  * Clarified how parked and hidden items are handled during display-spread detection.

* **Tests**
  * Added coverage for parked items, settled items, and genuine cross-display movement scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->