### PR TITLE
fix(menubar): stop the layout from repairing itself into collapse (#958, #956, #863)

### DIFF
--- a/MenuBarItemService/ExtrasMenuBarProbeStore.swift
+++ b/MenuBarItemService/ExtrasMenuBarProbeStore.swift
@@ -1,0 +1,47 @@
+//
+//  ExtrasMenuBarProbeStore.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+
+/// Reads and writes ``ExtrasMenuBarProbeMemory``'s contents.
+///
+/// The service has no access to the app's `Defaults`, and does not need it:
+/// this memory is written by the process that does the probing and read by
+/// nobody else, so it lives in the service's own defaults domain
+/// (`com.stonerl.Thaw.MenuBarItemService`). Keeping it out of the app's
+/// domain also keeps it out of everything that treats that domain as user
+/// settings — this is a measurement, not a preference, and losing it costs
+/// one slow scan.
+nonisolated enum ExtrasMenuBarProbeStore {
+    private static let key = "ExtrasMenuBarProbeMisses"
+
+    private static let diagLog = DiagLog(category: "ExtrasMenuBarProbeStore")
+
+    /// The remembered consecutive-miss count per bundle identifier.
+    static func load() -> [String: Int] {
+        stored()
+    }
+
+    /// Writes `misses`, unless it matches what is already stored.
+    ///
+    /// The write guard is what makes it safe to call this from the cache
+    /// cleanup, which runs whenever any process on the system starts or exits
+    /// — roughly every nine seconds in the field. The memory converges within
+    /// the first minute of a session and then stops changing.
+    static func save(_ misses: [String: Int]) {
+        guard misses != stored() else {
+            return
+        }
+        UserDefaults.standard.set(misses, forKey: key)
+        diagLog.debug("Stored extras-bar probe memory for \(misses.count) applications")
+    }
+
+    private static func stored() -> [String: Int] {
+        UserDefaults.standard.dictionary(forKey: key) as? [String: Int] ?? [:]
+    }
+}

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -49,7 +49,15 @@ actor SourcePIDCache {
 
         private struct State {
             var extrasMenuBar: UIElement?
-            var checkedWithNoResult = false
+
+            /// Consecutive checks that found no extras menu bar. Drives the
+            /// TTL ladder in ``ExtrasMenuBarNegativeCachePolicy``.
+            var consecutiveMisses = 0
+
+            /// The instant after which a missing extras menu bar may be
+            /// probed again, or `nil` when this app has never come back
+            /// empty. Only meaningful while `extrasMenuBar` is `nil`.
+            var retryAfter: ContinuousClock.Instant?
         }
 
         private let lock = OSAllocatedUnfairLock(initialState: State())
@@ -77,6 +85,23 @@ actor SourcePIDCache {
             lock.withLock { $0.extrasMenuBar != nil }
         }
 
+        /// Whether an unexpired negative deadline would make
+        /// ``getOrCreateExtrasMenuBar()`` skip its accessibility calls.
+        ///
+        /// Diagnostics only, and sampled outside the lock that
+        /// ``getOrCreateExtrasMenuBar()`` takes, so it is a count rather
+        /// than a guarantee. It exists because a field log that reports
+        /// only "checked N apps" cannot distinguish a scan that probed the
+        /// whole system from one the negative cache spared.
+        var isSkippingExtrasMenuBarProbe: Bool {
+            lock.withLock { state in
+                guard state.extrasMenuBar == nil, let retryAfter = state.retryAfter else {
+                    return false
+                }
+                return retryAfter > ContinuousClock.now
+            }
+        }
+
         /// A Boolean value indicating whether the app is in a valid
         /// state for making accessibility calls.
         private var isValidForAccessibility: Bool {
@@ -100,13 +125,20 @@ actor SourcePIDCache {
         /// access on subsequent calls.
         func getOrCreateExtrasMenuBar() -> UIElement? {
             // Fast path: check cached state under the lock first.
-            let (hasCached, isNegative) = lock.withLock {
-                ($0.extrasMenuBar, $0.checkedWithNoResult)
+            let now = ContinuousClock.now
+            let (hasCached, isBarred) = lock.withLock { state -> (UIElement?, Bool) in
+                guard state.extrasMenuBar == nil else {
+                    return (state.extrasMenuBar, false)
+                }
+                guard let retryAfter = state.retryAfter else {
+                    return (nil, false)
+                }
+                return (nil, retryAfter > now)
             }
             if let bar = hasCached {
                 return bar
             }
-            if isNegative {
+            if isBarred {
                 return nil
             }
 
@@ -122,28 +154,26 @@ actor SourcePIDCache {
                 let app = AXHelpers.application(for: runningApp),
                 let bar = AXHelpers.extrasMenuBar(for: app)
             else {
-                // App is reachable but has no extras menu bar.
+                // App is reachable but has no extras menu bar. Bar it from
+                // the next scans rather than flagging it permanently: it may
+                // still register a status item later, so the deadline grows
+                // with each empty check instead of never expiring.
                 lock.withLock {
                     if $0.extrasMenuBar == nil {
-                        $0.checkedWithNoResult = true
+                        $0.consecutiveMisses += 1
+                        $0.retryAfter = ContinuousClock.now + ExtrasMenuBarNegativeCachePolicy.ttl(
+                            afterConsecutiveMisses: $0.consecutiveMisses
+                        )
                     }
                 }
                 return nil
             }
-            lock.withLock { $0.extrasMenuBar = bar }
-            return bar
-        }
-
-        /// Resets the negative cache so the app will be re-checked
-        /// on the next scan. Called during cleanup to discover apps
-        /// that register status items after launch. Preserves a
-        /// valid `extrasMenuBar` to avoid unnecessary AX re-queries.
-        func resetNegativeCache() {
             lock.withLock {
-                if $0.extrasMenuBar == nil {
-                    $0.checkedWithNoResult = false
-                }
+                $0.extrasMenuBar = bar
+                $0.consecutiveMisses = 0
+                $0.retryAfter = nil
             }
+            return bar
         }
     }
 
@@ -254,7 +284,7 @@ actor SourcePIDCache {
         let windowIDs = Bridging.getMenuBarWindowList(option: .itemsOnly)
         let currentAppPids = Set(runningApps.map(\.processIdentifier))
 
-        let reusedApps = state.withLock { state -> [CachedApplication] in
+        state.withLock { state in
             // Clean up entries for terminated apps to prevent memory leaks
             let oldAppPids = Set(state.apps.map(\.processIdentifier))
             let terminatedPids = oldAppPids.subtracting(currentAppPids)
@@ -275,10 +305,6 @@ actor SourcePIDCache {
                 }
             }
 
-            // Collect reused apps to reset their negative caches after
-            // releasing the lock.
-            var reused = [CachedApplication]()
-
             // Preserve unexpired negative entries across cleanup. Dropping
             // them would let a known-unresolvable window start a full scan
             // immediately after every application-list update.
@@ -292,8 +318,11 @@ actor SourcePIDCache {
 
                 if let app = appMappings[pid] {
                     // Prefer the cached app, as it may have already done
-                    // the work to initialize its extras menu bar.
-                    reused.append(app)
+                    // the work to initialize its extras menu bar. Its
+                    // extras-bar negative deadline rides along: it expires on
+                    // its own schedule, so a status item registered after
+                    // launch is still discovered without re-probing every
+                    // app on the system each time this list changes.
                     result.apps.append(app)
                 } else {
                     // App wasn't in the cache, so it must be new.
@@ -320,14 +349,6 @@ actor SourcePIDCache {
             if !terminatedPids.isEmpty {
                 SourcePIDCache.diagLog.info("Cleaned up PID cache entries for terminated processes: \(terminatedPids)")
             }
-
-            return reused
-        }
-
-        // Reset negative caches outside the state lock so we don't
-        // hold the unfair lock while acquiring per-app locks.
-        for app in reusedApps {
-            app.resetNegativeCache()
         }
     }
 
@@ -445,6 +466,7 @@ actor SourcePIDCache {
         let thawBundleID = "com.stonerl.Thaw"
         var appsChecked = 0
         var appsWithBar = 0
+        var appsSkipped = 0
         var totalChildrenChecked = 0
         var totalMatchesFound = 0
         var unresolvedWindows = Set(allWindows.map(\.windowID))
@@ -454,6 +476,9 @@ actor SourcePIDCache {
                 break
             }
             appsChecked += 1
+            if app.isSkippingExtrasMenuBarProbe {
+                appsSkipped += 1
+            }
             autoreleasepool {
                 guard let bar = app.getOrCreateExtrasMenuBar() else {
                     return
@@ -731,7 +756,7 @@ actor SourcePIDCache {
         }
 
         let finalPID = state.withLock { $0.pids[window.windowID] }
-        SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsWithBar) with extras bar, \(totalChildrenChecked) children)")
+        SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsSkipped) skipped by negative cache, \(appsWithBar) with extras bar, \(totalChildrenChecked) children)")
 
         // Negative-cache every window that survived the full scan unresolved,
         // with a deadline that backs off as consecutive failures accumulate:

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -393,13 +393,24 @@ actor SourcePIDCache {
         }
     }
 
-    /// Whether `window` still needs the full AX traversal: no PID has been
-    /// cached for it, and any negative-cache entry has expired by `now`.
+    /// Whether `window` still needs the full AX traversal: it has area to
+    /// match on, no PID has been cached for it, and any negative-cache entry
+    /// has expired by `now`.
     ///
     /// Split out of `pidsBody` so the search predicate, the lock, and the
     /// deadline comparison are not three closures deep.
     private nonisolated func needsScan(_ window: WindowInfo, asOf now: ContinuousClock.Instant) -> Bool {
-        state.withLock { state in
+        // A window with no area cannot be matched to an accessibility
+        // element, so it must not start a scan on its own behalf: allowed to,
+        // it wakes a full traversal of every running app once per
+        // negative-cache TTL for the life of the session and never resolves.
+        // It is still resolved by a scan another window starts, and bounds
+        // are re-read on every request, so one that gains area later stops
+        // being skipped.
+        guard !window.isDegenerate else {
+            return false
+        }
+        return state.withLock { state in
             guard state.pids[window.windowID] == nil else {
                 return false
             }

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -85,6 +85,16 @@ actor SourcePIDCache {
             lock.withLock { $0.extrasMenuBar != nil }
         }
 
+        /// How many consecutive checks have found no extras menu bar.
+        ///
+        /// Zero once one is found, so this doubles as what
+        /// ``ExtrasMenuBarProbeMemory`` wants to remember: a positive count
+        /// is an application worth skipping next launch, and zero is one
+        /// whose entry must be dropped.
+        var consecutiveExtrasMenuBarMisses: Int {
+            lock.withLock { $0.consecutiveMisses }
+        }
+
         /// Whether an unexpired negative deadline would make
         /// ``getOrCreateExtrasMenuBar()`` skip its accessibility calls.
         ///
@@ -114,8 +124,22 @@ actor SourcePIDCache {
 
         /// Creates a `CachedApplication` instance with the given running
         /// application.
-        init(_ runningApp: NSRunningApplication) {
+        ///
+        /// - Parameter seed: What earlier sessions learned about this
+        ///   application, from ``ExtrasMenuBarProbeMemory``. Starting on a
+        ///   rung of the ladder rather than at the bottom is what keeps a
+        ///   cold start from re-probing the whole system; a seeded deadline
+        ///   still expires within seconds, so the memory is confirmed rather
+        ///   than believed.
+        init(_ runningApp: NSRunningApplication, seed: (misses: Int, initialTTL: Duration)? = nil) {
             self.runningApp = runningApp
+            guard let seed else {
+                return
+            }
+            lock.withLock {
+                $0.consecutiveMisses = seed.misses
+                $0.retryAfter = ContinuousClock.now + seed.initialTTL
+            }
         }
 
         /// Returns the accessibility element representing the app's extras
@@ -252,6 +276,16 @@ actor SourcePIDCache {
     /// (which remain actor-isolated) are in flight.
     private nonisolated let state = OSAllocatedUnfairLock(initialState: State())
 
+    /// What earlier sessions learned about which applications have an extras
+    /// menu bar, read once at init and rewritten as this session revises it.
+    ///
+    /// `nonisolated` and separately locked for the same reason as `state`:
+    /// it is touched from `performCleanupBody`, which is `nonisolated` and
+    /// cannot reach actor-isolated storage.
+    private nonisolated let probeMemory = OSAllocatedUnfairLock(
+        initialState: ExtrasMenuBarProbeStore.load()
+    )
+
     /// Lock to prevent multiple concurrent full scans of all applications.
     ///
     /// `nonisolated` for the same reason as `state` above — it is the
@@ -291,6 +325,7 @@ actor SourcePIDCache {
 
         let windowIDs = Bridging.getMenuBarWindowList(option: .itemsOnly)
         let currentAppPids = Set(runningApps.map(\.processIdentifier))
+        let remembered = probeMemory.withLock { $0 }
 
         state.withLock { state in
             // Clean up entries for terminated apps to prevent memory leaks
@@ -333,8 +368,18 @@ actor SourcePIDCache {
                     // app on the system each time this list changes.
                     result.apps.append(app)
                 } else {
-                    // App wasn't in the cache, so it must be new.
-                    result.apps.append(CachedApplication(app))
+                    // App wasn't in the cache, so it must be new. An app the
+                    // memory has an opinion about starts partway up the
+                    // negative-cache ladder instead of at the bottom, which
+                    // is what keeps the first scan of a session off the ~155
+                    // of ~170 applications that have never had an extras
+                    // menu bar (#956).
+                    let seed = app.bundleIdentifier.flatMap { bundleID in
+                        ExtrasMenuBarProbeMemory.seed(
+                            forRememberedMisses: remembered[bundleID]
+                        )
+                    }
+                    result.apps.append(CachedApplication(app, seed: seed))
                 }
 
                 if let pids = pidMappings[pid] {
@@ -358,6 +403,39 @@ actor SourcePIDCache {
                 SourcePIDCache.diagLog.info("Cleaned up PID cache entries for terminated processes: \(terminatedPids)")
             }
         }
+
+        recordExtrasMenuBarProbeResults(startingFrom: remembered)
+    }
+
+    /// Folds what this session has learned about extras menu bars back into
+    /// the memory the next launch starts from.
+    ///
+    /// Runs after every cleanup rather than at exit because the service has
+    /// no orderly shutdown: it is an on-demand XPC service that is killed
+    /// when the system decides it is idle, so anything not already written is
+    /// lost.
+    private nonisolated func recordExtrasMenuBarProbeResults(
+        startingFrom remembered: [String: Int]
+    ) {
+        let apps = state.withLock { $0.apps }
+        let observed = apps.reduce(into: [String: Int]()) { result, app in
+            guard let bundleID = app.bundleIdentifier else {
+                return
+            }
+            // Several processes can share a bundle identifier. The lowest
+            // count wins, so one instance publishing an extras menu bar
+            // speaks for the identifier — the direction that costs a probe
+            // rather than an unresolved item.
+            result[bundleID] = min(result[bundleID] ?? .max, app.consecutiveExtrasMenuBarMisses)
+        }
+
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: remembered,
+            observed: observed,
+            runningBundleIDs: Set(observed.keys)
+        )
+        probeMemory.withLock { $0 = merged }
+        ExtrasMenuBarProbeStore.save(merged)
     }
 
     /// Starts the observers for the cache.

--- a/MenuBarItemService/SourcePIDCache.swift
+++ b/MenuBarItemService/SourcePIDCache.swift
@@ -222,6 +222,14 @@ actor SourcePIDCache {
     // SourcePIDNegativeCachePolicy (Shared/), so the ladder is unit-testable
     // from ThawTests.
 
+    /// How long a single app's extras-bar probe may take before the scan
+    /// names it in the log.
+    ///
+    /// Low enough that a handful of slow apps stand out inside a scan that
+    /// takes a few hundred milliseconds in total, high enough that a healthy
+    /// scan says nothing at all.
+    private static let slowProbeThreshold: Duration = .milliseconds(50)
+
     /// Minimum interval between unresolved-diagnostic dumps for an unchanged
     /// unresolved set. The dump re-walks every app's AX tree, so repeating it
     /// can add seconds of IPC without yielding new information.
@@ -461,6 +469,7 @@ actor SourcePIDCache {
         }
 
         SourcePIDCache.diagLog.debug("SourcePIDCache.pid: performing batch resolution via AX API")
+        let scanStart = ContinuousClock.now
 
         // Fetch all current menu bar item windows to perform a single batch resolution.
         // This avoids doing the O(W*A*C) work (Windows * Apps * Children) for every request.
@@ -491,7 +500,25 @@ actor SourcePIDCache {
                 appsSkipped += 1
             }
             autoreleasepool {
-                guard let bar = app.getOrCreateExtrasMenuBar() else {
+                // Accessibility reads are serviced by the *target* process,
+                // normally on its main thread, and are bounded only by the
+                // unresponsive timeout set in `init`. One busy app can
+                // therefore account for most of a scan's wall time. Naming
+                // the slow ones is what separates "the app list is too long"
+                // from "two apps are wedged" — the first calls for a
+                // narrower scan, the second for a shorter timeout, and a
+                // total alone cannot tell them apart.
+                let probeStart = ContinuousClock.now
+                let bar = app.getOrCreateExtrasMenuBar()
+                let probeDuration = ContinuousClock.now - probeStart
+                if probeDuration >= SourcePIDCache.slowProbeThreshold {
+                    let label = app.bundleIdentifier ?? app.localizedName ?? "pid \(app.processIdentifier)"
+                    SourcePIDCache.diagLog.debug(
+                        "SourcePIDCache.pid: slow extras-bar probe: \(label) took \(probeDuration)"
+                    )
+                }
+
+                guard let bar else {
                     return
                 }
                 appsWithBar += 1
@@ -767,7 +794,7 @@ actor SourcePIDCache {
         }
 
         let finalPID = state.withLock { $0.pids[window.windowID] }
-        SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsSkipped) skipped by negative cache, \(appsWithBar) with extras bar, \(totalChildrenChecked) children)")
+        SourcePIDCache.diagLog.debug("SourcePIDCache.pid: batch resolution finished. Found \(totalMatchesFound) matches. Requested windowID \(window.windowID) -> PID \(finalPID.map { "\($0)" } ?? "nil") (checked \(appsChecked) apps, \(appsSkipped) skipped by negative cache, \(appsWithBar) with extras bar, \(totalChildrenChecked) children, took \(ContinuousClock.now - scanStart))")
 
         // Negative-cache every window that survived the full scan unresolved,
         // with a deadline that backs off as consecutive failures accumulate:

--- a/Shared/Utilities/ExtrasMenuBarNegativeCachePolicy.swift
+++ b/Shared/Utilities/ExtrasMenuBarNegativeCachePolicy.swift
@@ -1,0 +1,45 @@
+//
+//  ExtrasMenuBarNegativeCachePolicy.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+/// TTL ladder for the per-application extras-menu-bar negative cache.
+///
+/// A full source-PID scan walks every running application and asks each one
+/// for its extras menu bar over the Accessibility API. On a typical system
+/// only ~16 of ~170 running applications ever have one, so the other ~155
+/// contribute nothing but blocking IPC — and an AX read is serviced by the
+/// *target* process, usually on its main thread, so a wide scan makes the
+/// whole system stutter rather than just this service.
+///
+/// A bare "checked, no result" flag is not enough on its own, because the
+/// flag has to be cleared periodically: an application can register a status
+/// item long after it finishes launching. Clearing it on every cache cleanup
+/// made the flag nearly worthless — cleanup is driven by
+/// `NSWorkspace.runningApplications`, which churns whenever *any* process on
+/// the system starts or exits (observed at ~9s intervals in the field), so
+/// every scan re-probed the whole application list.
+///
+/// Deadlines replace the flag. Repeated misses back off, so an application
+/// that has never had an extras menu bar is re-probed at the steady-state
+/// interval instead of on every scan, while the early rungs stay short enough
+/// to catch an application that publishes a status item shortly after launch.
+nonisolated enum ExtrasMenuBarNegativeCachePolicy {
+    /// How long an application that reported no extras menu bar is skipped,
+    /// after `misses` consecutive checks have come back empty (1 = the first
+    /// miss).
+    ///
+    /// Values at or below 1 clamp to the first rung so a bookkeeping error
+    /// upstream degrades to more scanning, never to a permanent bar.
+    static func ttl(afterConsecutiveMisses misses: Int) -> Duration {
+        switch misses {
+        case ...1: .seconds(5)
+        case 2: .seconds(30)
+        case 3: .seconds(120)
+        default: .seconds(300)
+        }
+    }
+}

--- a/Shared/Utilities/ExtrasMenuBarProbeMemory.swift
+++ b/Shared/Utilities/ExtrasMenuBarProbeMemory.swift
@@ -1,0 +1,124 @@
+//
+//  ExtrasMenuBarProbeMemory.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+
+/// What the extras-menu-bar probe learned about each application in earlier
+/// sessions, so a cold start does not pay to learn it again.
+///
+/// `ExtrasMenuBarNegativeCachePolicy` keeps a full scan off the ~155 of ~170
+/// running applications that have no extras menu bar, but it builds that
+/// knowledge from nothing every launch: the first scan after start probes
+/// every application over the Accessibility API, and an AX read is serviced
+/// by the *target* process on its main thread. That scan measured 3.85s in
+/// the log attached to #956, landing squarely in the window where the app is
+/// restoring a layout and the user is trying to use their machine.
+///
+/// An application that had no extras menu bar last session almost certainly
+/// has none now, and remembering that is the difference between probing the
+/// system and probing the handful of hosts that matter.
+///
+/// This memory only ever reorders work; it can never produce an answer.
+/// Skipping an application leaves items unresolved for one scan, which the
+/// layout gates already wait for and `MenuBarItemNameMemory` already papers
+/// over for display — it cannot attribute an item to the wrong owner, which
+/// is why the memory is trusted here and deliberately not trusted for
+/// identity.
+nonisolated enum ExtrasMenuBarProbeMemory {
+    /// The largest number of remembered applications kept.
+    ///
+    /// A busy system runs ~170 applications; the rest of the budget absorbs
+    /// years of installing and removing them. An entry for an application
+    /// that is never launched again is never read, so this exists only to
+    /// bound growth.
+    static let capacity = 1024
+
+    /// How many consecutive misses an application must have accumulated
+    /// before the result is worth remembering across launches.
+    ///
+    /// One miss is not evidence. An application probed while it was still
+    /// launching, or while it was wedged, reports no extras menu bar for
+    /// reasons that have nothing to do with whether it has one — and
+    /// `getOrCreateExtrasMenuBar()` only refuses to count the cases it can
+    /// detect. Two consecutive misses within a session is the cheapest
+    /// filter that excludes the transient one.
+    static let minimumMissesToRemember = 2
+
+    /// The largest miss count stored.
+    ///
+    /// `ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses:)`
+    /// saturates at its top rung, so counting past it records nothing the
+    /// ladder can act on.
+    static let maximumRememberedMisses = 4
+
+    /// The state a freshly created cache entry should adopt for an
+    /// application the memory has an opinion about, or `nil` when it has
+    /// none worth acting on.
+    ///
+    /// The deadline is deliberately the *first* rung rather than the one the
+    /// miss count earns. Memory is good enough to say "probably nothing
+    /// here", which is exactly the claim needed to stay out of the cold-start
+    /// scan — the most expensive scan there is, and the one running while
+    /// half the system is still launching. It is not good enough to buy five
+    /// minutes of silence: an application that gained a status item since
+    /// last session would go unnoticed for that whole window. One confirming
+    /// probe a few seconds later settles it, and costs a single AX round trip
+    /// at a moment when nothing else is competing for the main thread.
+    ///
+    /// The seeded count is what makes the confirmation cheap: an application
+    /// that misses again resumes the ladder where it left off instead of
+    /// climbing 5s → 30s → 120s → 300s from the bottom a second time.
+    static func seed(forRememberedMisses misses: Int?) -> (misses: Int, initialTTL: Duration)? {
+        guard let misses, misses >= minimumMissesToRemember else {
+            return nil
+        }
+        return (
+            misses: min(misses, maximumRememberedMisses),
+            initialTTL: ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 1)
+        )
+    }
+
+    /// The memory to persist, given what was already stored and what this
+    /// session observed.
+    ///
+    /// - Parameters:
+    ///   - persisted: The memory as it was last written.
+    ///   - observed: Consecutive misses per bundle identifier for the
+    ///     applications running now. Zero means the application has an extras
+    ///     menu bar, since finding one resets the count.
+    ///   - runningBundleIDs: The applications running now, used to decide
+    ///     what to evict when the memory is over capacity.
+    ///
+    /// An observation always wins over what was stored, in both directions:
+    /// an application that has since published an extras menu bar loses its
+    /// entry outright rather than decaying out of one, because a stale entry
+    /// here costs that application's items a scan on every future launch.
+    static func merged(
+        persisted: [String: Int],
+        observed: [String: Int],
+        runningBundleIDs: Set<String>
+    ) -> [String: Int] {
+        var merged = persisted
+
+        for (bundleID, misses) in observed {
+            if misses >= minimumMissesToRemember {
+                merged[bundleID] = min(misses, maximumRememberedMisses)
+            } else {
+                merged.removeValue(forKey: bundleID)
+            }
+        }
+
+        guard merged.count > capacity else {
+            return merged
+        }
+        // Everything running now is worth keeping and the overflow is
+        // necessarily made up of applications that are not, which mirrors how
+        // `MenuBarItemNameMemory` sheds its own overflow.
+        return merged.filter { runningBundleIDs.contains($0.key) }
+    }
+}

--- a/Shared/Utilities/WindowInfo.swift
+++ b/Shared/Utilities/WindowInfo.swift
@@ -46,6 +46,23 @@ nonisolated struct WindowInfo {
         ownerName == "Window Server"
     }
 
+    /// A Boolean value that indicates whether the window has no area to
+    /// match an accessibility element against.
+    ///
+    /// Every source-PID match path anchors on this window's centre — the
+    /// strict pass, the owner-corroborated pass, and the marker-pair
+    /// fallback all compare it against an accessibility element's frame. A
+    /// window with zero width or height has no centre worth comparing, so a
+    /// full scan started on its behalf cannot succeed.
+    ///
+    /// These are real and they persist. The log attached to #956 carries a
+    /// status item at `(-4323, 0, 0, 0)` whose nearest accessibility frame
+    /// is Control Center's own zero-width placeholder; nine consecutive
+    /// scans over seven minutes left it unresolved.
+    var isDegenerate: Bool {
+        bounds.isEmpty
+    }
+
     /// A Boolean value that indicates whether the window is a menu-related window.
     ///
     /// This property returns `true` if the window's layer corresponds to a

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -920,13 +920,24 @@ nonisolated enum LayoutSolver {
         liveMovableUIDs: Set<String>,
         unanchorableUIDs: Set<String> = []
     ) -> HiddenDividerAnchor? {
-        if let rightmostHidden = desiredHidden.first(where: liveMovableUIDs.contains) {
-            return unanchorableUIDs.contains(rightmostHidden) ? nil : .rightOf(rightmostHidden)
+        // One selection rule, shared with hiddenDividerAnchorCandidate so a
+        // caller logging the refused candidate can never name an item other
+        // than the one this planner considered.
+        guard let candidate = hiddenDividerAnchorCandidate(
+            desiredHidden: desiredHidden,
+            desiredVisible: desiredVisible,
+            liveMovableUIDs: liveMovableUIDs
+        ) else {
+            return nil
         }
-        if let leftmostVisible = desiredVisible.last(where: liveMovableUIDs.contains) {
-            return unanchorableUIDs.contains(leftmostVisible) ? nil : .leftOf(leftmostVisible)
+        if unanchorableUIDs.contains(candidate) {
+            return nil
         }
-        return nil
+        // Hidden side first: rightOf it. Visible side only as fallback:
+        // leftOf it.
+        return desiredHidden.first(where: liveMovableUIDs.contains) == candidate
+            ? .rightOf(candidate)
+            : .leftOf(candidate)
     }
 
     /// The item ``planHiddenDividerAnchor(desiredHidden:desiredVisible:liveMovableUIDs:unanchorableUIDs:)``

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -767,6 +767,45 @@ nonisolated enum LayoutSolver {
         desiredHidden: Set<String>,
         desiredAlwaysHidden: Set<String>
     ) -> Int {
+        hiddenBoundaryOffenders(
+            currentVisible: currentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: currentAlwaysHidden,
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: desiredAlwaysHidden
+        ).count
+    }
+
+    /// The items counted by ``hiddenBoundaryMismatch(currentVisible:currentHidden:currentAlwaysHidden:desiredVisible:desiredHidden:desiredAlwaysHidden:)``,
+    /// named and split by the direction they have to travel.
+    ///
+    /// The tally decides that a repair is needed; this decides what the
+    /// repair moves. Deriving one from the other keeps a caller that fixes
+    /// the boundary item-by-item from disagreeing with the count that sent
+    /// it there.
+    struct HiddenBoundaryOffenders: Equatable {
+        /// Currently visible, wanted in hidden or always-hidden. These
+        /// travel to the divider's concealed side.
+        var wronglyVisible: Set<String>
+        /// Currently concealed, wanted in visible. These travel to its
+        /// visible side.
+        var wronglyConcealed: Set<String>
+
+        var count: Int { wronglyVisible.count + wronglyConcealed.count }
+    }
+
+    /// Splits the boundary mismatch into the two directions of travel.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func hiddenBoundaryOffenders(
+        currentVisible: Set<String>,
+        currentHidden: Set<String>,
+        currentAlwaysHidden: Set<String>,
+        desiredVisible: Set<String>,
+        desiredHidden: Set<String>,
+        desiredAlwaysHidden: Set<String>
+    ) -> HiddenBoundaryOffenders {
         // Everything the profile places left of the hidden divider, in
         // either of the two concealed sections. Which of the two an item
         // lands in is the always-hidden divider's problem, handled by the
@@ -774,10 +813,45 @@ nonisolated enum LayoutSolver {
         let desiredConcealed = desiredHidden.union(desiredAlwaysHidden)
         let currentConcealed = currentHidden.union(currentAlwaysHidden)
 
-        let wronglyVisible = currentVisible.intersection(desiredConcealed)
-        let wronglyConcealed = currentConcealed.intersection(desiredVisible)
+        return HiddenBoundaryOffenders(
+            wronglyVisible: currentVisible.intersection(desiredConcealed),
+            wronglyConcealed: currentConcealed.intersection(desiredVisible)
+        )
+    }
 
-        return wronglyVisible.count + wronglyConcealed.count
+    /// Whether a boundary mismatch should be repaired by dragging the
+    /// hidden divider, or by moving the offending items to it.
+    ///
+    /// Dragging H_ctrl re-sections every item it crosses. The cost is the
+    /// whole bar and the benefit is one drag, so the trade is only worth
+    /// taking when the divider itself is what drifted rather than the
+    /// items. That shows up as a side with nothing live left on it:
+    ///
+    /// - Nothing concealed is #879, where the divider had drifted past
+    ///   every managed item and eighteen of eighteen read visible. Moving
+    ///   them one at a time would mean eighteen drags across a boundary
+    ///   that is in the wrong place anyway.
+    /// - Nothing visible is the collapse in #958, where the whole bar has
+    ///   ended up behind the divider. The drag is the recovery.
+    ///
+    /// Anything in between means the divider is roughly where it belongs
+    /// and some items have wandered across it. #958's 21 August log is the
+    /// case that settles the trade: one item on the wrong side, nine still
+    /// correctly concealed, and the drag planned to reach that one item
+    /// would have carried H_ctrl from minX -3871 to 1648, across the
+    /// entire visible section.
+    ///
+    /// Counts exclude the control items. The chevron is always on the
+    /// visible side of H_ctrl, so counting it would keep `liveVisibleCount`
+    /// above zero on precisely the collapsed bar the second case exists to
+    /// rescue.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func shouldMoveHiddenDivider(
+        liveConcealedCount: Int,
+        liveVisibleCount: Int
+    ) -> Bool {
+        liveConcealedCount == 0 || liveVisibleCount == 0
     }
 
     /// Plans where to drag the hidden divider so the visible/hidden split

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -765,7 +765,8 @@ nonisolated enum LayoutSolver {
         currentAlwaysHidden: Set<String>,
         desiredVisible: Set<String>,
         desiredHidden: Set<String>,
-        desiredAlwaysHidden: Set<String>
+        desiredAlwaysHidden: Set<String>,
+        overflowExemptUIDs: Set<String> = []
     ) -> Int {
         hiddenBoundaryOffenders(
             currentVisible: currentVisible,
@@ -773,7 +774,8 @@ nonisolated enum LayoutSolver {
             currentAlwaysHidden: currentAlwaysHidden,
             desiredVisible: desiredVisible,
             desiredHidden: desiredHidden,
-            desiredAlwaysHidden: desiredAlwaysHidden
+            desiredAlwaysHidden: desiredAlwaysHidden,
+            overflowExemptUIDs: overflowExemptUIDs
         ).count
     }
 
@@ -793,9 +795,24 @@ nonisolated enum LayoutSolver {
         var wronglyConcealed: Set<String>
 
         var count: Int { wronglyVisible.count + wronglyConcealed.count }
+
+        var isEmpty: Bool {
+            wronglyVisible.isEmpty && wronglyConcealed.isEmpty
+        }
     }
 
     /// Splits the boundary mismatch into the two directions of travel.
+    ///
+    /// `overflowExemptUIDs` carries the notch-overflow eject set
+    /// (`notchOverflowEjectedUIDs`). An ejected item sits in hidden while
+    /// the profile still lists it visible — that divergence is by design,
+    /// the same rule `currentLayoutDivergesFromSaved` applies through its
+    /// own overflow exemption. Counting it here makes Phase 1 recall the
+    /// item to visible every apply and the next cycle's overflow plan
+    /// eject it again: a two-drag oscillation for as long as the bar stays
+    /// over budget (#958's 20 August log, nk-tedo-001). The exemption only
+    /// covers an item actually sitting in hidden; one that drifted into
+    /// always-hidden is genuine drift and keeps counting.
     ///
     /// Pure over its inputs.
     static nonisolated func hiddenBoundaryOffenders(
@@ -804,7 +821,8 @@ nonisolated enum LayoutSolver {
         currentAlwaysHidden: Set<String>,
         desiredVisible: Set<String>,
         desiredHidden: Set<String>,
-        desiredAlwaysHidden: Set<String>
+        desiredAlwaysHidden: Set<String>,
+        overflowExemptUIDs: Set<String> = []
     ) -> HiddenBoundaryOffenders {
         // Everything the profile places left of the hidden divider, in
         // either of the two concealed sections. Which of the two an item
@@ -816,6 +834,7 @@ nonisolated enum LayoutSolver {
         return HiddenBoundaryOffenders(
             wronglyVisible: currentVisible.intersection(desiredConcealed),
             wronglyConcealed: currentConcealed.intersection(desiredVisible)
+                .subtracting(overflowExemptUIDs.intersection(currentHidden))
         )
     }
 

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -1809,7 +1809,9 @@ nonisolated enum LayoutSolver {
             gate.alwaysHiddenSectionResolved &&
             gate.hiddenSectionHasRoom &&
             !gate.hasPendingDivergence &&
-            !gate.hasUnfinishedMoveBatch
+            !gate.hasUnfinishedMoveBatch &&
+            !gate.isWithinMoveCooldown &&
+            !gate.menuBarDisplayChanged
     }
 
     /// The signals ``shouldPersistSavedOrder(_:)`` reads.
@@ -1829,6 +1831,34 @@ nonisolated enum LayoutSolver {
         var hiddenSectionHasRoom = true
         var hasPendingDivergence = false
         var hasUnfinishedMoveBatch = false
+
+        /// Whether a move landed recently enough that `applySavedLayout`
+        /// would decline to run.
+        ///
+        /// The two paths have to agree. `applySavedLayout` holds a five
+        /// second cooldown after any move so a wave of relaunching apps
+        /// cannot cascade into re-applies; this gate did not, so a cycle
+        /// inside the cooldown skipped the restore and took the save,
+        /// which is the one ordering that writes an unsettled bar down as
+        /// the user's layout. In the #958 log that pairing is a single
+        /// millisecond apart, and it moved twelve items out of the
+        /// visible section for good.
+        var isWithinMoveCooldown = false
+
+        /// Whether the menu bar is on a different display than it was on
+        /// the cycle that produced the current cache.
+        ///
+        /// macOS moves status items to the new screen one at a time, so a
+        /// snapshot taken during the relocation reads a bar that is
+        /// partly on each. `itemsSpanMultipleDisplays` is meant to catch
+        /// exactly that, but it can only see the items still classified
+        /// visible — and misclassification is the fault, so by the time
+        /// it matters the evidence has already been moved out of its
+        /// input. It correctly stopped a save 2.5 minutes earlier in the
+        /// #958 log with sixteen visible items, then passed the one that
+        /// mattered with four. This signal is derived from the displays
+        /// themselves and does not thin out as items are misread.
+        var menuBarDisplayChanged = false
     }
 
     /// Whether the always-hidden section is resolved well enough for the

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -541,11 +541,20 @@ nonisolated enum LayoutSolver {
     /// so the divider flickers on-screen then springs back once per attempt
     /// for the full retry budget (#881: cursor seizure and icon storm).
     ///
-    /// Pure over its inputs. Matches the center-on-screen convention used
-    /// by ``itemsSpanMultipleDisplays(itemCenters:screenFrames:)``.
+    /// Measured at the leading edge, not the center. A collapsed hidden
+    /// divider is 5000 points wide — that width is how the section conceals
+    /// the items to its left — so its center sits 2500 points right of the
+    /// divider itself. In #958 the divider was parked at minX -3871 with a
+    /// center at -1371, which on a three-display arrangement with a display
+    /// left of the origin lands squarely on a screen. The guard that was
+    /// meant to refuse a drag from a parked divider read that center, saw a
+    /// screen, and let the drag through. Every ordinary item is narrow
+    /// enough that the two measurements agree.
+    ///
+    /// Pure over its inputs.
     static nonisolated func isOnScreen(bounds: CGRect, screenFrames: [CGRect]) -> Bool {
-        let center = CGPoint(x: bounds.midX, y: bounds.midY)
-        return screenFrames.contains { $0.contains(center) }
+        let leadingEdge = CGPoint(x: bounds.minX, y: bounds.midY)
+        return screenFrames.contains { $0.contains(leadingEdge) }
     }
 
     // MARK: - Notch overflow
@@ -2022,7 +2031,7 @@ nonisolated enum LayoutSolver {
     /// closed always-hidden section full of legitimately parked items does not
     /// read as a fault.
     ///
-    /// Pure over its inputs. Matches the center-on-screen convention used by
+    /// Pure over its inputs. Off-bar membership is decided by
     /// ``isOnScreen(bounds:screenFrames:)``.
     static nonisolated func hasVisibleItemParkedOffBar(
         itemBounds: [CGRect],

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -787,20 +787,63 @@ nonisolated enum LayoutSolver {
     /// profile that empties the hidden section still parks the divider
     /// past every visible item instead of leaving it mid-bar.
     ///
+    /// An anchor in `unanchorableUIDs` yields nil rather than a search
+    /// that continues past it. The anchor names the gap the divider
+    /// belongs in, so the next candidate along is an item the profile
+    /// wants on the *other* side of that gap; anchoring there would drag
+    /// the divider past an item instead of up to it.
+    ///
+    /// Thaw's own control items are what reaches that test. The caller's
+    /// candidate set is already filtered to items that are movable and on
+    /// screen, and the chevron satisfies both whatever the rest of the bar
+    /// is doing — which makes it the anchor of last resort in exactly the
+    /// passes where every real item on its side has been dragged off the
+    /// bar and filtered out. #958's reporter restored a known-good plist
+    /// with Thaw quit and watched the first apply after relaunch collapse
+    /// it again: eleven items the profile assigns to visible were sitting
+    /// parked on the hidden side, nothing else visible was live, and the
+    /// fallback returned the chevron. Dragging H_ctrl up to it swept the
+    /// rest of the section across with it.
+    ///
+    /// Returning nil leaves the boundary where it is and hands the work to
+    /// the per-item LCS pass, which moves the items back to the divider.
+    /// That is the direction that restores the profile; this move is the
+    /// direction that destroys it.
+    ///
     /// Pure over its inputs. Returns nil when neither section has a live
     /// movable member to anchor against.
     static nonisolated func planHiddenDividerAnchor(
         desiredHidden: [String],
         desiredVisible: [String],
-        liveMovableUIDs: Set<String>
+        liveMovableUIDs: Set<String>,
+        unanchorableUIDs: Set<String> = []
     ) -> HiddenDividerAnchor? {
         if let rightmostHidden = desiredHidden.first(where: liveMovableUIDs.contains) {
-            return .rightOf(rightmostHidden)
+            return unanchorableUIDs.contains(rightmostHidden) ? nil : .rightOf(rightmostHidden)
         }
         if let leftmostVisible = desiredVisible.last(where: liveMovableUIDs.contains) {
-            return .leftOf(leftmostVisible)
+            return unanchorableUIDs.contains(leftmostVisible) ? nil : .leftOf(leftmostVisible)
         }
         return nil
+    }
+
+    /// The item ``planHiddenDividerAnchor(desiredHidden:desiredVisible:liveMovableUIDs:unanchorableUIDs:)``
+    /// picks before the unanchorable test, so the caller's log line can say
+    /// which item was refused instead of reporting a bar with nothing live
+    /// as the same event.
+    ///
+    /// The two nil cases need telling apart in the field: one says the
+    /// profile's items are not on the bar right now, the other says they
+    /// are on the wrong side of it and the divider must not chase them.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func hiddenDividerAnchorCandidate(
+        desiredHidden: [String],
+        desiredVisible: [String],
+        liveMovableUIDs: Set<String>
+    ) -> String? {
+        desiredHidden.first(where: liveMovableUIDs.contains)
+            ?? desiredVisible.last(where: liveMovableUIDs.contains)
     }
 
     // MARK: - LCS reorder

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem.swift
@@ -201,7 +201,11 @@ nonisolated struct MenuBarItem: CustomStringConvertible {
         lazy var fallbackName = "Menu Bar Item"
 
         guard let sourceApplication else {
-            return fallbackName
+            // The source process has not resolved yet. Fall back to the name
+            // this item resolved to on an earlier pass or launch rather than
+            // labelling everything on the bar "Menu Bar Item" for the few
+            // seconds the accessibility scan takes (#956).
+            return MenuBarItemNameMemory.rememberedName(for: self) ?? fallbackName
         }
 
         lazy var sourceName = sourceApplication.localizedName ?? sourceApplication.bundleIdentifier

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemFailureLedger.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemFailureLedger.swift
@@ -84,19 +84,33 @@ final class MenuBarItemFailureLedger {
     /// When each marked key was last seen failing as an unresponsive owner.
     private var markDates: [String: Date]
 
-    /// Keys that have failed once in this session but are not marked yet.
+    /// How many times each key has failed against an unresponsive owner in
+    /// this session, for keys not yet marked.
     ///
     /// A single failure is not evidence. Event operations can time out for
     /// reasons that have nothing to do with the owner — contention on the
     /// event semaphore is the obvious one — and a mark earned that way
     /// would stand for two weeks against an app that was never at fault.
-    /// Requiring a second failure costs the pathological case nothing,
-    /// since an owner that never answers reaches two within the same
-    /// session.
+    /// Requiring a run of them costs the pathological case nothing, since an
+    /// owner that never answers reaches the threshold within one session.
     ///
-    /// Deliberately not persisted: a lone failure per session is not the
-    /// behaviour this ledger exists to remember.
-    private var provisionalMarks = Set<String>()
+    /// Deliberately not persisted: a handful of failures in a single session
+    /// is not the behaviour this ledger exists to remember.
+    private var provisionalMarks = [String: Int]()
+
+    /// How many unresponsive-owner failures a key must accumulate in one
+    /// session before it earns a persisted mark.
+    ///
+    /// Two was the intent and one was the effect: `move` filed a failure
+    /// before throwing and its callers filed the same failure again on the
+    /// catch, so a single failed bulk-apply move satisfied both halves at
+    /// once. `MenuBarItemManager.moveAlreadyFiledFailure(for:)` closes that,
+    /// which restores two as a real threshold — and two failed moves is
+    /// thinner evidence than it sounds during a startup restore wave, where
+    /// contention alone can cost an item its budget twice. Three keeps the
+    /// verdict for owners that are actually silent, at the cost of one more
+    /// retry cycle for the ones that are.
+    private static let failuresBeforeMarking = 3
 
     init() {
         let storedBuild = Defaults.string(forKey: .unresponsiveMenuBarItemsBuild)
@@ -196,7 +210,8 @@ final class MenuBarItemFailureLedger {
     /// Records a failed operation.
     ///
     /// Every failure extends the backoff window. Only an unresponsive owner
-    /// can earn a persisted mark, and only on its second such failure.
+    /// can earn a persisted mark, and only once it has failed that way
+    /// ``failuresBeforeMarking`` times in this session.
     func recordFailure(
         for item: MenuBarItem,
         kind: FailureKind,
@@ -209,9 +224,15 @@ final class MenuBarItemFailureLedger {
             return
         }
         let wasMarked = markDates[key] != nil
-        guard wasMarked || !provisionalMarks.insert(key).inserted else {
-            Self.diagLog.debug("\(key) failed once; waiting for a second failure before marking it")
-            return
+        if !wasMarked {
+            let failures = (provisionalMarks[key] ?? 0) + 1
+            provisionalMarks[key] = failures
+            guard failures >= Self.failuresBeforeMarking else {
+                Self.diagLog.debug(
+                    "\(key) failed \(failures) time(s); waiting for \(Self.failuresBeforeMarking) before marking it"
+                )
+                return
+            }
         }
         markDates[key] = .now
         persist()
@@ -227,7 +248,7 @@ final class MenuBarItemFailureLedger {
     func recordSuccess(for item: MenuBarItem) {
         let key = Self.key(for: item)
         backoffHistory.removeValue(forKey: key)
-        provisionalMarks.remove(key)
+        provisionalMarks.removeValue(forKey: key)
         guard markDates.removeValue(forKey: key) != nil else {
             return
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -192,6 +192,22 @@ extension MenuBarItemManager {
         _ thawIcon: MenuBarItem,
         controlItems: ControlItemPair
     ) async -> Bool {
+        // The destination is the right of H_ctrl. When the divider itself is
+        // parked offscreen, that destination is in the parked zone: the drag
+        // strands the chevron beside it, invisible to the user (#958's
+        // 16:32:49.505 move dragged the chevron toward a divider parked at
+        // minX -3440). Worse, the move engine warps to the chevron's cached
+        // frame to start the drag, and a cached on-screen frame over a
+        // physically parked chevron clicks whatever item now occupies that
+        // frame. The #881 recovery this relocation exists for needs the
+        // divider on screen anyway; until it is, skipping is strictly better.
+        let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+        if !LayoutSolver.isOnScreen(bounds: bestBounds(for: controlItems.hidden), screenFrames: screenFrames) {
+            MenuBarItemManager.diagLog.warning(
+                "Skipping Thaw icon relocation, the hidden divider is parked offscreen (minX=\(controlItems.hidden.bounds.minX)); moving the icon beside it would strand both"
+            )
+            return false
+        }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
         do {
             try await move(
@@ -402,6 +418,19 @@ extension MenuBarItemManager {
             let alwaysHidden = controlItems.alwaysHidden,
             bestBounds(for: hidden).maxX <= bestBounds(for: alwaysHidden).minX
         else {
+            return
+        }
+
+        // Moving AH_ctrl to the left of a parked H_ctrl drops the entire
+        // always-hidden section into the parked zone with it. The inversion
+        // this enforces cannot be fixed while the reference divider is
+        // stranded; defer to the recovery paths the same way the boundary
+        // repair and the per-item moves do.
+        let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+        if !LayoutSolver.isOnScreen(bounds: bestBounds(for: hidden), screenFrames: screenFrames) {
+            MenuBarItemManager.diagLog.warning(
+                "Skipping control item order enforcement, the hidden divider is parked offscreen (minX=\(hidden.bounds.minX))"
+            )
             return
         }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -772,7 +772,11 @@ extension MenuBarItemManager {
 
         if recoverCollapsedHiddenSectionIfNeeded(
             hiddenSectionHasRoom: hiddenSectionHasRoom,
-            controlItems: context.controlItems
+            controlItems: context.controlItems,
+            // The dividers are excluded: a rebuild that only has the two
+            // control items to place cannot strand anything on the wrong
+            // side of the one it is rebuilding.
+            managedItemCount: context.cache.managedItems.count(where: { !$0.isControlItem })
         ) {
             return
         }
@@ -951,13 +955,17 @@ extension MenuBarItemManager {
         completedCacheCycles += 1
     }
 
-    /// Recreates the hidden divider at its seeded position after repeated,
-    /// authoritative evidence that stale geometry closed the hidden span.
+    /// Rebuilds the hidden divider after repeated, authoritative evidence
+    /// that stale geometry closed the hidden span.
     /// The saved order remains untouched, so the next cache pass can restore
     /// section membership through the normal saved-layout apply.
+    ///
+    /// `managedItemCount` decides whether the rebuild may also re-stamp the
+    /// seeded position. See ``canSeedRebuiltDividerPosition(managedItemCount:)``.
     private func recoverCollapsedHiddenSectionIfNeeded(
         hiddenSectionHasRoom: Bool,
-        controlItems: ControlItemPair
+        controlItems: ControlItemPair,
+        managedItemCount: Int
     ) -> Bool {
         // A provisional reading must not advance, reset, or re-arm the
         // recovery episode. Only authoritative observations may mutate it.
@@ -982,10 +990,11 @@ extension MenuBarItemManager {
         }
 
         didRecoverHiddenSectionForCurrentCollapse = true
+        let seedPosition = Self.seedPositionForRebuiltDivider(managedItemCount: managedItemCount)
         MenuBarItemManager.diagLog.warning(
-            "Hidden section remained collapsed for \(hiddenSectionCollapseStreak) authoritative cache passes; recreating H_ctrl at its seeded position"
+            "Hidden section remained collapsed for \(hiddenSectionCollapseStreak) authoritative cache passes; rebuilding H_ctrl\(Self.seedDescription(seedPosition))"
         )
-        hiddenControlItem.recreateStatusItem(preferredPosition: 1)
+        hiddenControlItem.recreateStatusItem(preferredPosition: seedPosition)
 
         Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(100))
@@ -994,12 +1003,16 @@ extension MenuBarItemManager {
         return true
     }
 
-    /// Recreates an authoritatively identified hidden divider after it remains
+    /// Rebuilds an authoritatively identified hidden divider after it remains
     /// parked through repeated layout applies that need it on the bar.
+    ///
+    /// `managedItemCount` decides whether the rebuild may also re-stamp the
+    /// seeded position. See ``canSeedRebuiltDividerPosition(managedItemCount:)``.
     func recoverParkedHiddenDividerIfNeeded(
         hiddenBoundaryMismatch: Int,
         hiddenControlItem: MenuBarItem,
-        screenFrames: [CGRect]
+        screenFrames: [CGRect],
+        managedItemCount: Int
     ) -> Bool {
         guard hiddenBoundaryMismatch > 0,
               !LayoutSolver.isOnScreen(bounds: hiddenControlItem.bounds, screenFrames: screenFrames)
@@ -1020,10 +1033,11 @@ extension MenuBarItemManager {
         }
 
         didRecoverParkedHiddenDividerForCurrentMismatch = true
+        let seedPosition = Self.seedPositionForRebuiltDivider(managedItemCount: managedItemCount)
         MenuBarItemManager.diagLog.warning(
-            "H_ctrl remained parked through \(parkedHiddenDividerMismatchStreak) authoritative mismatch applies; recreating it at its seeded position"
+            "H_ctrl remained parked through \(parkedHiddenDividerMismatchStreak) authoritative mismatch applies; rebuilding it\(Self.seedDescription(seedPosition))"
         )
-        hiddenControl.recreateStatusItem(preferredPosition: 1)
+        hiddenControl.recreateStatusItem(preferredPosition: seedPosition)
 
         Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(100))

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -787,6 +787,11 @@ extension MenuBarItemManager {
             return
         }
 
+        // Read before the assignment below overwrites it: the save gate needs
+        // to know whether the menu bar changed display between the cycle that
+        // produced the standing cache and this one (#958).
+        let previousCacheDisplayID = itemCache.displayID
+
         itemCache = context.cache
 
         // Remember what the resolved items are called, so the next launch can
@@ -803,6 +808,30 @@ extension MenuBarItemManager {
 
         let hasPendingDivergence = pendingDivergenceObservedAt != nil
 
+        // Mirrors applySavedLayout's own cooldown. Whatever stops the restore
+        // has to stop the save, or the cycle that skips one and takes the
+        // other writes down a bar nobody arranged (#958).
+        //
+        // A move the user made themselves is exempt, and the exemption is
+        // load-bearing rather than a nicety: after a Layout-editor drag the
+        // live bar diverges from the saved order, and it is the save winning
+        // inside the cooldown that makes the drag the new saved order. Hold
+        // it back and the restore, once the cooldown lapses, reads the drag
+        // as drift and reverts it.
+        let isWithinMoveCooldown = lastMoveOperationOccurred(within: .seconds(5)) &&
+            !lastUserMoveOperationOccurred(within: .seconds(5))
+
+        // A relocation in progress. Both displays have to be known for the
+        // comparison to mean anything: a nil on either side is the ordinary
+        // first cycle, not a change.
+        let menuBarDisplayChanged: Bool = if let previousCacheDisplayID,
+                                            let currentDisplayID = context.cache.displayID
+        {
+            previousCacheDisplayID != currentDisplayID
+        } else {
+            false
+        }
+
         // The bar after a batch that gave up partway is the batch's own
         // wreckage, not a layout anyone chose. Recording it hands the next
         // pass a target it just moved, which is how a failed apply turns
@@ -818,7 +847,9 @@ extension MenuBarItemManager {
                    alwaysHiddenSectionResolved: alwaysHiddenSectionResolved,
                    hiddenSectionHasRoom: hiddenSectionHasRoom,
                    hasPendingDivergence: hasPendingDivergence,
-                   hasUnfinishedMoveBatch: hasUnfinishedMoveBatch
+                   hasUnfinishedMoveBatch: hasUnfinishedMoveBatch,
+                   isWithinMoveCooldown: isWithinMoveCooldown,
+                   menuBarDisplayChanged: menuBarDisplayChanged
                )
            )
         {
@@ -894,6 +925,18 @@ extension MenuBarItemManager {
             // correction, after which the next cycle sees a settled layout.
             MenuBarItemManager.diagLog.warning(
                 "Skipping saveSectionOrder; layout divergence pending confirmation (applySavedLayout has not yet restored the cached layout)"
+            )
+        } else if isWithinMoveCooldown {
+            // Warning level like the rest: a run of these means the bar is
+            // being moved often enough that the save never gets a settled
+            // cycle, which is its own problem — but it is no longer the
+            // problem of a save landing on an unsettled bar (#958).
+            MenuBarItemManager.diagLog.warning(
+                "Skipping saveSectionOrder; within the 5s move cooldown that applySavedLayout also honours"
+            )
+        } else if menuBarDisplayChanged {
+            MenuBarItemManager.diagLog.warning(
+                "Skipping saveSectionOrder; menu bar moved display since the standing cache (\(previousCacheDisplayID.map { "\($0)" } ?? "nil") -> \(context.cache.displayID.map { "\($0)" } ?? "nil")), relocation in progress"
             )
         } else if hasUnfinishedMoveBatch {
             // Warning level, like the two above, because a run of these is

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -789,6 +789,10 @@ extension MenuBarItemManager {
 
         itemCache = context.cache
 
+        // Remember what the resolved items are called, so the next launch can
+        // label them before its own source-PID scan lands (#956).
+        MenuBarItemNameMemory.remember(itemCache.managedItems)
+
         // Reset isRestoringItemOrder if it's been stuck for too long (10 seconds).
         // This prevents stale flags from blocking saves after user manual moves.
         if isRestoringItemOrder, let timestamp = isRestoringItemOrderTimestamp, Date().timeIntervalSince(timestamp) > 10 {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -1499,6 +1499,45 @@ extension MenuBarItemManager {
 
         MenuBarItemManager.diagLog.debug("cacheItemsRegardless: found control items, hidden windowID=\(controlItems.hidden.windowID), alwaysHidden=\(controlItems.alwaysHidden.map { "\($0.windowID)" } ?? "nil")")
 
+        // A display change can strand the always-hidden divider on another
+        // screen's menu bar while the hidden divider resolves fine.
+        // ControlItemPair models the missing divider as an optional, so the
+        // pair succeeds and the lookup-failure rebuild above never fires:
+        // #863's HDMI re-plug left alwaysHidden=nil for 12+ hours and the
+        // whole always-hidden section drained into visible. Count only
+        // authoritative cycles (a provisional correlation must not advance
+        // recovery, same rule as the parked-divider streak), and only while
+        // the feature is enabled — a disabled section's absent divider is
+        // intentional, not a loss to recover from.
+        if appState?.settings.advanced.enableAlwaysHiddenSection == true,
+           controlItems.canRepositionControlItems {
+            if controlItems.alwaysHidden == nil {
+                missingAlwaysHiddenDividerStreak += 1
+                if Self.shouldRecoverMissingAlwaysHiddenDivider(
+                    consecutiveMissingReadings: missingAlwaysHiddenDividerStreak,
+                    alreadyRecovered: didRecoverMissingAlwaysHiddenDivider
+                ) {
+                    didRecoverMissingAlwaysHiddenDivider = true
+                    MenuBarItemManager.diagLog.warning(
+                        "cacheItemsRegardless: always-hidden section enabled but its divider has not resolved for \(missingAlwaysHiddenDividerStreak) consecutive cycles, recreating it"
+                    )
+                    await MainActor.run {
+                        appState?.menuBarManager.controlItem(withName: .alwaysHidden)?.recreateStatusItem()
+                    }
+                    Task { [weak self] in
+                        try? await Task.sleep(for: .milliseconds(100))
+                        await self?.cacheItemsRegardless()
+                    }
+                }
+            } else {
+                missingAlwaysHiddenDividerStreak = 0
+                didRecoverMissingAlwaysHiddenDivider = false
+            }
+        } else {
+            missingAlwaysHiddenDividerStreak = 0
+            didRecoverMissingAlwaysHiddenDivider = false
+        }
+
         if Self.isDegradedIdentityEnrichmentEnabled {
             enrichDegradedItemIdentities(in: items)
         } else if !degradedItemAXIdentities.isEmpty {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -823,7 +823,10 @@ extension MenuBarItemManager {
         // it back and the restore, once the cooldown lapses, reads the drag
         // as drift and reverts it.
         let isWithinMoveCooldown = lastMoveOperationOccurred(within: .seconds(5)) &&
-            !lastUserMoveOperationOccurred(within: .seconds(5))
+            !Self.saveCooldownExemptForUserMove(
+                lastMoveOperationTimestamp: lastMoveOperationTimestamp,
+                lastUserMoveOperationTimestamp: lastUserMoveOperationTimestamp
+            )
 
         // A relocation in progress. Both displays have to be known for the
         // comparison to mean anything: a nil on either side is the ordinary
@@ -1510,7 +1513,8 @@ extension MenuBarItemManager {
         // the feature is enabled — a disabled section's absent divider is
         // intentional, not a loss to recover from.
         if appState?.settings.advanced.enableAlwaysHiddenSection == true,
-           controlItems.canRepositionControlItems {
+           controlItems.canRepositionControlItems
+        {
             if controlItems.alwaysHidden == nil {
                 missingAlwaysHiddenDividerStreak += 1
                 if Self.shouldRecoverMissingAlwaysHiddenDivider(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -1507,39 +1507,39 @@ extension MenuBarItemManager {
         // ControlItemPair models the missing divider as an optional, so the
         // pair succeeds and the lookup-failure rebuild above never fires:
         // #863's HDMI re-plug left alwaysHidden=nil for 12+ hours and the
-        // whole always-hidden section drained into visible. Count only
-        // authoritative cycles (a provisional correlation must not advance
-        // recovery, same rule as the parked-divider streak), and only while
-        // the feature is enabled — a disabled section's absent divider is
-        // intentional, not a loss to recover from.
-        if appState?.settings.advanced.enableAlwaysHiddenSection == true,
-           controlItems.canRepositionControlItems
-        {
-            if controlItems.alwaysHidden == nil {
-                missingAlwaysHiddenDividerStreak += 1
-                if Self.shouldRecoverMissingAlwaysHiddenDivider(
-                    consecutiveMissingReadings: missingAlwaysHiddenDividerStreak,
-                    alreadyRecovered: didRecoverMissingAlwaysHiddenDivider
-                ) {
-                    didRecoverMissingAlwaysHiddenDivider = true
-                    MenuBarItemManager.diagLog.warning(
-                        "cacheItemsRegardless: always-hidden section enabled but its divider has not resolved for \(missingAlwaysHiddenDividerStreak) consecutive cycles, recreating it"
-                    )
-                    await MainActor.run {
-                        appState?.menuBarManager.controlItem(withName: .alwaysHidden)?.recreateStatusItem()
+        // whole always-hidden section drained into visible. Only
+        // authoritative cycles may advance, reset, or re-arm the episode —
+        // a provisional correlation says nothing either way, the same rule
+        // the parked-divider streak applies — and a disabled section's
+        // absent divider is intentional, not a loss to recover from.
+        if controlItems.canRepositionControlItems {
+            if appState?.settings.advanced.enableAlwaysHiddenSection == true {
+                if controlItems.alwaysHidden == nil {
+                    missingAlwaysHiddenDividerStreak += 1
+                    if Self.shouldRecoverMissingAlwaysHiddenDivider(
+                        consecutiveMissingReadings: missingAlwaysHiddenDividerStreak,
+                        alreadyRecovered: didRecoverMissingAlwaysHiddenDivider
+                    ) {
+                        didRecoverMissingAlwaysHiddenDivider = true
+                        MenuBarItemManager.diagLog.warning(
+                            "cacheItemsRegardless: always-hidden section enabled but its divider has not resolved for \(missingAlwaysHiddenDividerStreak) consecutive cycles, recreating it"
+                        )
+                        await MainActor.run {
+                            appState?.menuBarManager.controlItem(withName: .alwaysHidden)?.recreateStatusItem()
+                        }
+                        Task { [weak self] in
+                            try? await Task.sleep(for: .milliseconds(100))
+                            await self?.cacheItemsRegardless()
+                        }
                     }
-                    Task { [weak self] in
-                        try? await Task.sleep(for: .milliseconds(100))
-                        await self?.cacheItemsRegardless()
-                    }
+                } else {
+                    missingAlwaysHiddenDividerStreak = 0
+                    didRecoverMissingAlwaysHiddenDivider = false
                 }
             } else {
                 missingAlwaysHiddenDividerStreak = 0
                 didRecoverMissingAlwaysHiddenDivider = false
             }
-        } else {
-            missingAlwaysHiddenDividerStreak = 0
-            didRecoverMissingAlwaysHiddenDivider = false
         }
 
         if Self.isDegradedIdentityEnrichmentEnabled {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1442,9 +1442,20 @@ extension MenuBarItemManager {
             currentAlwaysHidden: currentAHSet,
             desiredVisible: desiredVisibleSet,
             desiredHidden: desiredHiddenSet,
-            desiredAlwaysHidden: desiredAHSet
+            desiredAlwaysHidden: desiredAHSet,
+            overflowExemptUIDs: notchOverflowEjectedUIDs
         )
         let hiddenBoundaryMismatch = hiddenBoundaryOffenders.count
+        // How many offenders the exemption absorbed this cycle, so a soak can
+        // tell a by-design divergence from one that would have been repaired.
+        // Equivalent to the unexempted tally minus this one: the solver only
+        // ever drops wronglyConcealed entries (an ejected item sits in
+        // hidden, never in desiredConcealed), and exempt ∩ currentHidden ⊆
+        // currentHidden ⊆ currentConcealed collapses the intersection.
+        // No feature gating here: Phase 4 above replaced or cleared the set
+        // under shouldManageNotchOverflow, so it is fresh for this apply.
+        let exemptedEjectedCount = notchOverflowEjectedUIDs.intersection(currentHiddenSet)
+            .intersection(desiredVisibleSet).count
 
         // ...but only when it is the divider that drifted. isProfileItem
         // admits the chevron, so the counts that decide this have to drop
@@ -1495,6 +1506,11 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.debug(
             "Profile layout Phase 1: hiddenBoundaryMismatch=\(hiddenBoundaryMismatch)"
         )
+        if exemptedEjectedCount > 0 {
+            MenuBarItemManager.diagLog.debug(
+                "Profile layout Phase 1: \(exemptedEjectedCount) notch-overflow-ejected item(s) exempt from the H_ctrl boundary check (by-design divergence)"
+            )
+        }
         MenuBarItemManager.diagLog.debug(
             "Profile layout Phase 1: liveConcealed=\(liveConcealedCount), liveVisible=\(liveVisibleCount), moveHiddenDivider=\(shouldMoveHiddenDivider)"
         )

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1346,6 +1346,10 @@ extension MenuBarItemManager {
         // a control item is cheaper than moving individual items.
         var movedCount = 0
         var didAttemptHCtrl = false
+        /// Set when a boundary repair carried items across H_ctrl instead of
+        /// carrying H_ctrl across them. Either way the sections the AH_ctrl
+        /// planning below reads are stale afterwards.
+        var didCrossHiddenBoundary = false
         var canRepositionControlItems = controlItems.canRepositionControlItems
         // Moves this batch planned for an item that is still on the bar and
         // then did not enact. Any of these leaves the bar in an arrangement
@@ -1431,14 +1435,33 @@ extension MenuBarItemManager {
         // divider-only divergence leaves current equal to desired and
         // plans no moves, and the apply reports "all items already in
         // correct positions" while the whole hidden section stays visible
-        // (#879). One H_ctrl move fixes every one of them.
-        let hiddenBoundaryMismatch = LayoutSolver.hiddenBoundaryMismatch(
+        // (#879). One H_ctrl move fixes every one of them...
+        let hiddenBoundaryOffenders = LayoutSolver.hiddenBoundaryOffenders(
             currentVisible: currentVisibleSet,
             currentHidden: currentHiddenSet,
             currentAlwaysHidden: currentAHSet,
             desiredVisible: desiredVisibleSet,
             desiredHidden: desiredHiddenSet,
             desiredAlwaysHidden: desiredAHSet
+        )
+        let hiddenBoundaryMismatch = hiddenBoundaryOffenders.count
+
+        // ...but only when it is the divider that drifted. isProfileItem
+        // admits the chevron, so the counts that decide this have to drop
+        // Thaw's own items first, or a collapsed bar always looks like it
+        // still has one item on the visible side and never qualifies for
+        // the drag that would rescue it.
+        let liveControlUIDs = Set(items.lazy.filter(\.isControlItem).map(\.uniqueIdentifier))
+        let liveConcealedCount = currentHiddenSet
+            .union(currentAHSet)
+            .subtracting(liveControlUIDs)
+            .count
+        let liveVisibleCount = currentVisibleSet
+            .subtracting(liveControlUIDs)
+            .count
+        let shouldMoveHiddenDivider = LayoutSolver.shouldMoveHiddenDivider(
+            liveConcealedCount: liveConcealedCount,
+            liveVisibleCount: liveVisibleCount
         )
 
         // Format contract: parsed by ProfileLayoutLogReplayTests.parse(_:).
@@ -1472,21 +1495,24 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.debug(
             "Profile layout Phase 1: hiddenBoundaryMismatch=\(hiddenBoundaryMismatch)"
         )
+        MenuBarItemManager.diagLog.debug(
+            "Profile layout Phase 1: liveConcealed=\(liveConcealedCount), liveVisible=\(liveVisibleCount), moveHiddenDivider=\(shouldMoveHiddenDivider)"
+        )
         if hiddenBoundaryMismatch == 0 {
             parkedHiddenDividerMismatchStreak = 0
             didRecoverParkedHiddenDividerForCurrentMismatch = false
         }
 
-        // ── Sub-phase 1: Move H_ctrl to the visible/hidden boundary ──
+        // ── Sub-phase 1: Restore the visible/hidden boundary ──
         //
         // Runs before the AH_ctrl placement so the always-hidden planning
         // below sees a divider pair that already brackets the right set of
-        // items. Both dividers move by the same mechanism: one drag that
-        // re-sections everything it crosses, which is why neither is left
-        // to the per-item LCS pass.
+        // items. Which way the repair runs is shouldMoveHiddenDivider's
+        // call: a drag that re-sections everything it crosses when the
+        // divider is what drifted, and per-item moves when it isn't.
         if hiddenBoundaryMismatch > 0, canRepositionControlItems, !Task.isCancelled {
             MenuBarItemManager.diagLog.debug(
-                "Profile layout: \(hiddenBoundaryMismatch) item(s) on the wrong side of H_ctrl, moving H_ctrl to the boundary"
+                "Profile layout: \(hiddenBoundaryMismatch) item(s) on the wrong side of H_ctrl, moving \(shouldMoveHiddenDivider ? "H_ctrl to the boundary" : "them to H_ctrl")"
             )
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
@@ -1528,129 +1554,224 @@ extension MenuBarItemManager {
                 scheduleDeferredCacheRefresh()
                 return
             }
-            // Exclude items parked off-screen from the anchor candidate set.
-            // A parked item's center falls on no screen; using it as the
-            // H_ctrl drag anchor makes the move fail every retry — AppKit
-            // snaps the divider back to its autosave position on mouse-up,
-            // one on-screen flicker per attempt for the full 8-attempt
-            // budget (#881: cursor seizure and icon storm). The per-item
-            // LCS pass handles repositioning parked items onto the bar.
-            let liveMovableUIDs = Set(
-                allFreshItems.lazy.filter { item in
-                    guard item.isMovable, isProfileItem(item) else { return false }
-                    return LayoutSolver.isOnScreen(bounds: item.bounds, screenFrames: screenFrames)
-                }.map(\.uniqueIdentifier)
-            )
-            // Thaw's own control items clear both filters above whatever the
-            // rest of the bar is doing: they are movable, and they stay on
-            // screen even on a pass where every real item the profile puts on
-            // this side of the divider has been dragged to the other side and
-            // parked. That leaves the chevron as the anchor of last resort in
-            // exactly the passes where the bar has diverged most, and dragging
-            // H_ctrl up to it collapses the section the apply was restoring
-            // (#958). The LCS pass below already bars them for the same
-            // reason (#924, #927).
-            let controlItemUIDs = Set(
-                allFreshItems.lazy.filter(\.isControlItem).map(\.uniqueIdentifier)
-            )
-            let desiredHidden = itemOrder["hidden"] ?? []
-            let desiredVisible = itemOrder["visible"] ?? []
-            let anchor = LayoutSolver.planHiddenDividerAnchor(
-                desiredHidden: desiredHidden,
-                desiredVisible: desiredVisible,
-                liveMovableUIDs: liveMovableUIDs,
-                unanchorableUIDs: controlItemUIDs
-            )
+            if shouldMoveHiddenDivider {
+                // Exclude items parked off-screen from the anchor candidate set.
+                // A parked item falls on no screen; using it as the
+                // H_ctrl drag anchor makes the move fail every retry — AppKit
+                // snaps the divider back to its autosave position on mouse-up,
+                // one on-screen flicker per attempt for the full 8-attempt
+                // budget (#881: cursor seizure and icon storm). The per-item
+                // LCS pass handles repositioning parked items onto the bar.
+                let liveMovableUIDs = Set(
+                    allFreshItems.lazy.filter { item in
+                        guard item.isMovable, isProfileItem(item) else { return false }
+                        return LayoutSolver.isOnScreen(bounds: item.bounds, screenFrames: screenFrames)
+                    }.map(\.uniqueIdentifier)
+                )
+                // Thaw's own control items clear both filters above whatever the
+                // rest of the bar is doing: they are movable, and they stay on
+                // screen even on a pass where every real item the profile puts on
+                // this side of the divider has been dragged to the other side and
+                // parked. That leaves the chevron as the anchor of last resort in
+                // exactly the passes where the bar has diverged most, and dragging
+                // H_ctrl up to it collapses the section the apply was restoring
+                // (#958). The LCS pass below already bars them for the same
+                // reason (#924, #927).
+                let controlItemUIDs = Set(
+                    allFreshItems.lazy.filter(\.isControlItem).map(\.uniqueIdentifier)
+                )
+                let desiredHidden = itemOrder["hidden"] ?? []
+                let desiredVisible = itemOrder["visible"] ?? []
+                let anchor = LayoutSolver.planHiddenDividerAnchor(
+                    desiredHidden: desiredHidden,
+                    desiredVisible: desiredVisible,
+                    liveMovableUIDs: liveMovableUIDs,
+                    unanchorableUIDs: controlItemUIDs
+                )
 
-            if let anchor {
-                let hItem = freshControl.hidden
-                let anchorUID = switch anchor {
-                case let .rightOf(uid), let .leftOf(uid): uid
-                }
-                if let anchorItem = allFreshItems.first(where: { $0.uniqueIdentifier == anchorUID }) {
-                    let dest: MoveDestination = switch anchor {
-                    case .rightOf: .rightOfItem(anchorItem)
-                    case .leftOf: .leftOfItem(anchorItem)
+                if let anchor {
+                    let hItem = freshControl.hidden
+                    let anchorUID = switch anchor {
+                    case let .rightOf(uid), let .leftOf(uid): uid
                     }
-                    if !LayoutSolver.isOnScreen(bounds: hItem.bounds, screenFrames: screenFrames) {
-                        // The divider itself has to be on screen for the drag
-                        // to land. #881 excluded parked *anchors*; a parked
-                        // H_ctrl fails the same way from the other side — the
-                        // drag point is on screen so the owner accepts the
-                        // events, but AppKit still snaps the divider back to
-                        // its autosave position on mouse-up, and every attempt
-                        // reports "events succeeded but item not at
-                        // destination" for the full budget (#899). The
-                        // per-item LCS pass below repositions items without
-                        // needing the divider to travel.
-                        unenactedMoveCount += 1
-                        MenuBarItemManager.diagLog.warning(
-                            "Profile layout: H_ctrl is parked offscreen (minX=\(hItem.bounds.minX)), skipping the boundary move"
-                        )
-                    } else if failureLedger.isUnderBackoff(for: hItem) {
-                        // Same governance the per-item moves below already get.
-                        // Without it a boundary move that cannot land is retried
-                        // in full by every re-sort — eight drags a pass, a pass
-                        // every few seconds, for as long as the mismatch stands.
-                        // In #899 that ran until the user killed the app.
-                        unenactedMoveCount += 1
-                        MenuBarItemManager.diagLog.warning(
-                            "Profile layout: H_ctrl under move-failure backoff, skipping"
-                        )
-                    } else {
-                        MenuBarItemManager.diagLog.debug("Profile layout: moving H_ctrl → \(dest.logString)")
-                        didAttemptHCtrl = true
-                        do {
-                            try await move(item: hItem, to: dest, skipInputPause: true)
-                            movedCount += 1
-                            failureLedger.recordSuccess(for: hItem)
-                            try? await Task.sleep(for: .milliseconds(200))
-                        } catch {
+                    if let anchorItem = allFreshItems.first(where: { $0.uniqueIdentifier == anchorUID }) {
+                        let dest: MoveDestination = switch anchor {
+                        case .rightOf: .rightOfItem(anchorItem)
+                        case .leftOf: .leftOfItem(anchorItem)
+                        }
+                        if !LayoutSolver.isOnScreen(bounds: hItem.bounds, screenFrames: screenFrames) {
+                            // The divider itself has to be on screen for the drag
+                            // to land. #881 excluded parked *anchors*; a parked
+                            // H_ctrl fails the same way from the other side — the
+                            // drag point is on screen so the owner accepts the
+                            // events, but AppKit still snaps the divider back to
+                            // its autosave position on mouse-up, and every attempt
+                            // reports "events succeeded but item not at
+                            // destination" for the full budget (#899). The
+                            // per-item LCS pass below repositions items without
+                            // needing the divider to travel.
                             unenactedMoveCount += 1
-                            // A move cancelled by a newer apply says nothing
-                            // about the divider, and recording it would earn
-                            // H_ctrl a backoff window it did not deserve —
-                            // the same rule the LCS pass applies below.
-                            if Task.isCancelled {
-                                MenuBarItemManager.diagLog.debug(
-                                    "Profile layout: H_ctrl move interrupted by a newer apply; leaving it unrecorded"
-                                )
-                            } else {
-                                if !Self.moveAlreadyFiledFailure(for: error) {
-                                    failureLedger.recordFailure(for: hItem, kind: Self.failureKind(of: error))
+                            MenuBarItemManager.diagLog.warning(
+                                "Profile layout: H_ctrl is parked offscreen (minX=\(hItem.bounds.minX)), skipping the boundary move"
+                            )
+                        } else if failureLedger.isUnderBackoff(for: hItem) {
+                            // Same governance the per-item moves below already get.
+                            // Without it a boundary move that cannot land is retried
+                            // in full by every re-sort — eight drags a pass, a pass
+                            // every few seconds, for as long as the mismatch stands.
+                            // In #899 that ran until the user killed the app.
+                            unenactedMoveCount += 1
+                            MenuBarItemManager.diagLog.warning(
+                                "Profile layout: H_ctrl under move-failure backoff, skipping"
+                            )
+                        } else {
+                            MenuBarItemManager.diagLog.debug("Profile layout: moving H_ctrl → \(dest.logString)")
+                            didAttemptHCtrl = true
+                            do {
+                                try await move(item: hItem, to: dest, skipInputPause: true)
+                                movedCount += 1
+                                failureLedger.recordSuccess(for: hItem)
+                                try? await Task.sleep(for: .milliseconds(200))
+                            } catch {
+                                unenactedMoveCount += 1
+                                // A move cancelled by a newer apply says nothing
+                                // about the divider, and recording it would earn
+                                // H_ctrl a backoff window it did not deserve —
+                                // the same rule the LCS pass applies below.
+                                if Task.isCancelled {
+                                    MenuBarItemManager.diagLog.debug(
+                                        "Profile layout: H_ctrl move interrupted by a newer apply; leaving it unrecorded"
+                                    )
+                                } else {
+                                    if !Self.moveAlreadyFiledFailure(for: error) {
+                                        failureLedger.recordFailure(for: hItem, kind: Self.failureKind(of: error))
+                                    }
+                                    MenuBarItemManager.diagLog.error("Profile layout: failed to move H_ctrl: \(error)")
                                 }
-                                MenuBarItemManager.diagLog.error("Profile layout: failed to move H_ctrl: \(error)")
                             }
                         }
                     }
+                } else if let refusedAnchor = LayoutSolver.hiddenDividerAnchorCandidate(
+                    desiredHidden: desiredHidden,
+                    desiredVisible: desiredVisible,
+                    liveMovableUIDs: liveMovableUIDs
+                ).flatMap({ controlItemUIDs.contains($0) ? $0 : nil }) {
+                    // Separated from the case below so a soak can tell the two
+                    // apart: this one means the profile's items are on the bar
+                    // but on the wrong side of the divider, which is the state
+                    // the LCS pass fixes and this move used to make worse.
+                    MenuBarItemManager.diagLog.warning(
+                        "Profile layout: only \(refusedAnchor) was left to anchor the H_ctrl boundary move; leaving the divider where it is"
+                    )
+                } else {
+                    // No live movable member on either side to anchor against;
+                    // the LCS pass below still runs against whatever ordering
+                    // divergence remains.
+                    MenuBarItemManager.diagLog.warning(
+                        "Profile layout: no anchor available for the H_ctrl boundary move"
+                    )
                 }
-            } else if let refusedAnchor = LayoutSolver.hiddenDividerAnchorCandidate(
-                desiredHidden: desiredHidden,
-                desiredVisible: desiredVisible,
-                liveMovableUIDs: liveMovableUIDs
-            ).flatMap({ controlItemUIDs.contains($0) ? $0 : nil }) {
-                // Separated from the case below so a soak can tell the two
-                // apart: this one means the profile's items are on the bar
-                // but on the wrong side of the divider, which is the state
-                // the LCS pass fixes and this move used to make worse.
+            } else if !LayoutSolver.isOnScreen(
+                bounds: freshControl.hidden.bounds,
+                screenFrames: screenFrames
+            ) {
+                // H_ctrl is the destination for every move the branch below
+                // would make, and a destination off the display gets a press
+                // at a point no owner is watching. #899 is the same failure
+                // seen from the divider's own side. recoverParkedHiddenDivider
+                // above rebuilds the divider once the mismatch persists; until
+                // then the LCS pass is the one that can make progress.
+                unenactedMoveCount += 1
                 MenuBarItemManager.diagLog.warning(
-                    "Profile layout: only \(refusedAnchor) was left to anchor the H_ctrl boundary move; leaving the divider where it is"
+                    "Profile layout: H_ctrl is parked offscreen (minX=\(freshControl.hidden.bounds.minX)), skipping the per-item boundary moves"
                 )
             } else {
-                // No live movable member on either side to anchor against;
-                // the LCS pass below still runs against whatever ordering
-                // divergence remains.
-                MenuBarItemManager.diagLog.warning(
-                    "Profile layout: no anchor available for the H_ctrl boundary move"
-                )
+                // The divider is roughly where it belongs and some items have
+                // wandered across it. Carry those items to the divider rather
+                // than the divider to them: the drag that would reach them
+                // re-sections every item it passes, and on a bar this close to
+                // correct that is most of the bar (#958).
+                let hItem = freshControl.hidden
+                let offenderUIDs = hiddenBoundaryOffenders.wronglyVisible
+                    .union(hiddenBoundaryOffenders.wronglyConcealed)
+                var offenders: [String: MenuBarItem] = [:]
+                for item in allFreshItems where offenderUIDs.contains(item.uniqueIdentifier) {
+                    guard item.isMovable,
+                          LayoutSolver.isOnScreen(bounds: item.bounds, screenFrames: screenFrames)
+                    else {
+                        continue
+                    }
+                    offenders[item.uniqueIdentifier] = item
+                }
+                if offenders.count < offenderUIDs.count {
+                    // Parked or immovable. The LCS pass below is the one that
+                    // brings items back onto the bar; it also crosses the
+                    // boundary, just without a divider drag.
+                    MenuBarItemManager.diagLog.debug(
+                        "Profile layout: \(offenderUIDs.count - offenders.count) boundary offender(s) not live and movable, leaving them to the LCS pass"
+                    )
+                }
+
+                // Each move lands its item immediately beside H_ctrl and
+                // pushes the previous one further from it, so walking the
+                // group away from the divider preserves the order they were
+                // already in. Same reasoning as the notch-overflow eject.
+                let toConceal = hiddenBoundaryOffenders.wronglyVisible
+                    .compactMap { offenders[$0] }
+                    .sorted { $0.bounds.minX < $1.bounds.minX }
+                let toReveal = hiddenBoundaryOffenders.wronglyConcealed
+                    .compactMap { offenders[$0] }
+                    .sorted { $0.bounds.minX > $1.bounds.minX }
+
+                for (item, dest) in toConceal.map({ ($0, MoveDestination.leftOfItem(hItem)) })
+                    + toReveal.map({ ($0, MoveDestination.rightOfItem(hItem)) })
+                {
+                    if Task.isCancelled {
+                        break
+                    }
+                    guard !failureLedger.isUnderBackoff(for: item) else {
+                        unenactedMoveCount += 1
+                        MenuBarItemManager.diagLog.debug(
+                            "Profile layout: \(item.logString) under move-failure backoff, skipping the boundary move"
+                        )
+                        continue
+                    }
+                    MenuBarItemManager.diagLog.debug(
+                        "Profile layout: moving \(item.logString) → \(dest.logString) to fix the H_ctrl boundary"
+                    )
+                    do {
+                        try await move(item: item, to: dest, skipInputPause: true)
+                        movedCount += 1
+                        didCrossHiddenBoundary = true
+                        failureLedger.recordSuccess(for: item)
+                    } catch {
+                        unenactedMoveCount += 1
+                        // A move cancelled by a newer apply says nothing about
+                        // the item, and recording it would earn a backoff
+                        // window it did not deserve.
+                        if Task.isCancelled {
+                            MenuBarItemManager.diagLog.debug(
+                                "Profile layout: boundary move for \(item.logString) interrupted by a newer apply; leaving it unrecorded"
+                            )
+                        } else {
+                            if !Self.moveAlreadyFiledFailure(for: error) {
+                                failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                            }
+                            MenuBarItemManager.diagLog.error(
+                                "Profile layout: failed to move \(item.logString) across the H_ctrl boundary: \(error)"
+                            )
+                        }
+                    }
+                }
             }
         }
 
-        // Moving H_ctrl changes the section of every item it crosses. The
-        // snapshot used to decide the move is therefore stale at this point;
-        // classify the post-move bounds again before deciding whether an
-        // AH_ctrl move (and its per-item fallback) is still warranted.
-        if didAttemptHCtrl {
+        // A boundary repair changes the section of everything that crossed,
+        // whether the divider moved or the items did. The snapshot used to
+        // decide the repair is therefore stale at this point; classify the
+        // post-move bounds again before deciding whether an AH_ctrl move
+        // (and its per-item fallback) is still warranted.
+        if didAttemptHCtrl || didCrossHiddenBoundary {
             var postMoveItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
             postMoveItems.removeAll(where: \.isSystemClone)
             var postMoveItemsCopy = postMoveItems

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1760,6 +1760,12 @@ extension MenuBarItemManager {
                         movedCount += 1
                         didCrossHiddenBoundary = true
                         failureLedger.recordSuccess(for: item)
+                        // Same settle the H_ctrl branch above grants itself:
+                        // each landed move re-sections the neighbours the
+                        // next iteration computes its target from, and a
+                        // drag issued against pre-move geometry lands where
+                        // the previous arrangement says it should.
+                        try? await Task.sleep(for: .milliseconds(200))
                     } catch {
                         unenactedMoveCount += 1
                         // A move cancelled by a newer apply says nothing about

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1512,7 +1512,13 @@ extension MenuBarItemManager {
                recoverParkedHiddenDividerIfNeeded(
                    hiddenBoundaryMismatch: hiddenBoundaryMismatch,
                    hiddenControlItem: freshControl.hidden,
-                   screenFrames: screenFrames
+                   screenFrames: screenFrames,
+                   // Counted from the fresh read rather than the Phase 1 sets,
+                   // which are keyed by identifier and would fold items that
+                   // share one across displays into a single entry.
+                   managedItemCount: allFreshItems.count(where: {
+                       isProfileItem($0) && !$0.isControlItem
+                   })
                )
             {
                 // Keep the prior unfinished-batch arm intact without counting
@@ -2201,6 +2207,50 @@ extension MenuBarItemManager {
         threshold: Int = MenuBarItemManager.parkedHiddenDividerRecoveryThreshold
     ) -> Bool {
         !alreadyRecovered && consecutiveMismatchReadings >= threshold
+    }
+
+    /// Whether a divider rebuild may also re-stamp the first-launch seed
+    /// position.
+    ///
+    /// Both rebuild paths exist to discard a stale autosave position, and both
+    /// discard it by writing the seed `preflightSetup` uses on a fresh install.
+    /// That value describes a bar Thaw has never arranged. Writing it onto a
+    /// bar that already holds managed items drops the rebuilt divider on one
+    /// side of all of them, and the next cache pass reads the entire bar into a
+    /// single section — the collapse `preflightSetup` documents for #895,
+    /// reached through the same guard-bypassing write that reopened it for
+    /// #890.
+    ///
+    /// #958's log is the direct evidence: one rebuild in five hours, and the
+    /// visible section goes from 12 items to 1 within three seconds of it,
+    /// while three earlier parkings that never rebuilt leave the bar intact.
+    ///
+    /// Skipping the stamp does not cost the recovery its purpose. Discarding
+    /// the old `NSStatusItem` is what gives the divider a window on the current
+    /// bar again; the follow-up apply the caller schedules is what walks it to
+    /// the saved boundary.
+    static nonisolated func canSeedRebuiltDividerPosition(managedItemCount: Int) -> Bool {
+        managedItemCount == 0
+    }
+
+    /// The preferred position a divider rebuild should stamp, or `nil` to
+    /// rebuild without touching the stored position.
+    ///
+    /// The value matches the one `ControlItem.preflightSetup` seeds for the
+    /// hidden divider, so an empty bar still lands where a fresh install puts
+    /// it.
+    static nonisolated func seedPositionForRebuiltDivider(managedItemCount: Int) -> CGFloat? {
+        canSeedRebuiltDividerPosition(managedItemCount: managedItemCount) ? 1 : nil
+    }
+
+    /// Log fragment naming what a divider rebuild did with the stored
+    /// position, so a field log says which branch ran without the reader
+    /// having to infer it from the collapse that follows.
+    static nonisolated func seedDescription(_ seedPosition: CGFloat?) -> String {
+        guard let seedPosition else {
+            return " and keeping its stored position (the bar holds managed items)"
+        }
+        return " at its seeded position (\(seedPosition))"
     }
 
     static nonisolated func baseIdentifier(forSavedIdentifier identifier: String) -> String {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -2353,6 +2353,17 @@ extension MenuBarItemManager {
         return min(baseDelay * (1 << exponent), maxDelay)
     }
 
+    /// Whether repeated authoritative cache cycles should reset an
+    /// always-hidden divider that the feature enables but which does not
+    /// resolve, while the hidden divider resolves fine.
+    static nonisolated func shouldRecoverMissingAlwaysHiddenDivider(
+        consecutiveMissingReadings: Int,
+        alreadyRecovered: Bool = false,
+        threshold: Int = MenuBarItemManager.missingAlwaysHiddenDividerRecoveryThreshold
+    ) -> Bool {
+        !alreadyRecovered && consecutiveMissingReadings >= threshold
+    }
+
     /// Whether a persistent zero-width hidden span has enough trustworthy
     /// observations to reset the hidden divider once for this episode.
     static nonisolated func shouldRecoverCollapsedHiddenSection(

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1595,7 +1595,9 @@ extension MenuBarItemManager {
                                     "Profile layout: H_ctrl move interrupted by a newer apply; leaving it unrecorded"
                                 )
                             } else {
-                                failureLedger.recordFailure(for: hItem, kind: Self.failureKind(of: error))
+                                if !Self.moveAlreadyFiledFailure(for: error) {
+                                    failureLedger.recordFailure(for: hItem, kind: Self.failureKind(of: error))
+                                }
                                 MenuBarItemManager.diagLog.error("Profile layout: failed to move H_ctrl: \(error)")
                             }
                         }
@@ -2044,7 +2046,9 @@ extension MenuBarItemManager {
                 }
                 unenactedMoveCount += 1
                 consecutiveMoveFailures += 1
-                failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                if !Self.moveAlreadyFiledFailure(for: error) {
+                    failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                }
                 MenuBarItemManager.diagLog.error(
                     "Profile layout: failed to move \(planned.uid): \(error)"
                 )

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1541,10 +1541,25 @@ extension MenuBarItemManager {
                     return LayoutSolver.isOnScreen(bounds: item.bounds, screenFrames: screenFrames)
                 }.map(\.uniqueIdentifier)
             )
+            // Thaw's own control items clear both filters above whatever the
+            // rest of the bar is doing: they are movable, and they stay on
+            // screen even on a pass where every real item the profile puts on
+            // this side of the divider has been dragged to the other side and
+            // parked. That leaves the chevron as the anchor of last resort in
+            // exactly the passes where the bar has diverged most, and dragging
+            // H_ctrl up to it collapses the section the apply was restoring
+            // (#958). The LCS pass below already bars them for the same
+            // reason (#924, #927).
+            let controlItemUIDs = Set(
+                allFreshItems.lazy.filter(\.isControlItem).map(\.uniqueIdentifier)
+            )
+            let desiredHidden = itemOrder["hidden"] ?? []
+            let desiredVisible = itemOrder["visible"] ?? []
             let anchor = LayoutSolver.planHiddenDividerAnchor(
-                desiredHidden: itemOrder["hidden"] ?? [],
-                desiredVisible: itemOrder["visible"] ?? [],
-                liveMovableUIDs: liveMovableUIDs
+                desiredHidden: desiredHidden,
+                desiredVisible: desiredVisible,
+                liveMovableUIDs: liveMovableUIDs,
+                unanchorableUIDs: controlItemUIDs
             )
 
             if let anchor {
@@ -1609,6 +1624,18 @@ extension MenuBarItemManager {
                         }
                     }
                 }
+            } else if let refusedAnchor = LayoutSolver.hiddenDividerAnchorCandidate(
+                desiredHidden: desiredHidden,
+                desiredVisible: desiredVisible,
+                liveMovableUIDs: liveMovableUIDs
+            ).flatMap({ controlItemUIDs.contains($0) ? $0 : nil }) {
+                // Separated from the case below so a soak can tell the two
+                // apart: this one means the profile's items are on the bar
+                // but on the wrong side of the divider, which is the state
+                // the LCS pass fixes and this move used to make worse.
+                MenuBarItemManager.diagLog.warning(
+                    "Profile layout: only \(refusedAnchor) was left to anchor the H_ctrl boundary move; leaving the divider where it is"
+                )
             } else {
                 // No live movable member on either side to anchor against;
                 // the LCS pass below still runs against whatever ordering

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -37,14 +37,24 @@ extension MenuBarItemManager {
         func targetPoint(in targetBounds: CGRect, on displayBounds: CGRect) -> CGPoint {
             let targetIsParkedOffscreen = targetBounds.maxX <= displayBounds.minX
             let targetY = targetIsParkedOffscreen ? targetBounds.midY : targetBounds.minY
-            // A zero-width control-item divider (#923) gives AppKit no
-            // hit-test width to disambiguate which side the drop should
-            // land on. Bias one point into the requested section so the
-            // synthetic event's target X is unambiguous. On a normal-width
-            // divider the ±1 nudge is harmless but unnecessary; gate it to
-            // zero-width to avoid shifting the drop point away from a
-            // divider that already has span to resolve the side.
-            let sectionBias: CGFloat = (targetItem.isControlItem && targetBounds.width == 0) ? 1 : 0
+            // Dropping on a divider's own edge leaves AppKit free to choose
+            // either side of it, and in #923 it chose wrong every time:
+            // .leftOfItem(AH_ctrl) landed the item at the divider's minX + 1,
+            // one point into the section the user was dragging out of. Bias
+            // one point into the requested section so the synthetic event's
+            // target X is unambiguous.
+            //
+            // This was once gated to zero-width dividers, on the theory that
+            // a divider with span gives AppKit enough hit-test width to
+            // resolve the side on its own. The 21 August log kills that
+            // theory: the same reporter's AH_ctrl was thousands of points
+            // wide (parked, maxX ≤ 0, expanded to conceal the section) and
+            // the drop still landed at minX + 1 on attempts 1 and 5, with
+            // the ordinal check correctly rejecting both. A divider's width
+            // is its concealment mechanism, not hit-test slack; what matters
+            // is that the drop point is its edge, which is the boundary
+            // itself.
+            let sectionBias: CGFloat = targetItem.isControlItem ? 1 : 0
             return switch self {
             case .leftOfItem:
                 CGPoint(x: targetBounds.minX - sectionBias, y: targetY)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -54,7 +54,13 @@ extension MenuBarItemManager {
             // is its concealment mechanism, not hit-test slack; what matters
             // is that the drop point is its edge, which is the boundary
             // itself.
-            let sectionBias: CGFloat = targetItem.isControlItem ? 1 : 0
+            // The chevron is excluded: it is a control item but not a
+            // section boundary, and TemporaryShow anchors moves directly on
+            // it with .leftOfItem — biasing those drops would place the item
+            // one point left of an anchor that is not an edge between two
+            // sections, for no hit-test ambiguity resolved.
+            let sectionBias: CGFloat = targetItem.tag == .hiddenControlItem
+                || targetItem.tag == .alwaysHiddenControlItem ? 1 : 0
             return switch self {
             case .leftOfItem:
                 CGPoint(x: targetBounds.minX - sectionBias, y: targetY)
@@ -144,6 +150,37 @@ extension MenuBarItemManager {
     ) -> Duration {
         let next = proposed > current ? proposed : (proposed + current) / 2
         return next.clamped(min: .milliseconds(75), max: .seconds(1))
+    }
+
+    /// Watchdog duration that covers the worst case of a single `move`
+    /// call: every one of `maxAttempts` attempts spends its whole
+    /// operation timeout four times over (two event posts, two response
+    /// waits), budgets can escalate to the merged ceiling, and a failed
+    /// attempt posts one more fallback at a fixed 100 ms. The result never
+    /// drops below the historical flat 10 s, so ordinary moves keep the
+    /// same safety net while an escalated stubborn item no longer outlasts
+    /// the watchdog and force-shows the cursor mid-sequence.
+    ///
+    /// Extracted so the arithmetic is unit-testable without posting events.
+    static nonisolated func cursorHideWatchdogTimeout(
+        operationCeiling: Duration = .seconds(1),
+        maxAttempts: Int = 8,
+        fallbackPost: Duration = .milliseconds(100),
+        floor: Duration = .seconds(10)
+    ) -> Duration {
+        // Per attempt: two event posts + two response waits, all capped at
+        // the ceiling. One millisecond is 10^15 attoseconds.
+        let attosecondsPerMillisecond = 1_000_000_000_000_000.0
+        let perAttemptComponents = operationCeiling.components
+        let perAttemptMs = Double(perAttemptComponents.seconds) * 1000.0
+            + Double(perAttemptComponents.attoseconds) / attosecondsPerMillisecond
+        let attempts = max(1, maxAttempts)
+        let fallbackMs = Double(fallbackPost.components.seconds) * 1000.0
+            + Double(fallbackPost.components.attoseconds) / attosecondsPerMillisecond
+        let floorMs = Double(floor.components.seconds) * 1000.0
+            + Double(floor.components.attoseconds) / attosecondsPerMillisecond
+        let totalMs = max(floorMs, perAttemptMs * Double(attempts) * 4 + fallbackMs)
+        return .milliseconds(Int(totalMs.rounded(.up)))
     }
 
     /// Updates the cached timeout for move operations associated
@@ -786,15 +823,21 @@ extension MenuBarItemManager {
         // during a layout reset when items required multiple attempts).
         let mouseLocation = try getMouseLocation()
         // The default 1 s cursor-hide watchdog is too short for menu
-        // bar item moves: each item can take up to ~4 s across retries
-        // (8 attempts × ~500 ms timeout), and during a full layout pass
-        // many items move sequentially. When the watchdog fires partway
-        // through, the cursor is force-shown at the synthetic event's
-        // last cursorPosition (mid-display, per the offscreen-target
-        // override below in postMoveEvents) and the user sees a brief
-        // cursor flash. 10 s is long enough to cover any single move
-        // without giving up the safety net for genuinely stuck states.
-        MouseHelpers.hideCursor(watchdogTimeout: watchdogTimeout ?? .seconds(10))
+        // bar item moves, and the budget they can burn has grown: every
+        // attempt spends its whole timeout four times over (two event
+        // posts, two response waits), budgets escalate to the merged
+        // ceiling of one second per operation, and a failed attempt posts
+        // one more fallback at a fixed 100 ms. At the ceiling that is
+        // roughly 32 s for eight attempts — far past the old flat 10 s,
+        // whose comment still assumed "8 × ~500 ms". When the watchdog
+        // fires partway through, the cursor is force-shown at the
+        // synthetic event's last cursorPosition (mid-display, per the
+        // offscreen-target override below in postMoveEvents) and the user
+        // sees a brief cursor flash. The floor stays at 10 s so ordinary
+        // moves keep their safety net against genuinely stuck states.
+        MouseHelpers.hideCursor(
+            watchdogTimeout: watchdogTimeout ?? Self.cursorHideWatchdogTimeout()
+        )
         defer {
             MouseHelpers.restoreCursorPosition(to: mouseLocation)
             MouseHelpers.showCursor()

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -76,13 +76,27 @@ extension MenuBarItemManager {
 
     /// Returns the default timeout for move operations associated
     /// with the given item.
+    ///
+    /// A budget, not a cost. `waitForMoveEventResponse` polls the item's
+    /// origin every 10ms and returns the instant it changes, so an owner that
+    /// answers promptly is charged what it takes and nothing more. Raising
+    /// these values cannot slow a move that works; it only buys time for one
+    /// that would otherwise have been abandoned while it was still going to
+    /// succeed.
+    ///
+    /// 100ms was too little to survive contention. In the #687 log, of the
+    /// twelve moves that landed, five needed a second or third attempt — the
+    /// owners were answering, just not inside the budget — and only twelve of
+    /// thirty-two moves landed at all. Startup is the worst case for this:
+    /// the source-PID scan and the restore wave compete for the same
+    /// main threads the AX and event round-trips have to be serviced on.
     private func getDefaultMoveOperationTimeout(for item: MenuBarItem) -> Duration {
         if item.isBentoBox {
             // Bento Boxes (i.e. Control Center groups) generally
             // take a little longer to respond.
-            return .milliseconds(200)
+            return .milliseconds(350)
         }
-        return .milliseconds(100)
+        return .milliseconds(250)
     }
 
     /// Returns the cached timeout for move operations associated
@@ -94,16 +108,41 @@ extension MenuBarItemManager {
         return getDefaultMoveOperationTimeout(for: item)
     }
 
+    /// Merges a newly computed timeout with the one currently cached for an
+    /// item.
+    ///
+    /// Growth is adopted as computed; only shrinkage is smoothed against the
+    /// standing value. Averaging both directions halved every escalation step
+    /// and so undid the one `nextMoveOperationTimeout` had just decided on:
+    /// a budget escalating by half from 100ms reaches the ceiling in four
+    /// attempts, but smoothed it only reaches 476ms in eight, which is the
+    /// exact ladder the #687 log walks before giving up on 1Password
+    /// (0.1 → 0.125 → 0.156 → 0.195 → 0.244 → 0.305 → 0.381 → 0.476). The
+    /// attempts meant to be spent trying a bigger budget were spent creeping
+    /// toward one instead. Decay stays smoothed, because there the caution is
+    /// the point: one fast answer should not commit an owner to a budget it
+    /// cannot meet again.
+    ///
+    /// The floor is 75ms: `waitForMoveEventResponse` polls every 10ms, so a
+    /// budget below that leaves too little margin for system event latency and
+    /// causes `itemResponseTimeout` → retry cascades. The ceiling is a second,
+    /// which is what an escalating budget is allowed to cost before the item is
+    /// better classified as unresponsive than as slow.
+    static nonisolated func mergedMoveOperationTimeout(
+        proposed: Duration,
+        current: Duration
+    ) -> Duration {
+        let next = proposed > current ? proposed : (proposed + current) / 2
+        return next.clamped(min: .milliseconds(75), max: .seconds(1))
+    }
+
     /// Updates the cached timeout for move operations associated
     /// with the given item.
     private func updateMoveOperationTimeout(_ timeout: Duration, for item: MenuBarItem) {
-        let current = getMoveOperationTimeout(for: item)
-        let average = (timeout + current) / 2
-        // Minimum of 75ms: waitForMoveEventResponse polls every 10ms, so a
-        // timeout below ~75ms leaves too little margin for system event latency
-        // and causes itemResponseTimeout → retry cascades.
-        let clamped = average.clamped(min: .milliseconds(75), max: .milliseconds(500))
-        moveOperationTimeouts[item.tag] = clamped
+        moveOperationTimeouts[item.tag] = Self.mergedMoveOperationTimeout(
+            proposed: timeout,
+            current: getMoveOperationTimeout(for: item)
+        )
     }
 
     /// Prunes the move operation timeouts cache, keeping only the entries

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -836,7 +836,9 @@ extension MenuBarItemManager {
         // sees a brief cursor flash. The floor stays at 10 s so ordinary
         // moves keep their safety net against genuinely stuck states.
         MouseHelpers.hideCursor(
-            watchdogTimeout: watchdogTimeout ?? Self.cursorHideWatchdogTimeout()
+            watchdogTimeout: watchdogTimeout ?? Self.cursorHideWatchdogTimeout(
+                maxAttempts: max(1, maxMoveAttempts)
+            )
         )
         defer {
             MouseHelpers.restoreCursorPosition(to: mouseLocation)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -350,7 +350,9 @@ extension MenuBarItemManager {
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)
             } catch {
-                failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                if !Self.moveAlreadyFiledFailure(for: error) {
+                    failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                }
                 MenuBarItemManager.diagLog.error(
                     "Notch overflow rebalance: failed to eject \(item.logString): \(error)"
                 )

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -1992,4 +1992,25 @@ final class MenuBarItemManager {
         pendingDivergenceObservedAt = nil
         recordBulkApplyOutcome(unenactedMoveCount: 0)
     }
+
+    /// Whether the save gate's user-move exemption applies: it must, and only,
+    /// when the most recent move was the user's own.
+    ///
+    /// Comparing recency rather than presence closes a hole in the cooldown:
+    /// a user move at T0 followed by an automatic move at T+3 leaves both
+    /// timestamps inside the five-second window, and an exemption keyed on
+    /// "a user move happened recently" would disable the cooldown for an
+    /// arrangement Thaw generated itself, letting the next cache cycle
+    /// persist it.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func saveCooldownExemptForUserMove(
+        lastMoveOperationTimestamp: ContinuousClock.Instant?,
+        lastUserMoveOperationTimestamp: ContinuousClock.Instant?
+    ) -> Bool {
+        guard let lastMoveOperationTimestamp, let lastUserMoveOperationTimestamp else {
+            return false
+        }
+        return lastUserMoveOperationTimestamp >= lastMoveOperationTimestamp
+    }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -191,6 +191,19 @@ final class MenuBarItemManager {
     /// Timestamp of the most recent menu bar item move operation.
     var lastMoveOperationTimestamp: ContinuousClock.Instant?
 
+    /// When the user last moved an item themselves, as opposed to Thaw
+    /// moving one on their behalf.
+    ///
+    /// Both kinds stamp ``lastMoveOperationTimestamp``, and for the restore
+    /// cooldown that is right — a bar that just moved should be left alone
+    /// whoever moved it. The save gate needs to tell them apart. Thaw's own
+    /// moves mean the bar is mid-restore and must not be written down; a
+    /// user's move is the one thing that *must* be written down, and
+    /// promptly, because the restore will otherwise revert it on the next
+    /// cycle. Suppressing the save for both would make a Layout-editor drag
+    /// undo itself (#958).
+    var lastUserMoveOperationTimestamp: ContinuousClock.Instant?
+
     /// Cached timeouts for move operations.
     var moveOperationTimeouts = [MenuBarItemTag: Duration]()
 
@@ -545,6 +558,30 @@ final class MenuBarItemManager {
     /// move. Only `EventError` carries enough detail to blame the owner.
     static nonisolated func failureKind(of error: any Error) -> MenuBarItemFailureLedger.FailureKind {
         (error as? EventError)?.failureKind ?? .other
+    }
+
+    /// Whether ``move(item:to:on:skipInputPause:maxMoveAttempts:)`` already
+    /// filed this error against the item before throwing it.
+    ///
+    /// `move` files every unresponsive-owner failure itself, so a caller that
+    /// also files one on catching the throw counts a single failed move
+    /// twice. That is not a cosmetic tally: the ledger deliberately waits for
+    /// a run of unresponsive-owner failures before writing a persisted mark,
+    /// and double-filing consumed the whole run in the same instant — the
+    /// #687 log marks 1Password one millisecond after logging that it was
+    /// still waiting. Every item that failed a single bulk-apply move was
+    /// marked immediately, and marked items get one attempt instead of eight
+    /// thereafter.
+    ///
+    /// Callers still file the failures `move` does not, so the backoff window
+    /// keeps counting vanished items and stale destinations.
+    static nonisolated func moveAlreadyFiledFailure(for error: any Error) -> Bool {
+        // Pattern-matched rather than compared: `FailureKind`'s `Equatable`
+        // conformance is main-actor isolated and this runs nonisolated.
+        if case .unresponsiveOwner = failureKind(of: error) {
+            return true
+        }
+        return false
     }
 
     /// The move-operation budget the next attempt should use, given how the
@@ -1919,6 +1956,15 @@ final class MenuBarItemManager {
         return timestamp.duration(to: .now) <= duration
     }
 
+    /// Returns a Boolean value that indicates whether the user moved an item
+    /// themselves within the given duration.
+    func lastUserMoveOperationOccurred(within duration: Duration) -> Bool {
+        guard let timestamp = lastUserMoveOperationTimestamp else {
+            return false
+        }
+        return timestamp.duration(to: .now) <= duration
+    }
+
     /// Records an explicit user move, either a direct Cmd-drag or a completed
     /// drag in the Layout editor.
     ///
@@ -1926,6 +1972,7 @@ final class MenuBarItemManager {
     /// failed-batch save latch and any pending automatic-divergence reading.
     func recordExternalMoveOperation() {
         lastMoveOperationTimestamp = .now
+        lastUserMoveOperationTimestamp = .now
         pendingDivergenceObservedAt = nil
         recordBulkApplyOutcome(unenactedMoveCount: 0)
     }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -70,6 +70,17 @@ final class MenuBarItemManager {
     /// geometry clears and re-arms recovery for a later episode.
     var didRecoverParkedHiddenDividerForCurrentMismatch = false
 
+    /// Consecutive authoritative cache cycles in which the always-hidden
+    /// section is enabled but its divider did not resolve while the hidden
+    /// divider did. A display change can strand the AH status item on another
+    /// screen's menu bar; `ControlItemPair` treats the missing divider as
+    /// success, so the lookup-failure rebuild never sees it (#863).
+    var missingAlwaysHiddenDividerStreak = 0
+
+    /// Prevents repeated AH divider recreation until the divider resolves
+    /// again and re-arms recovery for a later episode.
+    var didRecoverMissingAlwaysHiddenDivider = false
+
     /// Number of consecutive `ControlItemPair` lookup failures required
     /// before the control items' status items are rebuilt.
     static nonisolated let controlItemRebuildThreshold = 3
@@ -81,6 +92,11 @@ final class MenuBarItemManager {
     /// Number of authoritative mismatch applies required before discarding a
     /// parked hidden divider's stale autosave position.
     static nonisolated let parkedHiddenDividerRecoveryThreshold = 2
+
+    /// Number of consecutive authoritative cache cycles with an enabled but
+    /// unresolved always-hidden divider required before that divider's status
+    /// item is rebuilt.
+    static nonisolated let missingAlwaysHiddenDividerRecoveryThreshold = 3
 
     /// Supplementary AX-derived identity for items whose CG-side identity is
     /// degraded (a Control-Center generic `Item-N` placeholder title, or a

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemNameMemory.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemNameMemory.swift
@@ -1,0 +1,115 @@
+//
+//  MenuBarItemNameMemory.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+
+/// The name each menu bar item last resolved to, remembered across launches.
+///
+/// Naming an item requires knowing which process created it, and as of
+/// macOS 26 that takes an Accessibility scan the app deliberately does not
+/// wait for: the first cache pass runs without source-PID resolution so the
+/// bar is usable immediately, and a second pass upgrades the items once the
+/// scan lands. Between the two — about three seconds in the log attached to
+/// #956 — every item answers to the generic "Menu Bar Item", which is what
+/// the user sees on hover and in the search panel.
+///
+/// The name an item resolved to last time is almost always the name it will
+/// resolve to this time, so remembering it closes that window. This is a
+/// display fallback only: it never feeds identity, movability, or layout
+/// decisions, all of which continue to wait for the real source PID.
+///
+/// Not every item may be remembered — see ``isEligible(_:)``. A confidently
+/// wrong name is worse than a generic one, because the user acts on it.
+///
+/// `nonisolated` because `MenuBarItem/autoDetectedName` is, and it reads
+/// user defaults directly for the same reason `MenuBarItem/customName`
+/// does: the values are already resident, and threading a store through
+/// every naming site would isolate a property that has never been isolated.
+nonisolated enum MenuBarItemNameMemory {
+    /// The largest number of remembered names kept.
+    ///
+    /// Names are cheap and a name for an item that no longer exists is never
+    /// read, so this exists only to bound growth across years of installing
+    /// and removing menu bar apps. A typical bar holds ~25 items.
+    private static let capacity = 512
+
+    /// Whether an item's name may be remembered and restored.
+    ///
+    /// Two kinds of item are refused:
+    ///
+    /// - Items with a UUID namespace, which macOS reassigns every session.
+    ///   Their key cannot match after a relaunch, so storing one only grows
+    ///   the dictionary. This mirrors `MenuBarItemFailureLedger`.
+    /// - Control Center's generic `Item-N` slots. Their key encodes a
+    ///   position in Control Center's hosting order, not an identity: which
+    ///   slot is `Item-0` versus `Item-0:9` depends on which agents launched
+    ///   this boot and in what order. Restoring a name onto one would
+    ///   eventually label Adobe's icon "Docker" — and unlike a generic
+    ///   label, a wrong one gets clicked. These are exactly the items that
+    ///   `MenuBarItem/immovabilityReason` already parks as
+    ///   `unresolvedControlCenterPlaceholder` until their real owner is
+    ///   known, for the same reason.
+    static func isEligible(_ item: MenuBarItem) -> Bool {
+        guard case .string = item.tag.namespace else {
+            return false
+        }
+        return !item.tag.isControlCenterGenericItem && !item.isControlItem
+    }
+
+    /// The name the item resolved to on an earlier pass or launch, or `nil`
+    /// when nothing was remembered for it.
+    static func rememberedName(for item: MenuBarItem) -> String? {
+        guard isEligible(item) else {
+            return nil
+        }
+        let names = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        return names[key(for: item)]
+    }
+
+    /// Records the resolved name of every item that has one.
+    ///
+    /// Items whose source process has not resolved are skipped rather than
+    /// stored: their name is the generic fallback this type exists to avoid
+    /// showing, and writing it back would make the memory self-defeating.
+    /// The test is the running application rather than the source PID,
+    /// because that is precisely the condition under which
+    /// `MenuBarItem/autoDetectedName` takes its resolved path — a PID whose
+    /// process has since exited would otherwise store the fallback.
+    static func remember(_ items: [MenuBarItem]) {
+        var names = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        let before = names
+
+        for item in items where item.sourceApplication != nil && isEligible(item) {
+            let name = item.autoDetectedName
+            guard !name.isEmpty else {
+                continue
+            }
+            names[key(for: item)] = name
+        }
+
+        if names.count > capacity {
+            // Keep the names of items that are on the bar right now; the
+            // overflow is necessarily made up of items that are not.
+            let live = Set(items.map { key(for: $0) })
+            names = names.filter { live.contains($0.key) }
+        }
+
+        guard names != before else {
+            return
+        }
+        Defaults.set(names, forKey: .menuBarItemResolvedNames)
+    }
+
+    /// The key an item's name is stored under.
+    ///
+    /// Derived exactly as `MenuBarItemFailureLedger` derives its own, so the
+    /// two stores agree on what counts as the same item across launches.
+    private static func key(for item: MenuBarItem) -> String {
+        MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+    }
+}

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -304,6 +304,11 @@ nonisolated extension Defaults {
 
         case menuBarItemCustomNames = "MenuBarItemCustomNames"
 
+        /// The name each item last resolved to, used to label items during
+        /// the window before source-PID resolution lands. Managed by
+        /// ``MenuBarItemNameMemory``; not exposed in Settings.
+        case menuBarItemResolvedNames = "MenuBarItemResolvedNames"
+
         // MARK: Internal (Event Delivery)
 
         /// Items whose owners have recently failed to answer synthetic

--- a/ThawTests/ExtrasMenuBarNegativeCachePolicyTests.swift
+++ b/ThawTests/ExtrasMenuBarNegativeCachePolicyTests.swift
@@ -1,0 +1,76 @@
+//
+//  ExtrasMenuBarNegativeCachePolicyTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Pins the extras-menu-bar negative-cache TTL ladder.
+///
+/// The regression this ladder fixes: the per-app "checked, no extras menu
+/// bar" flag was cleared on every cache cleanup, and cleanup is driven by
+/// `NSWorkspace.runningApplications` — which changes whenever any process on
+/// the system starts or exits. A field log (#956) showed cleanup running 46
+/// times in seven minutes, so nearly every full scan re-probed all ~170
+/// running applications over the Accessibility API even though only ~16 of
+/// them have an extras menu bar at all. Deadlines make the skip survive
+/// cleanup; the ladder is what keeps late-registered status items findable.
+struct ExtrasMenuBarNegativeCachePolicyTests {
+    @Test func firstMissRetriesQuickly() {
+        // An app that has just launched may publish its status item a
+        // moment after it becomes reachable over accessibility.
+        #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 1) == .seconds(5))
+    }
+
+    @Test func repeatMissesBackOff() {
+        #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 2) == .seconds(30))
+        #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 3) == .seconds(120))
+    }
+
+    @Test func settledAppsReachSteadyStateAndStayThere() {
+        for misses in 4...50 {
+            #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: misses) == .seconds(300))
+        }
+    }
+
+    @Test func ladderIsMonotonicNondecreasing() {
+        var previous = ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 1)
+        for misses in 2...10 {
+            let current = ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: misses)
+            #expect(current >= previous)
+            previous = current
+        }
+    }
+
+    @Test func nonPositiveCountsClampToFirstRung() {
+        // A bookkeeping error upstream must degrade to more scanning,
+        // never to a longer bar.
+        #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 0) == .seconds(5))
+        #expect(ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: -3) == .seconds(5))
+    }
+
+    @Test func steadyStateIsBoundedSoLateStatusItemsAreStillFound() {
+        // An app that registers a status item long after launch has to be
+        // rediscovered without user action. The steady-state rung is the
+        // worst-case delay for that, so it must stay bounded — this is the
+        // property the deleted blanket reset used to provide.
+        let steadyState = ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 99)
+        #expect(steadyState <= .seconds(300))
+    }
+
+    @Test func earlyRungsCoverTheStartupSettlingWindow() {
+        // Logging in launches every status-item agent at once, and an app
+        // that is reachable over accessibility before it publishes its
+        // status item comes back empty on the first probe. The first two
+        // rungs must therefore both elapse inside the app's ~90s startup
+        // settling window, giving such an app three chances to be seen
+        // before the ladder backs off to minutes.
+        let firstTwo = ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 1)
+            + ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 2)
+        #expect(firstTwo < .seconds(90))
+    }
+}

--- a/ThawTests/ExtrasMenuBarProbeMemoryTests.swift
+++ b/ThawTests/ExtrasMenuBarProbeMemoryTests.swift
@@ -1,0 +1,161 @@
+//
+//  ExtrasMenuBarProbeMemoryTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Pins what carries across launches about which applications have an extras
+/// menu bar, and — more importantly — what does not.
+///
+/// The memory exists to keep the first scan of a session off the ~155 of ~170
+/// running applications that have never had an extras menu bar, which cost
+/// 3.85s in the #956 log. It is allowed to be wrong: a wrong entry costs a
+/// scan, never an answer. What it is not allowed to do is go on being wrong,
+/// which is why every rule below is biased toward re-probing.
+@Suite("Extras menu bar probe memory")
+struct ExtrasMenuBarProbeMemoryTests {
+    // MARK: Seeding
+
+    /// Nothing remembered is nothing to act on: the application is probed on
+    /// the cold-start scan exactly as it was before this memory existed.
+    @Test("An unknown application is not seeded")
+    func unknownApplicationIsNotSeeded() {
+        #expect(ExtrasMenuBarProbeMemory.seed(forRememberedMisses: nil) == nil)
+    }
+
+    /// One miss is not evidence — an application probed while it was still
+    /// launching reports no extras menu bar for reasons of its own.
+    @Test("A single remembered miss is not enough to seed")
+    func singleMissIsNotEnoughToSeed() {
+        #expect(ExtrasMenuBarProbeMemory.seed(forRememberedMisses: 1) == nil)
+        #expect(ExtrasMenuBarProbeMemory.seed(forRememberedMisses: 0) == nil)
+    }
+
+    /// The count carries so a confirming miss resumes the ladder instead of
+    /// climbing it a second time.
+    @Test("A settled application resumes its rung on the ladder")
+    func settledApplicationResumesItsRung() {
+        let seed = ExtrasMenuBarProbeMemory.seed(forRememberedMisses: 3)
+        #expect(seed?.misses == 3)
+    }
+
+    /// The deadline is the first rung whatever the count says. Memory is good
+    /// enough to stay out of the cold-start scan and not good enough to buy
+    /// five minutes of silence from an application that gained a status item
+    /// since last launch.
+    @Test("A seeded deadline is always the first rung")
+    func seededDeadlineIsAlwaysTheFirstRung() {
+        for misses in 2...50 {
+            #expect(
+                ExtrasMenuBarProbeMemory.seed(forRememberedMisses: misses)?.initialTTL
+                    == ExtrasMenuBarNegativeCachePolicy.ttl(afterConsecutiveMisses: 1)
+            )
+        }
+    }
+
+    /// Counting past the ladder's top rung records nothing it can act on.
+    @Test("A seeded count is capped where the ladder saturates")
+    func seededCountIsCapped() {
+        #expect(ExtrasMenuBarProbeMemory.seed(forRememberedMisses: 900)?.misses
+            == ExtrasMenuBarProbeMemory.maximumRememberedMisses)
+    }
+
+    // MARK: Merging
+
+    /// The ordinary case: an application that came back empty twice is worth
+    /// skipping first thing next launch.
+    @Test("A settled miss is remembered")
+    func settledMissIsRemembered() {
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: [:],
+            observed: ["com.example.quiet": 3],
+            runningBundleIDs: ["com.example.quiet"]
+        )
+        #expect(merged["com.example.quiet"] == 3)
+    }
+
+    /// The case that matters most. An application that has since published an
+    /// extras menu bar loses its entry outright — a stale entry here would
+    /// cost that application's items a skipped probe on every future launch,
+    /// which is a permanent cost for a one-session observation.
+    @Test("An application that gained an extras menu bar is forgotten")
+    func applicationThatGainedABarIsForgotten() {
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: ["com.example.grew": 4],
+            observed: ["com.example.grew": 0],
+            runningBundleIDs: ["com.example.grew"]
+        )
+        #expect(merged["com.example.grew"] == nil)
+    }
+
+    /// A single miss neither earns an entry nor keeps one.
+    @Test("An unsettled miss is not remembered")
+    func unsettledMissIsNotRemembered() {
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: ["com.example.flaky": 4],
+            observed: ["com.example.flaky": 1],
+            runningBundleIDs: ["com.example.flaky"]
+        )
+        #expect(merged["com.example.flaky"] == nil)
+    }
+
+    /// An application that was not running says nothing about itself, so what
+    /// was learned about it survives sessions it sits out.
+    @Test("An application that was not running keeps its entry")
+    func absentApplicationKeepsItsEntry() {
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: ["com.example.absent": 4],
+            observed: ["com.example.present": 2],
+            runningBundleIDs: ["com.example.present"]
+        )
+        #expect(merged["com.example.absent"] == 4)
+        #expect(merged["com.example.present"] == 2)
+    }
+
+    /// Counts are stored capped, so the ladder's top rung is the widest thing
+    /// the memory can ask for.
+    @Test("A stored count is capped where the ladder saturates")
+    func storedCountIsCapped() {
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: [:],
+            observed: ["com.example.ancient": 800],
+            runningBundleIDs: ["com.example.ancient"]
+        )
+        #expect(merged["com.example.ancient"] == ExtrasMenuBarProbeMemory.maximumRememberedMisses)
+    }
+
+    /// Growth is bounded across years of installing and removing apps. The
+    /// overflow is shed rather than the live set, since an entry for an
+    /// application that is not running is the one that may never be read
+    /// again.
+    @Test("Overflow sheds the applications that are not running")
+    func overflowShedsAbsentApplications() {
+        let stale = (0..<(ExtrasMenuBarProbeMemory.capacity * 2)).reduce(into: [String: Int]()) {
+            $0["com.example.stale\($1)"] = 4
+        }
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: stale,
+            observed: ["com.example.live": 2],
+            runningBundleIDs: ["com.example.live"]
+        )
+        #expect(merged == ["com.example.live": 2])
+    }
+
+    /// Under capacity nothing is shed, so an application that simply was not
+    /// running this session is not evicted for it.
+    @Test("A memory under capacity is left intact")
+    func memoryUnderCapacityIsLeftIntact() {
+        let persisted = (0..<10).reduce(into: [String: Int]()) { $0["com.example.app\($1)"] = 4 }
+        let merged = ExtrasMenuBarProbeMemory.merged(
+            persisted: persisted,
+            observed: [:],
+            runningBundleIDs: []
+        )
+        #expect(merged == persisted)
+    }
+}

--- a/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
+++ b/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
@@ -240,6 +240,62 @@ struct ParkedHiddenDividerRecoveryTests {
     }
 }
 
+/// Covers the seed-position half of both divider rebuilds (#958).
+///
+/// A rebuild used to write `preflightSetup`'s fresh-install seed
+/// unconditionally, through the same guard-bypassing route that reopened
+/// #895/#890. On a populated bar that drops the rebuilt divider on one side of
+/// every managed item and the following cache pass reads the whole bar into one
+/// section. nk-tedo-001's log has the shape exactly: one rebuild in five hours,
+/// visible section 12 items before it and 1 item three seconds after, and three
+/// earlier off-screen parkings that never rebuilt and never collapsed.
+@Suite("Rebuilt divider seed position")
+struct RebuiltDividerSeedPositionTests {
+    @Test("An empty bar still gets the fresh-install seed")
+    func emptyBarKeepsTheSeed() {
+        #expect(MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: 0))
+        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: 0) == 1)
+    }
+
+    @Test("A single managed item is enough to withhold the seed")
+    func oneItemWithholdsTheSeed() {
+        #expect(!MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: 1))
+        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: 1) == nil)
+    }
+
+    /// The reported bar. Nothing about the count itself is special; the point
+    /// is that the populated case never reaches the stamp.
+    @Test("The reported bar withholds the seed")
+    func reportedBarWithholdsTheSeed() {
+        for count in 1 ... 38 {
+            #expect(
+                MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: count) == nil,
+                "managedItemCount=\(count) must not re-stamp the seed"
+            )
+        }
+    }
+
+    /// The gate is about what a rebuild would strand, so it reads the count
+    /// and nothing else. A negative count cannot occur, but answering "seed
+    /// it" for one would put the destructive branch behind an arithmetic slip.
+    @Test("A nonsensical count does not unlock the seed")
+    func negativeCountDoesNotSeed() {
+        #expect(!MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: -1))
+        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: -1) == nil)
+    }
+
+    /// The two branches have to be distinguishable in a field log, because
+    /// telling them apart is what separated cause from symptom in #958.
+    @Test("The log fragment names which branch ran")
+    func logFragmentNamesTheBranch() {
+        let seeded = MenuBarItemManager.seedDescription(1)
+        let kept = MenuBarItemManager.seedDescription(nil)
+        #expect(seeded.contains("seeded position"))
+        #expect(kept.contains("stored position"))
+        #expect(seeded != kept)
+    }
+}
+
 /// Covers the retry backoff #933 asked for: a permanently failing lookup
 /// left the window-ID snapshot uncommitted, so the change detector re-ran
 /// a full recache on every 3-second poll for 27 hours straight. The

--- a/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
+++ b/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
@@ -363,3 +363,82 @@ struct ControlItemLookupRetryBackoffTests {
         ) == .seconds(3))
     }
 }
+
+@Suite("Missing always-hidden divider recovery")
+struct MissingAlwaysHiddenDividerRecoveryTests {
+    @Test("The first missing reading is left alone")
+    func firstMissingReadingDoesNotRecover() {
+        #expect(!MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+            consecutiveMissingReadings: 1
+        ))
+    }
+
+    @Test("Repeated missing readings recreate the divider")
+    func repeatedMissingReadingsRecover() {
+        #expect(MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+            consecutiveMissingReadings: MenuBarItemManager.missingAlwaysHiddenDividerRecoveryThreshold
+        ))
+    }
+
+    @Test("A missing-divider episode recreates only once")
+    func missingEpisodeRecoversOnce() {
+        #expect(!MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+            consecutiveMissingReadings: MenuBarItemManager.missingAlwaysHiddenDividerRecoveryThreshold + 10,
+            alreadyRecovered: true
+        ))
+    }
+
+    /// Models the manager's own episode latch: missing readings accumulate,
+    /// recovery fires once at the threshold, and no second recovery is
+    /// allowed until a resolved reading re-arms the streak.
+    @Test("A persistent missing episode recovers only once, then re-arms on resolution")
+    func missingEpisodeRearmsOnResolution() {
+        var consecutiveMissing = 0
+        var alreadyRecovered = false
+        var recoverCount = 0
+
+        func recordMissing() {
+            consecutiveMissing += 1
+            if MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+                consecutiveMissingReadings: consecutiveMissing,
+                alreadyRecovered: alreadyRecovered
+            ) {
+                recoverCount += 1
+                alreadyRecovered = true
+            }
+        }
+
+        func recordResolved() {
+            consecutiveMissing = 0
+            alreadyRecovered = false
+        }
+
+        // The #863 field log: alwaysHidden=nil on every cycle for 12+ hours.
+        for _ in 0 ..< (MenuBarItemManager.missingAlwaysHiddenDividerRecoveryThreshold * 4) {
+            recordMissing()
+        }
+        #expect(recoverCount == 1)
+
+        // The divider comes back (replug, rebuild): the episode re-arms.
+        recordResolved()
+        for _ in 0 ..< MenuBarItemManager.missingAlwaysHiddenDividerRecoveryThreshold {
+            recordMissing()
+        }
+        #expect(recoverCount == 2)
+    }
+
+    /// A disabled always-hidden section has no divider by choice. The
+    /// orchestrator resets the streak in that state; this pins the decision
+    /// function's contract that only enabled-section readings reach it.
+    @Test("A custom threshold is respected")
+    func customThresholdIsRespected() {
+        #expect(!MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+            consecutiveMissingReadings: 1,
+            threshold: 2
+        ))
+        #expect(MenuBarItemManager.shouldRecoverMissingAlwaysHiddenDivider(
+            consecutiveMissingReadings: 2,
+            threshold: 2
+        ))
+    }
+}

--- a/ThawTests/MenuBar/Items/MenuBarItemFailureLedgerTests.swift
+++ b/ThawTests/MenuBar/Items/MenuBarItemFailureLedgerTests.swift
@@ -78,6 +78,23 @@ final class MenuBarItemFailureLedgerTests {
         )
     }
 
+    /// Records exactly as many unresponsive-owner failures as it takes to
+    /// earn a mark, for tests where being marked is setup rather than the
+    /// thing under test.
+    ///
+    /// The threshold itself is pinned by ``aSecondFailureStillDoesNotMark``
+    /// and ``aThirdFailureMarksTheItem``, so it lives as a literal in
+    /// exactly one place here.
+    private func failUntilMarked(
+        _ ledger: MenuBarItemFailureLedger,
+        _ item: MenuBarItem,
+        now: ContinuousClock.Instant = .now
+    ) {
+        for _ in 0..<3 {
+            ledger.recordFailure(for: item, kind: .unresponsiveOwner, now: now)
+        }
+    }
+
     @Test("An item the ledger has never seen is not unresponsive")
     func unknownItemIsNotUnresponsive() {
         let ledger = MenuBarItemFailureLedger()
@@ -94,24 +111,39 @@ final class MenuBarItemFailureLedgerTests {
         #expect(Defaults.object(forKey: .unresponsiveMenuBarItems) == nil)
     }
 
-    @Test("A second failure marks the item")
-    func aSecondFailureMarksTheItem() {
+    @Test("A second failure still does not mark an item")
+    func aSecondFailureStillDoesNotMark() {
+        // Two failed moves is thin evidence during a startup restore wave,
+        // where contention alone can cost an item its budget twice (#687).
         let item = item("at.obdev.littlesnitch", "Item-0")
         let ledger = MenuBarItemFailureLedger()
+        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
+        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
+
+        #expect(!ledger.isUnresponsive(item))
+        #expect(Defaults.object(forKey: .unresponsiveMenuBarItems) == nil)
+    }
+
+    @Test("A third failure marks the item")
+    func aThirdFailureMarksTheItem() {
+        let item = item("at.obdev.littlesnitch", "Item-0")
+        let ledger = MenuBarItemFailureLedger()
+        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
         ledger.recordFailure(for: item, kind: .unresponsiveOwner)
         ledger.recordFailure(for: item, kind: .unresponsiveOwner)
 
         #expect(ledger.isUnresponsive(item))
     }
 
-    @Test("A success between two failures resets the provisional failure")
+    @Test("A success resets the run of failures rather than decrementing it")
     func aSuccessResetsTheProvisionalFailure() {
-        // Two failures separated by a success are two unrelated blips, not
-        // an owner that never answers.
+        // Failures separated by a success are unrelated blips, not an owner
+        // that never answers, so the count starts over rather than carrying.
         let item = item("at.obdev.littlesnitch", "Item-0")
         let ledger = MenuBarItemFailureLedger()
-        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
+        failUntilMarked(ledger, item)
         ledger.recordSuccess(for: item)
+        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
         ledger.recordFailure(for: item, kind: .unresponsiveOwner)
 
         #expect(!ledger.isUnresponsive(item))
@@ -121,8 +153,7 @@ final class MenuBarItemFailureLedgerTests {
     func markSurvivesANewStore() {
         let item = item("at.obdev.littlesnitch", "Item-0")
         let first = MenuBarItemFailureLedger()
-        first.recordFailure(for: item, kind: .unresponsiveOwner)
-        first.recordFailure(for: item, kind: .unresponsiveOwner)
+        failUntilMarked(first, item)
 
         // A second instance reads only what was persisted, which is what a
         // relaunch does.
@@ -144,8 +175,7 @@ final class MenuBarItemFailureLedgerTests {
     @Test("Records are scoped to the exact item")
     func recordsAreScopedToTheExactItem() {
         let ledger = MenuBarItemFailureLedger()
-        ledger.recordFailure(for: item("at.obdev.littlesnitch", "Item-0"), kind: .unresponsiveOwner)
-        ledger.recordFailure(for: item("at.obdev.littlesnitch", "Item-0"), kind: .unresponsiveOwner)
+        failUntilMarked(ledger, item("at.obdev.littlesnitch", "Item-0"))
 
         #expect(!ledger.isUnresponsive(item("at.obdev.littlesnitch", "Item-1")))
         #expect(!ledger.isUnresponsive(item("com.example.other", "Item-0")))
@@ -157,8 +187,7 @@ final class MenuBarItemFailureLedgerTests {
         // would persist a key that can never match again.
         let ephemeral = ephemeralItem()
         let ledger = MenuBarItemFailureLedger()
-        ledger.recordFailure(for: ephemeral, kind: .unresponsiveOwner)
-        ledger.recordFailure(for: ephemeral, kind: .unresponsiveOwner)
+        failUntilMarked(ledger, ephemeral)
 
         #expect(!ledger.isUnresponsive(ephemeral))
         #expect(Defaults.object(forKey: .unresponsiveMenuBarItems) == nil)
@@ -168,8 +197,7 @@ final class MenuBarItemFailureLedgerTests {
     func removeAllForgetsEverything() {
         let item = item("at.obdev.littlesnitch", "Item-0")
         let ledger = MenuBarItemFailureLedger()
-        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
-        ledger.recordFailure(for: item, kind: .unresponsiveOwner)
+        failUntilMarked(ledger, item)
         ledger.removeAll()
 
         #expect(!ledger.isUnresponsive(item))
@@ -237,8 +265,7 @@ final class MenuBarItemFailureLedgerTests {
         let item = item("at.obdev.littlesnitch", "Item-0")
         let ledger = MenuBarItemFailureLedger()
         let now = ContinuousClock.Instant.now
-        ledger.recordFailure(for: item, kind: .unresponsiveOwner, now: now)
-        ledger.recordFailure(for: item, kind: .unresponsiveOwner, now: now)
+        failUntilMarked(ledger, item, now: now)
         #expect(ledger.isUnderBackoff(key: item.uniqueIdentifier, now: now))
         #expect(ledger.isUnresponsive(item))
 

--- a/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
+++ b/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
@@ -207,16 +207,22 @@ struct MenuBarItemNameMemoryTests {
 
     @Test("Refused items are never written into the memory")
     func refusedItemsAreNotRemembered() {
-        // sourcePID is set here, so only the eligibility rule can keep this
-        // out of the dictionary.
+        // sourcePID is set to a live process (this test runner), so the
+        // source-application filter passes and only the eligibility rule can
+        // keep this out of the dictionary. A dead hard-coded PID would let
+        // the test pass through the sourceApplication check instead.
         let item = MenuBarItem.fixture(
             tag: .appItem(bundleID: "com.apple.controlcenter", title: "Item-0"),
             windowID: 1100,
-            sourcePID: 1234
+            sourcePID: ProcessInfo.processInfo.processIdentifier
         )
+        #expect(item.sourceApplication != nil)
         let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
 
         let original = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        var baseline = original
+        baseline[key] = nil
+        Defaults.set(baseline, forKey: .menuBarItemResolvedNames)
         defer { Defaults.set(original, forKey: .menuBarItemResolvedNames) }
 
         MenuBarItemNameMemory.remember([item])

--- a/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
+++ b/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
@@ -1,0 +1,223 @@
+//
+//  MenuBarItemNameMemoryTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+import Testing
+@testable import Thaw
+
+/// Pins which items may carry a remembered name across launches.
+///
+/// The memory exists because the first cache pass after launch runs without
+/// source-PID resolution, so every item answers to the generic "Menu Bar
+/// Item" for the seconds the accessibility scan takes (#956). Restoring the
+/// previous name closes that window — but only where the key that name is
+/// stored under still means the same item next launch. Everything in this
+/// suite is about that second half: a generic label is a small annoyance,
+/// while a confidently wrong one gets clicked.
+struct MenuBarItemNameMemoryTests {
+    @Test("An ordinary app item is eligible")
+    func ordinaryAppItemIsEligible() {
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.app", title: "Widget"),
+            windowID: 42
+        )
+        #expect(MenuBarItemNameMemory.isEligible(item))
+    }
+
+    @Test("A Control-Center-hosted item with a distinctive title is eligible")
+    func distinctivelyTitledHostedItemIsEligible() {
+        // These are the items the #956 log shows going unnamed: hosted by
+        // Control Center, but carrying a title that names their owner, so
+        // the key stays meaningful across launches.
+        for title in ["raycastIcon", "com.goodsnooze.MacWhisper", "FocusModes"] {
+            let item = MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.apple.controlcenter", title: title),
+                windowID: 100
+            )
+            #expect(MenuBarItemNameMemory.isEligible(item), "\(title) should be eligible")
+        }
+    }
+
+    @Test("Control Center's generic slots are refused")
+    func genericControlCenterSlotsAreRefused() {
+        // `Item-N` encodes a position in Control Center's hosting order, not
+        // an identity. Which slot is Item-0 depends on which agents launched
+        // this boot, so a name restored here can land on another app's icon.
+        for title in ["Item-0", "Item-1", "Item-12"] {
+            let item = MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.apple.controlcenter", title: title),
+                windowID: 200
+            )
+            #expect(!MenuBarItemNameMemory.isEligible(item), "\(title) must be refused")
+        }
+    }
+
+    @Test("A generic slot stays refused at every instance index")
+    func genericSlotRefusedAtEveryInstanceIndex() {
+        // The field log carries Item-0:7, Item-0:9 and Item-0:10 side by
+        // side. The index is what makes them distinct *this* session and is
+        // exactly what does not survive a relaunch.
+        for index in 1...12 {
+            let item = MenuBarItem.fixture(
+                tag: .appItem(
+                    bundleID: "com.apple.controlcenter",
+                    title: "Item-0",
+                    instanceIndex: index
+                ),
+                windowID: 300
+            )
+            #expect(!MenuBarItemNameMemory.isEligible(item), "Item-0:\(index) must be refused")
+        }
+    }
+
+    @Test("Items with a UUID namespace are refused")
+    func uuidNamespacedItemsAreRefused() {
+        // macOS reassigns these every session, so the key could never match
+        // again. Mirrors MenuBarItemFailureLedger's own stability rule.
+        let item = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .uuid(UUID()), title: "Widget"),
+            windowID: 400
+        )
+        #expect(!MenuBarItemNameMemory.isEligible(item))
+    }
+
+    @Test("Thaw's own control items are refused")
+    func controlItemsAreRefused() {
+        // They already name themselves from Constants.displayName and never
+        // reach the fallback this memory feeds.
+        let item = MenuBarItem.fixture(tag: .hiddenControlItem, windowID: 500)
+        #expect(!MenuBarItemNameMemory.isEligible(item))
+    }
+
+    @Test("An unresolved item reads back nothing when nothing was stored")
+    func unresolvedItemWithoutMemoryReadsNothing() {
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.never-seen-\(UUID().uuidString)", title: "Widget"),
+            windowID: 600,
+            sourcePID: nil
+        )
+        #expect(MenuBarItemNameMemory.rememberedName(for: item) == nil)
+        // And with no memory to fall back on, the generic label still shows.
+        #expect(item.autoDetectedName == "Menu Bar Item")
+    }
+
+    @Test("A refused item never reads back a name, even if one is in defaults")
+    func refusedItemNeverReadsBack() {
+        // Guards the read side independently of the write side: even a
+        // dictionary hand-populated by an older build must not paint a name
+        // onto a generic slot.
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.apple.controlcenter", title: "Item-0"),
+            windowID: 700,
+            sourcePID: nil
+        )
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+
+        let original = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        defer { Defaults.set(original, forKey: .menuBarItemResolvedNames) }
+
+        var seeded = original
+        seeded[key] = "Docker Desktop"
+        Defaults.set(seeded, forKey: .menuBarItemResolvedNames)
+
+        #expect(MenuBarItemNameMemory.rememberedName(for: item) == nil)
+        #expect(item.autoDetectedName == "Menu Bar Item")
+    }
+
+    @Test("A remembered name labels an item whose source has not resolved")
+    func rememberedNameLabelsUnresolvedItem() {
+        let bundleID = "com.example.remembered-\(UUID().uuidString)"
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: bundleID, title: "Widget"),
+            windowID: 800,
+            sourcePID: nil
+        )
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+
+        let original = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        defer { Defaults.set(original, forKey: .menuBarItemResolvedNames) }
+
+        var seeded = original
+        seeded[key] = "Example Widget"
+        Defaults.set(seeded, forKey: .menuBarItemResolvedNames)
+
+        #expect(MenuBarItemNameMemory.rememberedName(for: item) == "Example Widget")
+        #expect(item.autoDetectedName == "Example Widget")
+    }
+
+    @Test("A custom name still outranks a remembered one")
+    func customNameOutranksRememberedName() {
+        // displayName's precedence order is user intent first. The memory is
+        // a fallback for the auto-detected name, not a competitor to it.
+        let bundleID = "com.example.custom-\(UUID().uuidString)"
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: bundleID, title: "Widget"),
+            windowID: 900,
+            sourcePID: nil
+        )
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+
+        let originalNames = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        let originalCustom = Defaults.dictionary(forKey: .menuBarItemCustomNames) as? [String: String] ?? [:]
+        defer {
+            Defaults.set(originalNames, forKey: .menuBarItemResolvedNames)
+            Defaults.set(originalCustom, forKey: .menuBarItemCustomNames)
+        }
+
+        var seededNames = originalNames
+        seededNames[key] = "Remembered"
+        Defaults.set(seededNames, forKey: .menuBarItemResolvedNames)
+
+        var seededCustom = originalCustom
+        seededCustom[item.uniqueIdentifier] = "Chosen By User"
+        Defaults.set(seededCustom, forKey: .menuBarItemCustomNames)
+
+        #expect(item.displayName == "Chosen By User")
+    }
+
+    @Test("Unresolved items are never written back into the memory")
+    func unresolvedItemsAreNotRemembered() {
+        // Storing the generic fallback would make the memory self-defeating:
+        // the next launch would restore "Menu Bar Item" as if it were a name.
+        let bundleID = "com.example.unresolved-\(UUID().uuidString)"
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: bundleID, title: "Widget"),
+            windowID: 1000,
+            sourcePID: nil
+        )
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+
+        let original = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        defer { Defaults.set(original, forKey: .menuBarItemResolvedNames) }
+
+        MenuBarItemNameMemory.remember([item])
+
+        let stored = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        #expect(stored[key] == nil)
+    }
+
+    @Test("Refused items are never written into the memory")
+    func refusedItemsAreNotRemembered() {
+        // sourcePID is set here, so only the eligibility rule can keep this
+        // out of the dictionary.
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.apple.controlcenter", title: "Item-0"),
+            windowID: 1100,
+            sourcePID: 1234
+        )
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+
+        let original = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        defer { Defaults.set(original, forKey: .menuBarItemResolvedNames) }
+
+        MenuBarItemNameMemory.remember([item])
+
+        let stored = Defaults.dictionary(forKey: .menuBarItemResolvedNames) as? [String: String] ?? [:]
+        #expect(stored[key] == nil)
+    }
+}

--- a/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
+++ b/ThawTests/MenuBar/Items/MenuBarItemNameMemoryTests.swift
@@ -19,6 +19,10 @@ import Testing
 /// stored under still means the same item next launch. Everything in this
 /// suite is about that second half: a generic label is a small annoyance,
 /// while a confidently wrong one gets clicked.
+///
+/// Serialized: the tests replace and restore the process-wide
+/// `menuBarItemResolvedNames` defaults dictionary, which must not interleave.
+@Suite(.serialized)
 struct MenuBarItemNameMemoryTests {
     @Test("An ordinary app item is eligible")
     func ordinaryAppItemIsEligible() {

--- a/ThawTests/MenuBar/Items/MoveEventCoordinatesTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEventCoordinatesTests.swift
@@ -41,8 +41,8 @@ struct MoveEventCoordinatesTests {
         )
     }
 
-    /// #923: dropping onto the exact coordinate of a zero-width section
-    /// divider leaves AppKit free to choose either side. The field log showed
+    /// #923: dropping onto the exact coordinate of a section divider leaves
+    /// AppKit free to choose either side. The field log showed
     /// `.leftOfItem(AH_ctrl)` repeatedly landing one point to its right.
     @Test("A control-item destination biases the drop into the requested section")
     func controlItemTargetPointUsesRequestedSide() {
@@ -69,16 +69,47 @@ struct MoveEventCoordinatesTests {
         )
     }
 
-    /// A control item with actual width (e.g. an expanded divider) already
-    /// gives AppKit enough hit-test span to disambiguate the side, so the
-    /// ±1 bias must not fire and shift the drop point away from the edge.
-    @Test("A wide control-item destination gets no section bias")
-    func wideControlItemTargetPointGetsNoBias() {
+    /// A divider that is thousands of points wide needs the bias just as much
+    /// as a zero-width one. The width is how the section conceals the items
+    /// behind it, not hit-test slack the drop can lean on: in the reporter's
+    /// 21 August log AH_ctrl was parked with `maxX <= 0` and expanded, and
+    /// `.leftOfItem` still landed the item at `minX + 1` on attempts 1 and 5.
+    @Test("An expanded control-item destination is biased too")
+    func expandedControlItemTargetPointIsBiased() {
         let displayBounds = CGRect(x: 0, y: 0, width: 1470, height: 956)
-        let bounds = CGRect(x: -9465, y: 0, width: 10, height: 33)
+        // The geometry the log implies: minX -9189, maxX at or left of the
+        // display origin, which is why targetPoint reaches for midY.
+        let bounds = CGRect(x: -9189, y: 0, width: 9189, height: 33)
         let target = MenuBarItem.fixture(
             tag: .alwaysHiddenControlItem,
-            windowID: 32279,
+            windowID: 43471,
+            bounds: bounds,
+            isOnScreen: false
+        )
+
+        #expect(
+            MenuBarItemManager.MoveDestination.leftOfItem(target).targetPoint(
+                in: bounds,
+                on: displayBounds
+            ) == CGPoint(x: bounds.minX - 1, y: bounds.midY)
+        )
+        #expect(
+            MenuBarItemManager.MoveDestination.rightOfItem(target).targetPoint(
+                in: bounds,
+                on: displayBounds
+            ) == CGPoint(x: bounds.maxX + 1, y: bounds.midY)
+        )
+    }
+
+    /// An ordinary item is not a section boundary, so its edge is a real drop
+    /// coordinate and must be left alone.
+    @Test("A regular item destination gets no section bias")
+    func regularItemTargetPointGetsNoBias() {
+        let displayBounds = CGRect(x: 0, y: 0, width: 1470, height: 956)
+        let bounds = CGRect(x: -4193, y: 0, width: 22, height: 33)
+        let target = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.target", title: "Target"),
+            windowID: 103,
             bounds: bounds,
             isOnScreen: false
         )
@@ -88,12 +119,6 @@ struct MoveEventCoordinatesTests {
                 in: bounds,
                 on: displayBounds
             ) == CGPoint(x: bounds.minX, y: bounds.midY)
-        )
-        #expect(
-            MenuBarItemManager.MoveDestination.rightOfItem(target).targetPoint(
-                in: bounds,
-                on: displayBounds
-            ) == CGPoint(x: bounds.maxX, y: bounds.midY)
         )
     }
 

--- a/ThawTests/MenuBar/Items/MoveFailureBackoffTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureBackoffTests.swift
@@ -41,3 +41,60 @@ struct MoveFailureBackoffTests {
         #expect(MenuBarItemManager.moveFailureBackoffInterval(failureCount: -3) == .seconds(30))
     }
 }
+
+/// Characterizes which failures `move` has already filed with the ledger by
+/// the time it throws, so a catch clause that files again does not charge one
+/// failed move twice.
+///
+/// Double-filing was invisible while it only widened a backoff window, but it
+/// made the "wait for another failure before marking" rule meaningless: both
+/// halves were consumed in the same instant. In the #687 log, 1Password was
+/// marked unresponsive one millisecond after the line saying it was still
+/// waiting for a second failure.
+@Suite("Move failure double filing")
+struct MoveFailureDoubleFilingTests {
+    private func makeItem() -> MenuBarItem {
+        .fixture(
+            tag: .appItem(bundleID: "com.example.wifi", title: "Wi-Fi"),
+            windowID: 42
+        )
+    }
+
+    /// The three the ledger treats as an unresponsive owner are exactly the
+    /// three `move` files for itself.
+    @Test("Unresponsive-owner failures are already filed")
+    func unresponsiveOwnerFailuresAreAlreadyFiled() {
+        let item = makeItem()
+        for error in [
+            MenuBarItemManager.EventError.ownerUnresponsive(item),
+            .eventOperationTimeout(item),
+            .itemResponseTimeout(item),
+        ] {
+            #expect(MenuBarItemManager.moveAlreadyFiledFailure(for: error))
+        }
+    }
+
+    /// Everything else is still the caller's to file, so the backoff window
+    /// keeps counting vanished items and stale destinations.
+    @Test("Other failures are left for the caller to file")
+    func otherFailuresAreLeftToTheCaller() {
+        let item = makeItem()
+        for error in [
+            MenuBarItemManager.EventError.cannotComplete,
+            .itemNotMovable(item),
+            .missingItemBounds(item),
+            .menuTrackingActive(item),
+            .eventWindowMismatch(item),
+            .staleDestination(item),
+        ] {
+            #expect(!MenuBarItemManager.moveAlreadyFiledFailure(for: error))
+        }
+    }
+
+    /// An error from outside the move path — a cancellation, say — is nobody's
+    /// filed failure.
+    @Test("A foreign error is not treated as already filed")
+    func foreignErrorIsNotAlreadyFiled() {
+        #expect(!MenuBarItemManager.moveAlreadyFiledFailure(for: CancellationError()))
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveOperationTimeoutTests.swift
+++ b/ThawTests/MenuBar/Items/MoveOperationTimeoutTests.swift
@@ -80,4 +80,88 @@ struct MoveOperationTimeoutTests {
         }
         #expect(timeout == .milliseconds(108)) // 256 → 192 → 144 → 108
     }
+
+    // MARK: Merging with the cached budget
+
+    /// The #687 fix. Smoothing an escalation against the standing value
+    /// halved it, so a budget that `nextMoveOperationTimeout` had just raised
+    /// by half only rose by a quarter.
+    @Test("An escalation is adopted at full size")
+    func escalationIsAdoptedWhole() {
+        #expect(
+            MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: .milliseconds(150), current: .milliseconds(100)
+            ) == .milliseconds(150)
+        )
+    }
+
+    /// Decay stays smoothed: one fast answer should not commit an owner to a
+    /// budget it cannot meet again.
+    @Test("A decay is smoothed against the standing budget")
+    func decayIsSmoothed() {
+        #expect(
+            MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: .milliseconds(150), current: .milliseconds(250)
+            ) == .milliseconds(200)
+        )
+    }
+
+    /// Regression lock for the #687 ladder. Escalating by half from the old
+    /// 100ms default, the log reached only 476ms in eight attempts before
+    /// giving up on 1Password. Unsmoothed, four attempts exhaust the budget.
+    @Test("Escalation reaches the ceiling in four attempts, not eight")
+    func escalationReachesTheCeilingQuickly() {
+        var timeout = Duration.milliseconds(250)
+        var attempts = 0
+        while timeout < .seconds(1) {
+            timeout = MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: MenuBarItemManager.nextMoveOperationTimeout(
+                    after: timeout, outcome: .ownerDidNotRespond
+                ),
+                current: timeout
+            )
+            attempts += 1
+        }
+        #expect(attempts == 4) // 250 → 375 → 562.5 → 843.75 → 1000
+        #expect(timeout == .seconds(1))
+    }
+
+    /// An owner that is answering slowly is given up to a second. Past that
+    /// it is better classified as unresponsive than as slow.
+    @Test("The budget is capped at a second")
+    func budgetIsCappedAtASecond() {
+        #expect(
+            MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: .seconds(4), current: .milliseconds(900)
+            ) == .seconds(1)
+        )
+    }
+
+    /// A budget under 75ms leaves less than eight polls of margin, which is
+    /// how the `itemResponseTimeout` cascades started.
+    @Test("The budget never falls below the polling floor")
+    func budgetNeverFallsBelowTheFloor() {
+        #expect(
+            MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: .milliseconds(10), current: .milliseconds(20)
+            ) == .milliseconds(75)
+        )
+    }
+
+    /// A cooperative item's budget still walks down over repeated landings
+    /// rather than sticking at whatever its first slow attempt cost.
+    @Test("Repeated landings still walk the cached budget down")
+    func landingsWalkTheBudgetDown() {
+        var timeout = Duration.milliseconds(350)
+        for _ in 0 ..< 8 {
+            timeout = MenuBarItemManager.mergedMoveOperationTimeout(
+                proposed: MenuBarItemManager.nextMoveOperationTimeout(
+                    after: timeout, outcome: .landed
+                ),
+                current: timeout
+            )
+        }
+        #expect(timeout < .milliseconds(200))
+        #expect(timeout >= .milliseconds(75))
+    }
 }

--- a/ThawTests/MenuBar/Items/MoveOperationTimeoutTests.swift
+++ b/ThawTests/MenuBar/Items/MoveOperationTimeoutTests.swift
@@ -165,3 +165,39 @@ struct MoveOperationTimeoutTests {
         #expect(timeout >= .milliseconds(75))
     }
 }
+
+/// The cursor-hide watchdog must outlast the worst case a single `move`
+/// call can burn: every attempt spends its whole budget four times over
+/// (two event posts, two response waits), budgets escalate to the merged
+/// ceiling, and a failed attempt posts one more fallback at a fixed 100 ms.
+/// An item that outlasts the watchdog gets the cursor force-shown at the
+/// synthetic event's last position mid-sequence — the flash this sizing
+/// exists to prevent.
+@Suite("Cursor hide watchdog sizing")
+struct CursorHideWatchdogSizingTests {
+    @Test("The default ceiling sizes the watchdog past eight escalated attempts")
+    func defaultCeilingCoversWorstCase() {
+        let watchdog = MenuBarItemManager.cursorHideWatchdogTimeout()
+        // 4 operations × 1 s × 8 attempts + 100 ms fallback.
+        #expect(watchdog == .milliseconds(32_100))
+    }
+
+    @Test("Ordinary budgets keep the historical 10 s floor")
+    func ordinaryBudgetsKeepTheFloor() {
+        // A never-escalated item: 4 × 250 ms × 8 + 100 ms = 8.1 s, below the floor.
+        let watchdog = MenuBarItemManager.cursorHideWatchdogTimeout(
+            operationCeiling: .milliseconds(250)
+        )
+        #expect(watchdog == .seconds(10))
+    }
+
+    @Test("Attempt count and fallback scale the result")
+    func attemptCountAndFallbackScale() {
+        // Above the floor: 4 × 1 s × 3 attempts + 500 ms = 12.5 s.
+        #expect(MenuBarItemManager.cursorHideWatchdogTimeout(
+            operationCeiling: .seconds(1),
+            maxAttempts: 3,
+            fallbackPost: .milliseconds(500)
+        ) == .milliseconds(12_500))
+    }
+}

--- a/ThawTests/MenuBar/Items/SaveGateUserMoveExemptionTests.swift
+++ b/ThawTests/MenuBar/Items/SaveGateUserMoveExemptionTests.swift
@@ -1,0 +1,68 @@
+//
+//  SaveGateUserMoveExemptionTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Characterizes the save gate's user-move exemption.
+///
+/// The exemption exists so a Layout-editor drag becomes the saved order even
+/// though it lands inside the five-second move cooldown that otherwise holds
+/// saves back while a restore is in flight. The exemption must key on the
+/// user's move being the *most recent* move, not merely a recent one: a user
+/// drag at T0 followed by an automatic move at T+3 leaves both timestamps
+/// inside the window, and exempting then would let the next cache cycle
+/// persist an arrangement Thaw generated itself.
+@Suite("Save gate user-move exemption")
+struct SaveGateUserMoveExemptionTests {
+    /// Instants far enough apart that ordering is unambiguous without
+    /// depending on the wall clock.
+    private func at(seconds: Int64) -> ContinuousClock.Instant {
+        ContinuousClock().now.advanced(by: .seconds(seconds))
+    }
+
+    /// The case the exemption exists for: the user's drag is the latest move.
+    @Test("A user move that is the latest move is exempt")
+    func latestUserMoveIsExempt() {
+        #expect(MenuBarItemManager.saveCooldownExemptForUserMove(
+            lastMoveOperationTimestamp: at(seconds: 10),
+            lastUserMoveOperationTimestamp: at(seconds: 10)
+        ))
+        #expect(MenuBarItemManager.saveCooldownExemptForUserMove(
+            lastMoveOperationTimestamp: at(seconds: 9),
+            lastUserMoveOperationTimestamp: at(seconds: 10)
+        ))
+    }
+
+    /// The regression: a user move followed by an automatic move must not
+    /// keep the exemption alive — the latest move is Thaw's, so the cooldown
+    /// has to hold against the generated intermediate arrangement.
+    @Test("An automatic move after the user's move is not exempt")
+    func automaticMoveAfterUserMoveIsNotExempt() {
+        #expect(!MenuBarItemManager.saveCooldownExemptForUserMove(
+            lastMoveOperationTimestamp: at(seconds: 13),
+            lastUserMoveOperationTimestamp: at(seconds: 10)
+        ))
+    }
+
+    @Test("No user move ever recorded is not exempt")
+    func noUserMoveIsNotExempt() {
+        #expect(!MenuBarItemManager.saveCooldownExemptForUserMove(
+            lastMoveOperationTimestamp: at(seconds: 10),
+            lastUserMoveOperationTimestamp: nil
+        ))
+    }
+
+    @Test("No move at all is not exempt")
+    func noMoveIsNotExempt() {
+        #expect(!MenuBarItemManager.saveCooldownExemptForUserMove(
+            lastMoveOperationTimestamp: nil,
+            lastUserMoveOperationTimestamp: nil
+        ))
+    }
+}

--- a/ThawTests/MenuBar/Items/ShouldPersistSavedOrderTests.swift
+++ b/ThawTests/MenuBar/Items/ShouldPersistSavedOrderTests.swift
@@ -162,4 +162,32 @@ struct ShouldPersistSavedOrderTests {
             )
         ))
     }
+
+    /// The move cooldown blocks the save, because `applySavedLayout` honours
+    /// the same window: for five seconds after a move it declines to restore.
+    /// A save allowed inside that window writes the bar as it stands while
+    /// the only thing that would have corrected it is standing down, so the
+    /// interrupted arrangement becomes the saved one (#958).
+    @Test("The move cooldown blocks the save")
+    func moveCooldownBlocks() {
+        #expect(!LayoutSolver.shouldPersistSavedOrder(
+            .init(
+                isWithinMoveCooldown: true
+            )
+        ))
+    }
+
+    /// The menu bar changing display blocks the save. The multi-display gate
+    /// can only see items still classified as visible, so a relocation that
+    /// strands items in the wrong section removes its own evidence: in the
+    /// #958 log it fired correctly with sixteen visible items and then passed
+    /// two and a half minutes later when only four were left.
+    @Test("The menu bar changing display blocks the save")
+    func displayChangeBlocks() {
+        #expect(!LayoutSolver.shouldPersistSavedOrder(
+            .init(
+                menuBarDisplayChanged: true
+            )
+        ))
+    }
 }

--- a/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
+++ b/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
@@ -577,7 +577,8 @@ struct HiddenBoundaryOffenderTests {
         currentAlwaysHidden: Set<String> = [],
         desiredVisible: Set<String>,
         desiredHidden: Set<String>,
-        desiredAlwaysHidden: Set<String> = []
+        desiredAlwaysHidden: Set<String> = [],
+        overflowExemptUIDs: Set<String> = []
     ) -> LayoutSolver.HiddenBoundaryOffenders {
         let split = LayoutSolver.hiddenBoundaryOffenders(
             currentVisible: currentVisible,
@@ -585,7 +586,8 @@ struct HiddenBoundaryOffenderTests {
             currentAlwaysHidden: currentAlwaysHidden,
             desiredVisible: desiredVisible,
             desiredHidden: desiredHidden,
-            desiredAlwaysHidden: desiredAlwaysHidden
+            desiredAlwaysHidden: desiredAlwaysHidden,
+            overflowExemptUIDs: overflowExemptUIDs
         )
         // The tally is defined in terms of the split, and every case here
         // checks that the two cannot drift apart.
@@ -595,7 +597,8 @@ struct HiddenBoundaryOffenderTests {
             currentAlwaysHidden: currentAlwaysHidden,
             desiredVisible: desiredVisible,
             desiredHidden: desiredHidden,
-            desiredAlwaysHidden: desiredAlwaysHidden
+            desiredAlwaysHidden: desiredAlwaysHidden,
+            overflowExemptUIDs: overflowExemptUIDs
         ))
         return split
     }
@@ -682,5 +685,264 @@ struct HiddenBoundaryOffenderTests {
             desiredHidden: []
         )
         #expect(split.count == 0)
+    }
+
+    // MARK: - Notch-overflow exemption (#958)
+
+    /// An item ejected into hidden by the notch-overflow rebalance sits on
+    /// the concealed side while the profile still lists it visible. That
+    /// divergence is by design; counting it makes Phase 1 recall the item
+    /// to visible, and the next cycle's overflow plan ejects it again — a
+    /// two-drag oscillation for as long as the bar stays over budget.
+    /// The exemption must absorb exactly that case.
+    @Test("A notch-overflow-ejected item sitting in hidden is exempt from the boundary check")
+    func overflowEjectedItemInHiddenIsExempt() {
+        let split = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c", "ejected"],
+            desiredVisible: ["a", "b", "ejected"],
+            desiredHidden: ["c"],
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ejected"]
+        )
+        #expect(split.isEmpty)
+
+        // Without the exemption the same bar counts the ejected item —
+        // this documents the oscillation mechanism, not desired behavior.
+        let unexempt = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c", "ejected"],
+            desiredVisible: ["a", "b", "ejected"],
+            desiredHidden: ["c"]
+        )
+        #expect(unexempt.wronglyConcealed == ["ejected"])
+    }
+
+    /// An ejected item that drifted into always-hidden has left the section
+    /// the eject placed it in. That is genuine drift and must keep counting,
+    /// matching the rule `currentLayoutDivergesFromSaved` applies.
+    @Test("A notch-overflow-ejected item that drifted to always-hidden still counts")
+    func overflowEjectedItemInAlwaysHiddenStillCounts() {
+        let split = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c"],
+            currentAlwaysHidden: ["ejected"],
+            desiredVisible: ["a", "b", "ejected"],
+            desiredHidden: ["c"],
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ejected"]
+        )
+        #expect(split.wronglyConcealed == ["ejected"])
+    }
+
+    /// An ejected item that made its own way back to the visible side needs
+    /// no exemption (it is where the profile wants it), but the exempt set
+    /// must not swallow other genuine offenders on the concealed side.
+    @Test("The exemption does not hide unrelated wrongly-concealed items")
+    func exemptionDoesNotHideOtherOffenders() {
+        let split = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c", "drifted", "ejected"],
+            desiredVisible: ["a", "b", "drifted", "ejected"],
+            desiredHidden: ["c"],
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ejected"]
+        )
+        #expect(split.wronglyConcealed == ["drifted"])
+    }
+
+    /// The exemption exists to stop Phase 1 recalling ejected items from
+    /// hidden. An exempt UID currently sitting VISIBLE and wanted concealed
+    /// is the opposite situation — a genuine offender in the other direction
+    /// — and must keep counting whatever the exempt set says.
+    @Test("The exemption never suppresses wrongly-visible offenders")
+    func exemptionNeverSuppressesWronglyVisible() {
+        let split = offenders(
+            currentVisible: ["a", "b", "ejected"],
+            currentHidden: ["c"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c", "ejected"],
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ejected"]
+        )
+        #expect(split.wronglyVisible == ["ejected"])
+        #expect(split.wronglyConcealed.isEmpty)
+        #expect(split.count == 1)
+    }
+
+    /// The exemption parameter defaults to empty; every pre-existing caller
+    /// relies on that meaning "no exemption". Pin the identity so a default-
+    /// value regression cannot silently change long-standing tallies.
+    @Test("An empty exempt set reproduces the legacy tally exactly")
+    func emptyExemptSetMatchesLegacyTally() {
+        let inputs = (
+            currentVisible: Set(["a", "b", "x"]),
+            currentHidden: Set(["c", "d"]),
+            currentAlwaysHidden: Set(["e"]),
+            desiredVisible: Set(["a", "d"]),
+            desiredHidden: Set(["b", "c"]),
+            desiredAlwaysHidden: Set(["e"])
+        )
+        let legacy = LayoutSolver.hiddenBoundaryOffenders(
+            currentVisible: inputs.currentVisible,
+            currentHidden: inputs.currentHidden,
+            currentAlwaysHidden: inputs.currentAlwaysHidden,
+            desiredVisible: inputs.desiredVisible,
+            desiredHidden: inputs.desiredHidden,
+            desiredAlwaysHidden: inputs.desiredAlwaysHidden
+        )
+        let explicitEmpty = LayoutSolver.hiddenBoundaryOffenders(
+            currentVisible: inputs.currentVisible,
+            currentHidden: inputs.currentHidden,
+            currentAlwaysHidden: inputs.currentAlwaysHidden,
+            desiredVisible: inputs.desiredVisible,
+            desiredHidden: inputs.desiredHidden,
+            desiredAlwaysHidden: inputs.desiredAlwaysHidden,
+            overflowExemptUIDs: []
+        )
+        // Both directions of travel are populated here, so this pins the
+        // identity for wronglyVisible and wronglyConcealed at once.
+        #expect(explicitEmpty == legacy)
+        #expect(legacy.wronglyVisible == ["b"])
+        #expect(legacy.wronglyConcealed == ["d"])
+    }
+
+    /// UIDs in the exempt set that name no item on the bar must change
+    /// nothing: the eject set can outlive the items it once named (an app
+    /// quits between cycles), and stale entries must be inert.
+    @Test("Exempt UIDs that match nothing on the bar are inert")
+    func unknownExemptUIDsAreInert() {
+        let baseline = offenders(
+            currentVisible: ["a"],
+            currentHidden: ["c", "gone-before", "drifted"],
+            desiredVisible: ["a", "drifted"],
+            desiredHidden: ["c"]
+        )
+        #expect(baseline.wronglyConcealed == ["drifted"])
+        let exempted = offenders(
+            currentVisible: ["a"],
+            currentHidden: ["c", "gone-before", "drifted"],
+            desiredVisible: ["a", "drifted"],
+            desiredHidden: ["c"],
+            overflowExemptUIDs: ["never-existed", "quit-app:Item-0"]
+        )
+        #expect(exempted == baseline)
+    }
+
+    /// A tight bar can hold several ejected items at once. Exempting a
+    /// subset absorbs exactly that subset; the rest keep counting.
+    @Test("A partial exempt set absorbs only its own items")
+    func partialExemptionAbsorbsOnlyItsOwnItems() {
+        let split = offenders(
+            currentVisible: ["a"],
+            currentHidden: ["c", "ej1", "ej2", "ej3"],
+            desiredVisible: ["a", "ej1", "ej2", "ej3"],
+            desiredHidden: ["c"],
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ej1", "ej3"]
+        )
+        #expect(split.wronglyConcealed == ["ej2"])
+    }
+
+    /// `hiddenBoundaryMismatch` is the value the parked-divider recovery
+    /// streak counts on, so it must see the exempted tally too — an
+    /// eject-only divergence must neither advance nor reset the streak's
+    /// input dishonestly.
+    @Test("hiddenBoundaryMismatch honours the exemption")
+    func mismatchHonoursExemption() {
+        let mismatchCurrentVisible = Set(["a", "b"])
+        let currentHidden = Set(["c", "ejected"])
+        let desiredVisible = Set(["a", "b", "ejected"])
+        let desiredHidden = Set(["c"])
+
+        let unexempt = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: mismatchCurrentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: [],
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: []
+        )
+        let exempt = LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: mismatchCurrentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: [],
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: [],
+            overflowExemptUIDs: ["ejected"]
+        )
+        #expect(unexempt == 1)
+        #expect(exempt == 0)
+    }
+
+    /// applyProfileLayout derives the soak diagnostic without re-running the
+    /// solver, as |exempt ∩ currentHidden ∩ desiredVisible|. That shortcut is
+    /// only valid while the solver drops wronglyConcealed entries exclusively
+    /// through that same intersection. Walk every placement of the exempt UID
+    /// across the three sections and confirm the two computations agree.
+    @Test("Absorbed-offender count equals the exempt intersection in every placement")
+    func absorbedCountMatchesExemptIntersectionEverywhere() {
+        let placements: [(section: String, currentHidden: Set<String>, currentAH: Set<String>)] = [
+            (section: "hidden", currentHidden: ["ejected"], currentAH: []),
+            (section: "always-hidden", currentHidden: [], currentAH: ["ejected"]),
+            (section: "visible", currentHidden: [], currentAH: []),
+            (section: "nowhere", currentHidden: [], currentAH: []),
+        ]
+
+        for placement in placements {
+            let currentVisible = Set(["a", "b"] + (placement.section == "visible" ? ["ejected"] : []))
+            let desiredVisible = Set(["a", "b", "ejected"])
+
+            let unexempt = LayoutSolver.hiddenBoundaryOffenders(
+                currentVisible: currentVisible,
+                currentHidden: placement.currentHidden,
+                currentAlwaysHidden: placement.currentAH,
+                desiredVisible: desiredVisible,
+                desiredHidden: ["c"],
+                desiredAlwaysHidden: []
+            )
+            let exemptSet: Set = ["ejected"]
+            let exempt = LayoutSolver.hiddenBoundaryOffenders(
+                currentVisible: currentVisible,
+                currentHidden: placement.currentHidden,
+                currentAlwaysHidden: placement.currentAH,
+                desiredVisible: desiredVisible,
+                desiredHidden: ["c"],
+                desiredAlwaysHidden: [],
+                overflowExemptUIDs: exemptSet
+            )
+
+            let absorbed = unexempt.count - exempt.count
+            let shortcut = exemptSet.intersection(placement.currentHidden)
+                .intersection(desiredVisible).count
+            #expect(
+                absorbed == shortcut,
+                "Placement \(placement.section): solver absorbed \(absorbed) but the orchestrator shortcut computes \(shortcut)"
+            )
+        }
+    }
+
+    /// Covers ``LayoutSolver.HiddenBoundaryOffenders/isEmpty`` directly: it
+    /// gates nothing today but is the readable spelling future callers will
+    /// reach for, so its agreement with count must not drift.
+    @Test("isEmpty agrees with count")
+    func isEmptyAgreesWithCount() {
+        let empty = offenders(
+            currentVisible: ["a"],
+            currentHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: []
+        )
+        #expect(empty.isEmpty)
+
+        let occupied = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: ["b"]
+        )
+        #expect(!occupied.isEmpty)
+        #expect(occupied.count == 1)
     }
 }

