### PR TITLE
fix(settings): snap icon refresh slider to integer fps

### DIFF
--- a/Thaw/Settings/Models/AdvancedSettings.swift
+++ b/Thaw/Settings/Models/AdvancedSettings.swift
@@ -126,6 +126,26 @@ final class AdvancedSettings {
         }
     }
 
+    /// Integer fps the slider should show for a stored interval.
+    ///
+    /// `1/n` is not always binary-exact, so `1.0 / interval` can land just
+    /// below the intended integer (29.999… at 30 fps). The slider and its
+    /// `Int(...)` label both truncate that to the next step down and the thumb
+    /// will not stay on the value the user picked.
+    nonisolated static func iconRefreshRate(fromInterval interval: TimeInterval) -> Double {
+        guard interval > 0 else { return 0 }
+        let ceiling = MenuBarItemImageCache.maxIconRefreshRate
+        return min(max((1.0 / interval).rounded(), 1), ceiling)
+    }
+
+    /// Interval to store for a slider fps value. `<= 0` is Off.
+    nonisolated static func iconRefreshInterval(fromRate fps: Double) -> TimeInterval {
+        let ceiling = MenuBarItemImageCache.maxIconRefreshRate
+        let snapped = min(max(fps.rounded(), 0), ceiling)
+        guard snapped > 0 else { return 0 }
+        return 1.0 / snapped
+    }
+
     /// Snaps an icon-refresh interval onto the values the slider can express.
     ///
     /// - `<= 0` stays Off (`0`).
@@ -133,10 +153,7 @@ final class AdvancedSettings {
     ///   where the ceiling is ``MenuBarItemImageCache/maxIconRefreshRate``.
     /// - Idempotent: already-on-grid values round-trip unchanged.
     nonisolated static func normalizedIconRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
-        guard interval > 0 else { return 0 }
-        let ceiling = MenuBarItemImageCache.maxIconRefreshRate
-        let fps = min(max((1.0 / interval).rounded(), 1), ceiling)
-        return 1.0 / fps
+        iconRefreshInterval(fromRate: iconRefreshRate(fromInterval: interval))
     }
 
     /// A Boolean value that indicates whether diagnostic logging to file is enabled.

--- a/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/MenuBarLayoutSettingsPane.swift
@@ -178,10 +178,9 @@ struct MenuBarLayoutSettingsPane: View {
         let maxFPS = MenuBarItemImageCache.maxIconRefreshRate
         let fpsBinding = Binding<Double>(
             get: {
-                let interval = advancedSettings.iconRefreshInterval
-                return interval > 0 ? 1.0 / interval : 0
+                AdvancedSettings.iconRefreshRate(fromInterval: advancedSettings.iconRefreshInterval)
             },
-            set: { advancedSettings.iconRefreshInterval = $0 > 0 ? 1.0 / $0 : 0 }
+            set: { advancedSettings.iconRefreshInterval = AdvancedSettings.iconRefreshInterval(fromRate: $0) }
         )
         return LabeledContent {
             IceSlider(

--- a/ThawTests/Settings/Models/IconRefreshIntervalNormalizationTests.swift
+++ b/ThawTests/Settings/Models/IconRefreshIntervalNormalizationTests.swift
@@ -65,10 +65,27 @@ struct IconRefreshIntervalNormalizationTests {
         for fps in 0 ... ceiling {
             let interval: TimeInterval = fps == 0 ? 0 : 1.0 / Double(fps)
             let normalized = AdvancedSettings.normalizedIconRefreshInterval(interval)
-            let displayedFPS = normalized > 0 ? (1.0 / normalized).rounded() : 0
-            let restored: TimeInterval = displayedFPS > 0 ? 1.0 / displayedFPS : 0
+            let displayedFPS = AdvancedSettings.iconRefreshRate(fromInterval: normalized)
+            let restored = AdvancedSettings.iconRefreshInterval(fromRate: displayedFPS)
             #expect(AdvancedSettings.normalizedIconRefreshInterval(restored) == normalized)
             #expect(Int(displayedFPS) == fps)
         }
+    }
+
+    @Test("Slider fps is an integer even when 1/n is not binary-exact")
+    func sliderShowsIntegerFPS() {
+        #expect(AdvancedSettings.iconRefreshRate(fromInterval: 0) == 0)
+        #expect(AdvancedSettings.iconRefreshRate(fromInterval: 0.25) == 4)
+        #expect(AdvancedSettings.iconRefreshRate(fromInterval: 1.0 / 3.0) == 3)
+        #expect(AdvancedSettings.iconRefreshRate(fromInterval: 1.0 / 30.0) == 30)
+    }
+
+    @Test("Slider writes snap to integer fps before storage")
+    func sliderWritesSnapToIntegerFPS() {
+        #expect(AdvancedSettings.iconRefreshInterval(fromRate: 0) == 0)
+        #expect(AdvancedSettings.iconRefreshInterval(fromRate: 4) == 0.25)
+        #expect(AdvancedSettings.iconRefreshInterval(fromRate: 29.6) == 1.0 / 30.0)
+        #expect(AdvancedSettings.iconRefreshInterval(fromRate: 0.4) == 0)
+        #expect(AdvancedSettings.iconRefreshInterval(fromRate: 0.6) == 1.0)
     }
 }


### PR DESCRIPTION
# Summary

The Icon refresh rate slider still misbehaved on `development` after #929: stored intervals are `1/n` seconds, and `1.0 / interval` is not binary-exact. CompactSlider and the `Int(...)` label truncated 29.999… to **29 fps** at the max (and 2.999… to **2 fps** at 3), so the thumb would not stay on the value the user picked.

Round interval ↔ fps through shared helpers so the slider only ever sees integer fps.

**Scope:** Slider binding + the two conversion helpers + tests. Capture floor stays 30 fps; default stays ~4 fps.

## Linked issue (required)

Closes: N/A

## PR Type

- [x] Bug fix
- [x] Test addition or update

## Area

- [x] settings
- [x] layout

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the new behavior?

- `iconRefreshRate(fromInterval:)` rounds to 0 or 1…30 fps.
- `iconRefreshInterval(fromRate:)` stores `1/n` from that integer.
- The layout-pane slider get/set use those helpers, so 3 fps and 30 fps stick and the label matches the thumb.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] This PR targets the `development` branch.

Test commands run:

- CI. New cases: 1/3 → 3 fps, 1/30 → 30 fps, slider writes 29.6 → 1/30, 0.4 → Off.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789409378&installation_model_id=431242&pr_number=941&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F941&signature=0786733e4822bd21cace031c99415bbbe085661625f3c51ef8883070d6a535b6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved icon refresh-rate handling to keep values within supported limits.
  * Refresh-rate settings now consistently convert between interval and FPS values.
  * Slider adjustments snap to valid integer FPS values, preventing unsupported or inaccurate selections.

* **Tests**
  * Expanded coverage for refresh-rate conversion, display values, and slider behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->