### PR TITLE
fix(layout): stop a degenerate window from discarding hidden-item preview batches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ plans/
 
 # Local badge mockups
 .tmp-badge-preview/
+default.profraw

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -236,6 +236,15 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     /// Minimum spacing enforced between offscreen SkyLight batch captures.
     private static let minSkyLightBatchInterval: Duration = .seconds(1)
 
+    /// Whether a window's bounds can contribute to a composite capture.
+    ///
+    /// Both dimensions must be positive: the capture APIs omit degenerate
+    /// windows from the composite, so including one only corrupts the
+    /// geometry the composite is sliced with.
+    static nonisolated func isCapturableBounds(_ bounds: CGRect) -> Bool {
+        bounds.width > 0 && bounds.height > 0
+    }
+
     /// Timestamp of the last visible-section SCK capture, used to rate-limit
     /// the on-screen path the same way the offscreen one already is.
     private var lastSCKRefreshAt: ContinuousClock.Instant?
@@ -1262,6 +1271,25 @@ final class MenuBarItemImageCache: @unchecked Sendable {
 
         for item in items {
             guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
+                continue
+            }
+            // Degenerate windows must not reach the union. A zero-width or
+            // zero-height window contributes nothing to the composite — the
+            // capture APIs drop it, and `cropping(to:)` on an empty rect
+            // returns nil — but including it still corrupts the geometry the
+            // composite gets sliced against: parked off-screen it drags
+            // `boundsUnion` across the whole gap to its position, so the
+            // expected-width check below compares the composite of the real
+            // items against a union thousands of points wide and discards
+            // every batch.
+            //
+            // This holds whatever produced the degenerate bounds; the union
+            // and the slice loop below read the same storage, so a window that
+            // cannot contribute geometry must enter neither.
+            guard Self.isCapturableBounds(bounds) else {
+                MenuBarItemImageCache.diagLog.debug(
+                    "refreshImages: skipping degenerate bounds for \(item.logString) (\(bounds.width)x\(bounds.height))"
+                )
                 continue
             }
             windowIDs.append(item.windowID)

--- a/ThawTests/MenuBar/Items/CapturableBoundsTests.swift
+++ b/ThawTests/MenuBar/Items/CapturableBoundsTests.swift
@@ -1,0 +1,79 @@
+//
+//  CapturableBoundsTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+/// Characterizes which window bounds may take part in a composite capture.
+///
+/// `refreshImages` captures a batch of item windows as one image and slices it
+/// per item using each window's offset within the batch's bounds union. A
+/// degenerate window — zero width or zero height — breaks that: the capture
+/// APIs drop it from the composite, so it adds no pixels, while including it in
+/// the union corrupts the geometry the composite gets sliced against. Parked
+/// off-screen it widens the union across the whole gap, the composite's width
+/// no longer matches, and the batch is discarded. That is the difference
+/// between previews rendering and the Hidden rows appearing empty.
+///
+/// Which item produced the degenerate bounds does not matter to any of this.
+@Suite("Capturable bounds")
+struct CapturableBoundsTests {
+    @Test("An ordinary menu bar item window is capturable")
+    func ordinaryWindowIsCapturable() {
+        #expect(MenuBarItemImageCache.isCapturableBounds(CGRect(x: 1242, y: 0, width: 42, height: 33)))
+    }
+
+    @Test("A zero-width window is not capturable")
+    func zeroWidthIsNotCapturable() {
+        // A degenerate window parked off-screen, as observed in the field.
+        #expect(!MenuBarItemImageCache.isCapturableBounds(CGRect(x: -3774, y: 0, width: 0, height: 33)))
+    }
+
+    @Test("A zero-height window is not capturable")
+    func zeroHeightIsNotCapturable() {
+        #expect(!MenuBarItemImageCache.isCapturableBounds(CGRect(x: 1242, y: 0, width: 42, height: 0)))
+    }
+
+    @Test("A fully empty rect is not capturable")
+    func emptyRectIsNotCapturable() {
+        #expect(!MenuBarItemImageCache.isCapturableBounds(.zero))
+        #expect(!MenuBarItemImageCache.isCapturableBounds(.null))
+    }
+
+    /// The regression itself, in the geometry the field log recorded: seven
+    /// contiguous on-screen items plus two degenerate windows at x=-3774. With
+    /// those filtered, the union matches the composite the capture returns
+    /// (260pt → 520px at 2x); without them it is 5276pt wide and every batch is
+    /// thrown away.
+    @Test("Degenerate windows no longer widen the batch union")
+    func degenerateWindowsDoNotWidenTheUnion() {
+        let real = [
+            CGRect(x: 1242, y: 0, width: 42, height: 33),
+            CGRect(x: 1284, y: 0, width: 33, height: 33),
+            CGRect(x: 1317, y: 0, width: 34, height: 33),
+            CGRect(x: 1351, y: 0, width: 33, height: 33),
+            CGRect(x: 1384, y: 0, width: 38, height: 33),
+            CGRect(x: 1422, y: 0, width: 38, height: 33),
+            CGRect(x: 1460, y: 0, width: 42, height: 33),
+        ]
+        let degenerate = [
+            CGRect(x: -3774, y: 0, width: 0, height: 33),
+            CGRect(x: -3774, y: 0, width: 0, height: 33),
+        ]
+
+        let unfiltered = (real + degenerate).reduce(CGRect.null) { $0.union($1) }
+        #expect(unfiltered.width == 5276) // what the guard used to compare against
+
+        let filtered = (real + degenerate)
+            .filter(MenuBarItemImageCache.isCapturableBounds)
+            .reduce(CGRect.null) { $0.union($1) }
+        #expect(filtered.width == 260)
+        #expect(filtered.width * 2 == 520) // the composite the capture returns at 2x
+    }
+}


### PR DESCRIPTION
**Base:** `86fd78b6` (post-2.0.0-rc.4)

Closes: #963

## Symptom

In **Settings → Layout**, the Hidden and Always-Hidden rows render completely
empty — no icons, no placeholders — while the Visible row renders normally. The
items themselves are fine: they're enumerated, managed, and moving between
sections works. Only the previews are missing.

It happens whenever a hidden-section capture batch contains a **zero-area
window**. In the case investigated here those were orphaned Control Center
hosting slots left behind by an earlier Thaw process — see *How the state
arises*. The state is transient: once Control Center reclaims the slots, stock
`development` renders previews normally again.

Changing the **Section divider style** makes no difference (verified with `None`
and `Chevron`, identical failure) — that was an early wrong guess on my part.

## Cause

`refreshImages` captures a batch of item windows as a single composite image,
then slices it per item using each window's offset within the batch's bounds
union:

```swift
boundsUnion = boundsUnion.union(bounds)          // built over every item
…
let expectedWidth = boundsUnion.width * scale
guard CGFloat(compositeImage.width) == expectedWidth else { … skipping }
…
x: (bounds.origin.x - boundsUnion.origin.x) * scale
```

A window with zero width or height breaks that arrangement. The capture APIs
leave it out of the composite, so it contributes no pixels — but its origin
still widens the union. Parked off-screen, it drags the union across the entire
gap, so the composite's width can no longer match, and the batch is discarded.

### How the state arises

Thaw's status items are hosted by Control Center, so all of its control item
windows are owned by the Control Center process rather than by Thaw. A direct
window-list dump during the failure:

```
wid=10980  Control Center  x=1503   w=33    h=33  name=Thaw.ControlItem.Visible
wid=10981  Control Center  x=-3513  w=5016  h=33  name=Thaw.ControlItem.Hidden
wid=10982  Control Center  x=-8789  w=5016  h=33  name=Thaw.ControlItem.AlwaysHidden
wid=10267  Control Center  x=-8789  w=0     h=0   name=com.stonerl.Thaw   <-- orphan
wid=10268  Control Center  x=-8789  w=0     h=0   name=com.stonerl.Thaw   <-- orphan
```

The last two are hosting slots orphaned by an **earlier** Thaw process: their
window IDs are lower than the running instance's control items (10980-10982) and
lower than its Thaw Bar (10975), and they appear in logs from before that
instance started. Because Control Center owns them, they outlive Thaw restarts.
Their name is the bundle ID rather than `Thaw.ControlItem.*`, so
`ControlItemPair` does not recognise them as control items and does not strip
them — and they ride into the hidden/always-hidden batch.

I produced them by force-quitting Thaw repeatedly while debugging something
else; a crash or an ungraceful exit does the same thing to a user. They are not
permanent: `killall ControlCenter` reclaims them.

### Verified in all three states

| Orphan slots | Build | Result |
| --- | --- | --- |
| present | `development` | every batch discarded, rows empty (32 discards, 0 refreshes) |
| reclaimed (after `killall ControlCenter`) | `development` | previews render, `refreshImages: ✓ updated 4/4 items` |
| present | with this patch | previews render |

So this PR does not change behaviour in the healthy state; it makes the capture
geometry immune to a degenerate window, whatever produced it.

## Measurement

Instrumented `refreshImages` on an affected machine (hidden=8, always-hidden=2,
2× notched display):

```
composite=520x66  scale=2.0  unionX=-3774  unionW=5276  sumW=260
items= com.apple.controlcenter:Item-0@x=1242,w=42
     | com.apple.controlcenter:Item-0:1@x=1284,w=33
     | com.apple.controlcenter:Item-0:2@x=1317,w=34
     | com.apple.controlcenter:NowPlaying@x=1351,w=33
     | com.apple.controlcenter:Sound@x=1384,w=38
     | com.apple.controlcenter:FocusModes@x=1422,w=38
     | com.apple.controlcenter:Battery@x=1460,w=42
     | com.apple.controlcenter:com.stonerl.Thaw@x=-3774,w=0
     | com.apple.controlcenter:com.stonerl.Thaw:1@x=-3774,w=0
```

The seven real items are contiguous — x=1242→1502, 260pt — and the capture
returns exactly those at 520px (260 × 2). The two zero-width dividers at
x=−3774 inflate the union to 5276pt, so the guard compares **520 against
10552** and skips.

Across a session of diagnostic logs: **32 batches discarded, zero successful
hidden-section refreshes.** Deterministic, not a race — the guard cannot pass
while a degenerate window is in the batch.

## Fix

Filter degenerate bounds out of the batch before they reach the union. Such a
window could never have produced a preview anyway: `cropping(to:)` on an empty
rect returns nil, so it was always destined to be skipped a few lines later —
just after it had already corrupted the geometry for every other item.

`isCapturableBounds` is a pure predicate so the rule is testable without a live
window server. 5 tests, including one that reconstructs the geometry above and
pins both numbers (5276pt unfiltered vs 260pt filtered).

**On placement:** the filter sits where the union is built, not at the call site
that assembles the batch. Excluding collapsed dividers earlier would fix this
particular reproduction, but *any* zero-area window breaks composite slicing the
same way regardless of how it got there, so the invariant belongs next to the
geometry that depends on it. Happy to move it if you'd rather the batch never
contain them in the first place.

## Testing

- Full suite: **2,410 tests in 306 suites, 0 failures** (`xcodebuild test`,
  Debug, macOS).
- 5 new tests; suite count +5 from the current `development` baseline.
- Reproduced and instrumented on the affected machine; the measurement above is
  from that build. Before/after screenshots to follow — this is why the PR is
  open as a draft.

## Environment

- macOS 26.5.2 (25F84), Apple M1 Max, built-in Liquid Retina XDR (2× scale, notched)
- hidden = 8 items, always-hidden = 2
- Independent of Section divider style (`None` and `Chevron` both fail)

## Diffstat

```
 .gitignore                                                      |  1 +
 Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift           | 27 +++++++
 ThawTests/MenuBar/Items/CapturableBoundsTests.swift             | 77 ++++++++++++++++
 3 files changed, 105 insertions(+)
```

(The `.gitignore` line is `default.profraw`, a coverage artifact the test run
drops in the repo root.)

## Possibly related

- **#956** — "rc4 Hidden menu items don't work when clicked on, and don't have
  correct labels" mentions hidden items showing "Menu Bar Item" instead of real
  labels. If those rows are also missing their previews, this may be part of it,
  though the click and cursor-jump symptoms in that report are separate.
- **#957** — closed as a duplicate of #687; that one is on
  `macos-27-preview.5` and shows *placeholder* chevrons rather than empty rows,
  so it looks like a different failure.

## Follow-up worth considering separately

The orphaned slots slip past the ghost-control-item filter added in #821,
because that keys on the `Thaw.ControlItem.*` naming while these carry the
bundle ID. Dropping Control-Center-owned zero-size windows titled with our own
bundle ID at enumeration would remove them before anything downstream — the
image cache, the layout editor, the item cache — ever sees them. That seems
like the better root fix, and complementary to this one rather than a
replacement: composite slicing should not be fragile to a zero-area window
regardless of how one got into the list. Happy to open an issue for it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar image capture by ignoring collapsed or empty menu items.
  * Prevented invisible dividers from distorting capture dimensions and causing valid image batches to be discarded.

* **Tests**
  * Added coverage for zero-sized bounds, empty rectangles, and collapsed off-screen dividers.

* **Chores**
  * Excluded profiling output files from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->