--- a/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
+++ b/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
@@ -352,3 +352,178 @@ struct HiddenDividerBoundaryTests {
         }
     }
 }
+
+/// Pins the refusal that keeps the H_ctrl boundary move off Thaw's own
+/// chevron (#958).
+///
+/// The candidate set the caller hands the planner is already filtered to
+/// items that are movable and on screen. Thaw's control items pass both on
+/// every pass, so on a bar where the profile's items have been dragged to
+/// the wrong side of the divider and parked there, the chevron is the only
+/// candidate left standing — and it is the one anchor that must not be
+/// used. Dragging H_ctrl up to it sweeps the section it was restoring
+/// across with it.
+///
+/// #958's reporter imported a known-good plist with Thaw quit, confirmed it
+/// live, and watched the first apply after relaunch undo it:
+///
+/// ```
+/// Profile layout Phase 1: hiddenBoundaryMismatch=11
+/// Profile layout: 11 item(s) on the wrong side of H_ctrl, moving H_ctrl to the boundary
+/// Profile layout: moving H_ctrl -> left of <com.stonerl.Thaw:Thaw.ControlItem.Visible>
+/// post-H_ctrl classification crossSectionMoves=0, totalSectionMismatch=0
+/// ```
+///
+/// The roster below is the visible order from the `broken_profile.json`
+/// attached to the same issue, in profile order — index 0 rightmost. The
+/// chevron sits at index 11 with four items to its left, none of which are
+/// movable, which is what leaves it as the last candidate the search finds.
+@Suite("Boundary anchor refuses Thaw's own items")
+struct BoundaryAnchorControlItemRefusalTests {
+    private static let chevron = "com.stonerl.Thaw:Thaw.ControlItem.Visible"
+    private static let hiddenDivider = "com.stonerl.Thaw:Thaw.ControlItem.Hidden"
+
+    private static let desiredVisible = [
+        "leits.MeetingBar:Item-0",
+        "com.steipete.codexbar:codexbar-codex",
+        "com.steipete.codexbar:codexbar-claude",
+        "com.tunabellysoftware.tgpro:Item-0",
+        "eu.exelban.Stats:CPU_bar_chart",
+        "eu.exelban.Stats:GPU_bar_chart",
+        "eu.exelban.Stats:RAM_bar_chart",
+        "com.rogueamoeba.soundsource:SSMainAppMenuIcon",
+        "com.rogueamoeba.soundsource:Input",
+        "com.apphousekitchen.aldente-pro:Item-0",
+        "eu.exelban.Stats:Network_speed",
+        chevron,
+        "org.p0deje.Maccy:Item-0",
+        "com.apple.TextInputMenuAgent:Item-0",
+        "com.apple.controlcenter:BentoBox-0",
+        "com.apple.controlcenter:Clock",
+    ]
+
+    private static let desiredHidden = [
+        "com.electron.dockerdesktop:Item-0",
+        "com.proxyman.NSProxy:Item-0",
+        "com.apple.controlcenter:WiFi",
+    ]
+
+    // MARK: - The refusal
+
+    /// The reporter's state: every hidden-side item parked off screen and
+    /// every real visible item dragged across with them, leaving the
+    /// chevron alone in the candidate set.
+    @Test("The chevron alone yields no anchor")
+    func chevronAloneYieldsNoAnchor() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron],
+            unanchorableUIDs: [Self.chevron, Self.hiddenDivider]
+        )
+
+        #expect(anchor == nil)
+    }
+
+    /// The behaviour the refusal replaces, so the regression is pinned by
+    /// the shape it used to take rather than only by its absence.
+    @Test("Without the bar, the same inputs anchor on the chevron")
+    func sameInputsUsedToAnchorOnTheChevron() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron]
+        )
+
+        #expect(anchor == .leftOf(Self.chevron))
+    }
+
+    /// Refusing means stopping, not searching on. The next candidate to the
+    /// chevron's right is an item the profile wants right of the divider,
+    /// so anchoring there would drag H_ctrl past it and conceal it — the
+    /// same collapse one item smaller.
+    @Test("The search does not continue past a refused anchor")
+    func searchDoesNotContinuePastARefusedAnchor() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: [],
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron, "eu.exelban.Stats:Network_speed"],
+            unanchorableUIDs: [Self.chevron]
+        )
+
+        #expect(anchor == nil)
+    }
+
+    /// A divider that reached the desired-hidden order is refused the same
+    /// way, from the other side.
+    @Test("A control item on the hidden side is refused too")
+    func controlItemOnTheHiddenSideIsRefused() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: [Self.chevron, "com.proxyman.NSProxy:Item-0"],
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron, "com.proxyman.NSProxy:Item-0"],
+            unanchorableUIDs: [Self.chevron]
+        )
+
+        #expect(anchor == nil)
+    }
+
+    // MARK: - What the refusal must not cost
+
+    /// A real item at the boundary is still an anchor. The refusal is not a
+    /// blanket stand-down on bars that happen to have the chevron live.
+    @Test("A live real item to the chevron's left still anchors the move")
+    func liveRealItemStillAnchorsTheMove() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron, "org.p0deje.Maccy:Item-0"],
+            unanchorableUIDs: [Self.chevron, Self.hiddenDivider]
+        )
+
+        #expect(anchor == .leftOf("org.p0deje.Maccy:Item-0"))
+    }
+
+    /// The hidden side is tried first and is unaffected, so the common
+    /// repair — a profile whose hidden items are back on the bar — plans
+    /// the same move it always did.
+    @Test("A live hidden item still wins over the visible fallback")
+    func liveHiddenItemStillWins() {
+        let anchor = LayoutSolver.planHiddenDividerAnchor(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: ["com.proxyman.NSProxy:Item-0", Self.chevron],
+            unanchorableUIDs: [Self.chevron, Self.hiddenDivider]
+        )
+
+        #expect(anchor == .rightOf("com.proxyman.NSProxy:Item-0"))
+    }
+
+    // MARK: - Telling the two nil cases apart in the log
+
+    /// A refusal names the item it refused, so a field log distinguishes
+    /// "the items are on the wrong side" from "the items are not running".
+    @Test("The candidate helper names the refused chevron")
+    func candidateHelperNamesTheRefusedChevron() {
+        let candidate = LayoutSolver.hiddenDividerAnchorCandidate(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: [Self.chevron]
+        )
+
+        #expect(candidate == Self.chevron)
+    }
+
+    /// A bar with nothing live reports no candidate at all, which is the
+    /// pre-existing nil and keeps its own log line.
+    @Test("Nothing live yields no candidate")
+    func nothingLiveYieldsNoCandidate() {
+        let candidate = LayoutSolver.hiddenDividerAnchorCandidate(
+            desiredHidden: Self.desiredHidden,
+            desiredVisible: Self.desiredVisible,
+            liveMovableUIDs: []
+        )
+
+        #expect(candidate == nil)
+    }
+}

--- a/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
+++ b/ThawTests/MenuBar/Layout/HiddenDividerBoundaryTests.swift
@@ -527,3 +527,160 @@ struct BoundaryAnchorControlItemRefusalTests {
         #expect(candidate == nil)
     }
 }
+
+/// Pins which of the two boundary repairs Phase 1 takes.
+///
+/// Dragging H_ctrl re-sections every item it crosses, so it is the cheap
+/// repair only when the divider itself is what drifted. #958 is the case
+/// where it was not: one item on the wrong side, nine still correctly
+/// concealed, and the drag planned to reach that one item would have carried
+/// the divider from minX -3871 to 1648, across the entire visible section.
+@Suite("Divider drag versus per-item boundary moves")
+struct HiddenBoundaryRepairChoiceTests {
+    @Test("Nothing concealed means the divider drifted past everything (#879)")
+    func emptyConcealedSideDragsTheDivider() {
+        // The bar the boundary check was written for: eighteen managed items,
+        // all of them reading visible, none behind the divider.
+        #expect(LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 0, liveVisibleCount: 18))
+    }
+
+    @Test("Nothing visible is the collapsed bar, and the drag is the recovery (#958)")
+    func emptyVisibleSideDragsTheDivider() {
+        #expect(LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 19, liveVisibleCount: 0))
+    }
+
+    @Test("One stray item with a populated hidden section moves the item (#958)")
+    func oneStrayItemMovesTheItem() {
+        // oa's 21 August reading: nine items correctly concealed, one on the
+        // wrong side. The divider is where it belongs.
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 9, liveVisibleCount: 17))
+    }
+
+    @Test("A bar with most items concealed still moves items, not the divider")
+    func mostlyConcealedBarMovesItems() {
+        // oa's 05:00 reading: thirty-two concealed, eleven of them wrongly so.
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 32, liveVisibleCount: 4))
+    }
+
+    @Test("An empty bar qualifies for the drag rather than deadlocking")
+    func emptyBarDragsTheDivider() {
+        #expect(LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 0, liveVisibleCount: 0))
+    }
+}
+
+/// The repair has to move the same items the check counted.
+@Suite("Boundary offenders agree with the boundary tally")
+struct HiddenBoundaryOffenderTests {
+    private func offenders(
+        currentVisible: Set<String>,
+        currentHidden: Set<String>,
+        currentAlwaysHidden: Set<String> = [],
+        desiredVisible: Set<String>,
+        desiredHidden: Set<String>,
+        desiredAlwaysHidden: Set<String> = []
+    ) -> LayoutSolver.HiddenBoundaryOffenders {
+        let split = LayoutSolver.hiddenBoundaryOffenders(
+            currentVisible: currentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: currentAlwaysHidden,
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: desiredAlwaysHidden
+        )
+        // The tally is defined in terms of the split, and every case here
+        // checks that the two cannot drift apart.
+        #expect(split.count == LayoutSolver.hiddenBoundaryMismatch(
+            currentVisible: currentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: currentAlwaysHidden,
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: desiredAlwaysHidden
+        ))
+        return split
+    }
+
+    @Test("A matching layout has no offenders")
+    func matchingLayoutHasNoOffenders() {
+        let split = offenders(
+            currentVisible: ["a", "b"],
+            currentHidden: ["c"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c"]
+        )
+        #expect(split.wronglyVisible.isEmpty)
+        #expect(split.wronglyConcealed.isEmpty)
+        #expect(split.count == 0)
+    }
+
+    @Test("An item that should be concealed is named on the visible side")
+    func strayVisibleItemIsNamed() {
+        let split = offenders(
+            currentVisible: ["a", "b", "c"],
+            currentHidden: [],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c"]
+        )
+        #expect(split.wronglyVisible == ["c"])
+        #expect(split.wronglyConcealed.isEmpty)
+    }
+
+    @Test("An item that should be visible is named on the concealed side")
+    func strayConcealedItemIsNamed() {
+        let split = offenders(
+            currentVisible: ["a"],
+            currentHidden: ["b", "c"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c"]
+        )
+        #expect(split.wronglyVisible.isEmpty)
+        #expect(split.wronglyConcealed == ["b"])
+    }
+
+    @Test("Always-hidden counts as the concealed side, not a third direction")
+    func alwaysHiddenIsPartOfTheConcealedSide() {
+        let split = offenders(
+            currentVisible: ["a"],
+            currentHidden: [],
+            currentAlwaysHidden: ["b"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: [],
+            desiredAlwaysHidden: []
+        )
+        #expect(split.wronglyConcealed == ["b"])
+        // An item moving between hidden and always-hidden is AH_ctrl's
+        // problem and must not show up here.
+        let acrossAH = offenders(
+            currentVisible: ["a"],
+            currentHidden: ["b"],
+            desiredVisible: ["a"],
+            desiredHidden: [],
+            desiredAlwaysHidden: ["b"]
+        )
+        #expect(acrossAH.count == 0)
+    }
+
+    @Test("Offenders travel in both directions at once")
+    func bothDirectionsAtOnce() {
+        let split = offenders(
+            currentVisible: ["a", "c"],
+            currentHidden: ["b", "d"],
+            desiredVisible: ["a", "b"],
+            desiredHidden: ["c", "d"]
+        )
+        #expect(split.wronglyVisible == ["c"])
+        #expect(split.wronglyConcealed == ["b"])
+        #expect(split.count == 2)
+    }
+
+    @Test("An item the profile does not manage is nobody's offender")
+    func unmanagedItemIsNotAnOffender() {
+        let split = offenders(
+            currentVisible: ["a", "stranger"],
+            currentHidden: [],
+            desiredVisible: ["a"],
+            desiredHidden: []
+        )
+        #expect(split.count == 0)
+    }
+}

--- a/ThawTests/MenuBar/Layout/ParkedAnchorTests.swift
+++ b/ThawTests/MenuBar/Layout/ParkedAnchorTests.swift
@@ -31,7 +31,7 @@ struct ParkedAnchorTests {
 
     // MARK: - isOnScreen
 
-    @Test("An item whose center is on the display is on-screen")
+    @Test("An item whose leading edge is on the display is on-screen")
     func onScreenItemIsOnScreen() {
         let bounds = CGRect(x: 800, y: 0, width: 30, height: 22)
         #expect(LayoutSolver.isOnScreen(bounds: bounds, screenFrames: Self.screenFrames))
@@ -123,5 +123,58 @@ struct ParkedAnchorTests {
             return
         }
         #expect(uid == "com.adobe.acc.AdobeCreativeCloud:Item-0")
+    }
+}
+
+/// Pins the measurement point of ``LayoutSolver/isOnScreen(bounds:screenFrames:)``.
+///
+/// #958: a collapsed hidden divider is 5000 points wide, because that width is
+/// what pushes the concealed items off the display. Measuring it at its center
+/// therefore samples a point 2500 points right of the divider itself, and on
+/// oa's three-display arrangement that point landed on a screen while the
+/// divider was parked at minX -3871. The guard meant to refuse a drag from a
+/// parked divider read a screen hit and let the drag through; H_ctrl travelled
+/// to 1648 and swept the whole visible section into hidden.
+@Suite("Off-screen is measured at the leading edge")
+struct LeadingEdgeOnScreenTests {
+    /// oa's arrangement: the built-in display at the origin, with externals
+    /// placed left of it and below it.
+    private static let screenFrames = [
+        CGRect(x: 0, y: 0, width: 1728, height: 1117),
+        CGRect(x: -2560, y: -300, width: 2560, height: 1440),
+        CGRect(x: 0, y: -1080, width: 1920, height: 1080),
+    ]
+
+    @Test("A parked 5000-wide divider is off-screen even though its center is not")
+    func parkedWideDividerIsOffScreen() {
+        let divider = CGRect(x: -3871, y: 0, width: 5000, height: 33)
+        // The reading that let #958 through.
+        #expect(Self.screenFrames.contains { $0.contains(CGPoint(x: divider.midX, y: divider.midY)) })
+        #expect(!LayoutSolver.isOnScreen(bounds: divider, screenFrames: Self.screenFrames))
+    }
+
+    @Test("A 5000-wide divider sitting on the bar is on-screen")
+    func seatedWideDividerIsOnScreen() {
+        // Same width, but parked nowhere: the divider is where the profile
+        // wants it and the drag can land.
+        let divider = CGRect(x: 743, y: 0, width: 5000, height: 33)
+        #expect(LayoutSolver.isOnScreen(bounds: divider, screenFrames: Self.screenFrames))
+    }
+
+    @Test("A divider parked left of every display is off-screen")
+    func parkedLeftOfAllDisplaysIsOffScreen() {
+        let divider = CGRect(x: -8000, y: 0, width: 5000, height: 33)
+        #expect(!LayoutSolver.isOnScreen(bounds: divider, screenFrames: Self.screenFrames))
+    }
+
+    @Test("Narrow items read the same either way")
+    func narrowItemsAgree() {
+        for minX in [-4222.0, -31.0, 0.0, 800.0, -2000.0] {
+            let bounds = CGRect(x: minX, y: 0, width: 30, height: 22)
+            let byCenter = Self.screenFrames.contains {
+                $0.contains(CGPoint(x: bounds.midX, y: bounds.midY))
+            }
+            #expect(LayoutSolver.isOnScreen(bounds: bounds, screenFrames: Self.screenFrames) == byCenter)
+        }
     }
 }

--- a/ThawTests/Settings/Models/ProfileLayoutLogReplayTests.swift
+++ b/ThawTests/Settings/Models/ProfileLayoutLogReplayTests.swift
@@ -396,6 +396,91 @@ struct ProfileLayoutLogReplayTests {
         #expect(!LayoutSolver.isMenuBarGeometryReady(rightBoundary: .infinity, notchMaxX: 956))
         #expect(!LayoutSolver.isMenuBarGeometryReady(rightBoundary: .nan, notchMaxX: 956))
     }
+
+    // MARK: Regression lock for the overflow-eject vs boundary-repair oscillation (#958)
+
+    /// Replays a real field cycle (thaw_2026-08-20_11-21-26.log, 16:32:47.8,
+    /// nk-tedo-001's machine, build 52f4ed3): the bar is persistently over the
+    /// notch budget, so every apply re-plans an eject ("notch overflow;
+    /// 1 item(s)" fires at .826 and again 2.6 s later), while Phase 1 reads
+    /// `leits.MeetingBar` — hidden in this cycle's snapshot, visible per the
+    /// saved order — as wronglyConcealed. The log does not name which UID the
+    /// eject plan chose, but it names the count (1), and MeetingBar is the
+    /// one item the mismatch counted.
+    ///
+    /// On builds through e384ce36 that mismatch drove a divider drag; since
+    /// aa5b2850 it drives per-item moves that recall MeetingBar to visible,
+    /// and the next cycle's eject plan sends it back: two synthetic drags per
+    /// apply, forever (the "icons jumping randomly" reports). With this
+    /// cycle's overflow eject exempted, the boundary check scores zero and no
+    /// repair chases the item.
+    /// Red before the exemption (mismatch=1), green after (mismatch=0).
+    @Test("An overflow-ejected field cycle must not count the ejected item as a boundary offender")
+    func overflowEjectedFieldCycleIsNotABoundaryOffender() throws {
+        let log = """
+        2026-08-20 16:32:47.824 [DEBUG] [MenuBarItemManager] applyProfileLayout: current visible section has 12 items: ["com.steipete.codexbar:codexbar-codex", "com.steipete.codexbar:codexbar-claude", "com.tunabellysoftware.tgpro:Item-0", "eu.exelban.Stats:CPU_bar_chart", "eu.exelban.Stats:GPU_bar_chart", "eu.exelban.Stats:RAM_bar_chart", "com.rogueamoeba.soundsource:SSMainAppMenuIcon", "com.rogueamoeba.soundsource:Input", "com.apphousekitchen.aldente-pro:Item-0", "com.stonerl.Thaw:Thaw.ControlItem.Visible", "org.p0deje.Maccy:Item-0", "com.apple.TextInputMenuAgent:Item-0"]
+        2026-08-20 16:32:47.825 [DEBUG] [MenuBarItemManager] applyProfileLayout: current hidden section has 9 items: ["leits.MeetingBar:Item-0", "com.electron.dockerdesktop:Item-0", "com.proxyman.NSProxy:Item-0", "com.techsmith.snagit.capturehelper:Item-0", "com.nektony.App-Cleaner-SIII-UIHelper:Item-0", "com.paloaltonetworks.GlobalProtect.client:Item-0", "com.apple.KerberosMenuExtra:Item-0", "com.apple.controlcenter:Battery", "com.kaspersky.kav_agent:Item-0"]
+        2026-08-20 16:32:47.825 [DEBUG] [MenuBarItemManager] applyProfileLayout: current always-hidden section has 7 items: ["com.steipete.codexbar:codexbar-cursor", "com.nextcloud.desktopclient:Item-0", "ru.yandex.desktop.disk2:Item-0", "com.shortcutlabs.FlicMac:Item-0", "ru.keepcoder.Telegram:Item-0", "com.steipete.codexbar:codexbar-opencode", "com.apple.Spotlight:Item-0"]
+        2026-08-20 16:32:47.826 [INFO] [MenuBarItemManager] Profile layout: notch overflow; 1 item(s) moved from visible to hidden
+        2026-08-20 16:32:47.828 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: ahCtrlUID=com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden, crossSectionMoves=0, totalSectionMismatch=0
+        2026-08-20 16:32:47.828 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredHidden=["com.apple.KerberosMenuExtra:Item-0", "com.apple.controlcenter:Battery", "com.apple.controlcenter:NowPlaying", "com.apple.controlcenter:WiFi", "com.electron.dockerdesktop:Item-0", "com.kaspersky.kav_agent:Item-0", "com.nektony.App-Cleaner-SIII-UIHelper:Item-0", "com.paloaltonetworks.GlobalProtect.client:Item-0", "com.proxyman.NSProxy:Item-0", "com.techsmith.snagit.capturehelper:Item-0"]
+        2026-08-20 16:32:47.828 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: desiredVisible=["com.apphousekitchen.aldente-pro:Item-0", "com.apple.TextInputMenuAgent:Item-0", "com.apple.controlcenter:BentoBox-0", "com.apple.controlcenter:Clock", "com.rogueamoeba.soundsource:Input", "com.rogueamoeba.soundsource:SSMainAppMenuIcon", "com.steipete.codexbar:codexbar-claude", "com.steipete.codexbar:codexbar-codex", "com.stonerl.Thaw:Thaw.ControlItem.Visible", "com.tunabellysoftware.tgpro:Item-0", "eu.exelban.Stats:CPU_bar_chart", "eu.exelban.Stats:GPU_bar_chart", "eu.exelban.Stats:Network_speed", "eu.exelban.Stats:RAM_bar_chart", "leits.MeetingBar:Item-0", "org.p0deje.Maccy:Item-0"]
+        2026-08-20 16:32:47.828 [DEBUG] [MenuBarItemManager] Profile layout Phase 1: hiddenBoundaryMismatch=1
+        """
+        let parsed = ProfileLayoutLogReplay.parse(log)
+        let cycle = try #require(parsed.cycles.first)
+
+        // Field characterization: the buggy cycle counted exactly one
+        // offender — the item this very cycle's overflow plan had stashed in
+        // hidden.
+        #expect(cycle.loggedOverflowCount == 1)
+        let ejectedUID = "leits.MeetingBar:Item-0"
+        #expect(cycle.currentHidden.contains(ejectedUID))
+        #expect(cycle.desiredVisible?.contains(ejectedUID) == true)
+
+        let currentVisible = Set(cycle.currentVisible)
+        let currentHidden = Set(cycle.currentHidden)
+        let currentAlwaysHidden = Set(cycle.currentAlwaysHidden)
+        let desiredVisible = try Set(#require(cycle.desiredVisible))
+        let desiredHidden = Set(cycle.desiredHidden)
+        let desiredAlwaysHidden = Set(cycle.desiredAlwaysHidden)
+
+        // Without the exemption the ejected item is the offender — this
+        // documents the mechanism that sent the repair after it each cycle.
+        let unexempt = LayoutSolver.hiddenBoundaryOffenders(
+            currentVisible: currentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: currentAlwaysHidden,
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: desiredAlwaysHidden
+        )
+        #expect(unexempt.count == 1, "Field cycle logged hiddenBoundaryMismatch=1; replay disagrees")
+        #expect(unexempt.wronglyConcealed == [ejectedUID])
+
+        // With this cycle's overflow eject exempted, the by-design divergence
+        // no longer counts and no repair may chase the item.
+        let exempt = LayoutSolver.hiddenBoundaryOffenders(
+            currentVisible: currentVisible,
+            currentHidden: currentHidden,
+            currentAlwaysHidden: currentAlwaysHidden,
+            desiredVisible: desiredVisible,
+            desiredHidden: desiredHidden,
+            desiredAlwaysHidden: desiredAlwaysHidden,
+            overflowExemptUIDs: [ejectedUID]
+        )
+        #expect(exempt.isEmpty, "Exempting this cycle's overflow eject must clear the field mismatch")
+
+        // The gate itself stays false for these counts (nine correctly
+        // concealed, eleven visible after control items are dropped), so on
+        // aa5b2850+ builds the repair route was per-item drags — exactly the
+        // oscillation this exemption removes.
+        let liveControlUIDs: Set = ["com.stonerl.Thaw:Thaw.ControlItem.Visible",
+                                    "com.stonerl.Thaw:Thaw.ControlItem.AlwaysHidden"]
+        let liveConcealed = currentHidden.union(currentAlwaysHidden).subtracting(liveControlUIDs).count
+        let liveVisible = currentVisible.subtracting(liveControlUIDs).count
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: liveConcealed, liveVisibleCount: liveVisible))
+    }
 }
 
 /// Parses Thaw profile-layout log text into replayable cycles and drives the

--- a/ThawTests/Shared/WindowInfoDecodingTests.swift
+++ b/ThawTests/Shared/WindowInfoDecodingTests.swift
@@ -287,6 +287,48 @@ struct WindowInfoDecodingTests {
             #expect(window(ownerPID: -424_242).owningApplication == nil)
         }
 
+        /// A window with area is the ordinary case and must stay eligible to
+        /// start a source-PID scan; the fixture's 100x22 is a normal status
+        /// item's geometry.
+        @Test("A window with area is not degenerate")
+        func windowWithAreaIsNotDegenerate() {
+            #expect(!window().isDegenerate)
+        }
+
+        /// Every source-PID match path anchors on the window's centre, so a
+        /// window missing either dimension has nothing to match against. The
+        /// zero-width case is the one observed in the field (#956): a status
+        /// item at `(-4323, 0, 0, 0)` that nine consecutive scans over seven
+        /// minutes never resolved, while waking a full traversal of every
+        /// running app each time.
+        @Test(
+            "A window missing either dimension is degenerate",
+            arguments: [
+                CGRect(x: -4323, y: 0, width: 0, height: 0),
+                CGRect(x: 0, y: 0, width: 0, height: 22),
+                CGRect(x: 0, y: 0, width: 100, height: 0),
+            ]
+        )
+        func windowMissingADimensionIsDegenerate(_ bounds: CGRect) {
+            let window = WindowInfo(windowID: 1, ownerPID: 501, bounds: bounds, layer: 0)
+            #expect(window.isDegenerate)
+        }
+
+        /// Position alone must not decide this. An off-screen or negatively
+        /// positioned item is perfectly matchable — the field case sits at
+        /// x = -4323 and would be wrongly skipped by a rule that keyed on
+        /// coordinates instead of size.
+        @Test("A window far off-screen is not degenerate as long as it has area")
+        func offScreenWindowWithAreaIsNotDegenerate() {
+            let window = WindowInfo(
+                windowID: 1,
+                ownerPID: 501,
+                bounds: CGRect(x: -4323, y: 0, width: 40, height: 33),
+                layer: 0
+            )
+            #expect(!window.isDegenerate)
+        }
+
         @Test(
             "The Window Server is recognized only under its exact name",
             arguments: ["window server", "WINDOW SERVER", "WindowServer", "Window  Server", " Window Server", ""]

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -1,3 +1,4 @@
+$(SRCROOT)/MenuBarItemService/ExtrasMenuBarProbeStore.swift
 $(SRCROOT)/MenuBarItemService/Listener.swift
 $(SRCROOT)/MenuBarItemService/SourcePIDCache.swift
 $(SRCROOT)/MenuBarItemService/main.swift
@@ -8,6 +9,7 @@ $(SRCROOT)/Shared/Utilities/AXHelpers.swift
 $(SRCROOT)/Shared/Utilities/CodeSigningInfo.swift
 $(SRCROOT)/Shared/Utilities/DiagnosticLogger.swift
 $(SRCROOT)/Shared/Utilities/ExtrasMenuBarNegativeCachePolicy.swift
+$(SRCROOT)/Shared/Utilities/ExtrasMenuBarProbeMemory.swift
 $(SRCROOT)/Shared/Utilities/MarkerPairResolver.swift
 $(SRCROOT)/Shared/Utilities/SharedConstants.swift
 $(SRCROOT)/Shared/Utilities/SharedExtensions.swift

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -78,6 +78,7 @@ $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+TemporaryShow.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemNameMemory.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/PendingLedger.swift

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -7,6 +7,7 @@ $(SRCROOT)/Shared/Services/MenuBarItemService.swift
 $(SRCROOT)/Shared/Utilities/AXHelpers.swift
 $(SRCROOT)/Shared/Utilities/CodeSigningInfo.swift
 $(SRCROOT)/Shared/Utilities/DiagnosticLogger.swift
+$(SRCROOT)/Shared/Utilities/ExtrasMenuBarNegativeCachePolicy.swift
 $(SRCROOT)/Shared/Utilities/MarkerPairResolver.swift
 $(SRCROOT)/Shared/Utilities/SharedConstants.swift
 $(SRCROOT)/Shared/Utilities/SharedExtensions.swift


### PR DESCRIPTION
# Summary

Fixes for three field-reported layout-stability failures on macOS 26, all in
the menu bar item manager's layout pipeline. The branch carries 15 commits;
the newer half was driven by logs from #958 reporters, and each commit message
carries the field evidence that motivated it.

**Scope:** This PR changes one focused thing — the correctness of automatic
layout repair (boundary repair, divider recovery, save gating) plus minimal
plumbing. The commits are individually small and independently revertible.

## Linked issue (required)

Closes: #958

Also addresses: #956 (the label/resolve-window half), #863 (diagnosis; the
always-hidden divider recovery closes its mechanism on current builds).

## PR Type

- [x] Bug fix
- [x] Performance improvement
- [x] Test addition or update

## Area

- [x] menubar
- [x] layout

## Does this PR introduce a breaking change?

- [x] No

## What is the new behavior?

Four mechanisms, mapped to the failures:

### 1. The hidden-boundary repair chose destruction over repair (#958)

Phase 1 reached for a single drag of H_ctrl whenever *any* item read on the
wrong side of it. That drag re-sections everything it crosses — cheap only when
the divider itself drifted. Now:

- `aa5b2850` gates the drag on a side having nothing live left on it;
  `e384ce36` stops the anchor search from settling on Thaw's own chevron;
  `afd1811b` measures a parked divider at its edge so the parked-guard fires;
  `b3d0c2d4` adjusts drop-point bias.
- `2684910a` closes the loop `aa5b2850` opened: on bars over the notch budget,
  the overflow planner re-ejects the same item every cycle while Phase 1 keeps
  reading it as `wronglyConcealed`, producing two synthetic drags per apply,
  forever. The overflow eject set is now exempt from the boundary tally, with
  the same only-if-in-hidden rule the divergence check already used.

### 2. Damage reached disk faster than recovery could catch it

`74eb820b` gates `saveSectionOrder` behind the same cooldown and
unenacted-move accounting as `applySavedLayout`; `5350402d` stops a divider
rebuild from re-stamping a fresh-install seed position onto a populated bar.
The user-move exemption inside the gate now keys on the user's move being the
*most recent* move, not merely a recent one — a user drag followed by an
automatic move no longer disables the cooldown for Thaw-generated
arrangements.

### 3. Relocations into the parked zone (`afae89ef`)

With H_ctrl parked offscreen, `relocateThawIcon` and `enforceControlItemOrder`
still used it as their destination anchor — stranding the chevron or AH
divider in the parked zone, with drags starting from stale cached frames over
the live bar. Both skip when the reference divider fails the same
edge-of-bounds screen test the boundary repair uses.

### 4. An always-hidden divider that stops resolving never came back (`b0e29a17`)

`ControlItemPair` models the missing AH divider as an optional and succeeds,
so the lookup-failure rebuild never sees the loss (#863: `alwaysHidden=nil`
for 12+ hours after an HDMI re-plug). Authoritative cycles with an
enabled-but-unresolved AH divider now count toward recreating just that
status item once per episode.

### 5. Launch-window labelling and scan cost (#956)

`ea9b5521` labels items from name memory while their source PID is pending;
`04bcad88` gives slow item owners room to acknowledge before giving up;
`e2ad7e31` / `17e9b353` / `52f4ed3a` / `4123f6de` cut the accessibility-scan
cost that stretched the resolve window.

CodeRabbit review round: anchor-selection rule consolidated into one function,
cursor-hide watchdog sized for escalated worst case instead of the stale
"8 × ~500 ms" arithmetic, settle pause added after per-item boundary moves,
drop-point bias restricted to real section dividers, and the name-memory test
suite serialized around its process-wide defaults mutations.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below).
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles, `dependency-sca` is green.

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS'` — 2503 tests / 317 suites green
- `swiftlint --strict`

> Note on the first checkbox: this development machine runs macOS 27, where
> the AX/event bridging under test does not work — verification here is via
> the log-replay harness (`ProfileLayoutLogReplayTests`,
> `HiddenDividerBoundaryTests`) driving the pure planners against field-log
> states, plus unit tests on every new decision function. Field soak status:
> `b3d0c2d4` held 10 hours on the reproducing configuration
> ([soak report](https://github.com/thaw-app/Thaw/issues/958#issuecomment-5386426042));
> the overflow-exemption fix has a soak pending on nk-tedo-001's machine.

## Known limitations / follow-ups

- The LCS pass still executes with parked-zone geometry when H_ctrl is
  offscreen (wasted drags between parked zones); fixing it needs an answer to
  whether a recreated status item lands at autosave or at a fresh default.
- Per-host event backoff (Control Center not acknowledging synthetic drags,
  ulope's data in #687) is diagnosed but not addressed here.

## Other information

The replay/regression tests were built from reporter logs (nk-tedo-001's
16:32:47 cycle drives the overflow-exemption test directly). oa's soak of
`b3d0c2d4` on the reproducing configuration:
[10 hours, nine overflows, zero divider drags, no collapse](https://github.com/thaw-app/Thaw/issues/958#issuecomment-5386426042).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu bar layout recovery across displays, notches, hidden dividers, and off-screen items.
  - Prevented incorrect repositioning and unstable layout saves during moves or display changes.
  - Improved recovery of missing hidden dividers and handling of unresponsive items.
  - Adjusted move timing and retry behavior for more reliable operations.

- **Improvements**
  - Restored previously resolved menu bar item names between launches.
  - Reduced repeated checks for apps without extras menu bars.
  - Added safeguards for invalid or empty window data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->