### PR TITLE
feat(logging): rotate diagnostic logs by size and time

### DIFF
--- a/MenuBarItemService/Listener.swift
+++ b/MenuBarItemService/Listener.swift
@@ -42,7 +42,19 @@ final nonisolated class Listener: @unchecked Sendable {
             case .start:
                 diagLog.debug("Listener received start request")
                 return .start
-            case let .configureLogging(filePath):
+            case let .configureLogging(filePath, rotationPolicy):
+                if let rotationPolicy {
+                    // Prune by the app's retention settings, not this target's
+                    // defaults: both processes share one log directory.
+                    DiagnosticLogger.shared.setRotationPolicy(rotationPolicy)
+                }
+                guard let filePath else {
+                    // The app turned file logging off; stop writing to the
+                    // shared file rather than holding it open.
+                    DiagnosticLogger.shared.isEnabled = false
+                    diagLog.debug("Listener disabled diagnostic logging")
+                    return .configureLogging
+                }
                 // Only attach to files inside the app's approved log
                 // directory. The path arrives from the XPC peer, and in
                 // teamless (ad-hoc) builds the listener has no peer
@@ -58,7 +70,14 @@ final nonisolated class Listener: @unchecked Sendable {
                     )
                     return nil
                 }
-                DiagnosticLogger.shared.attachToFile(at: requested)
+                guard DiagnosticLogger.shared.attachToFile(at: requested) else {
+                    // Answering success here would leave the app believing both
+                    // processes share a file while this one keeps writing to the
+                    // previous segment — which retention eventually deletes out
+                    // from under it. Failing the request makes the app retry.
+                    diagLog.error("Listener failed to attach diagnostic logging to \(requested.path)")
+                    return nil
+                }
                 diagLog.debug("Listener attached diagnostic logging to \(requested.path)")
                 return .configureLogging
             case let .sourcePIDs(windows):

--- a/Shared/Services/MenuBarItemService.swift
+++ b/Shared/Services/MenuBarItemService.swift
@@ -15,7 +15,14 @@ nonisolated enum MenuBarItemService {
 nonisolated extension MenuBarItemService {
     enum Request: Codable {
         case start
-        case configureLogging(filePath: String)
+        /// Points the service's diagnostic logger at `filePath`, or turns its
+        /// file logging off when `nil`. Sent at startup, again on every log
+        /// rotation, and whenever the user toggles diagnostic logging.
+        ///
+        /// `rotationPolicy` carries the app's retention settings, so the
+        /// service prunes the shared log directory by the same rules rather
+        /// than by its own defaults.
+        case configureLogging(filePath: String?, rotationPolicy: DiagnosticLogger.RotationPolicy?)
         case sourcePIDs([WindowInfo])
     }
 

--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -25,11 +25,6 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
     var isEnabled: Bool {
         get { isEnabledLock.withLock { $0 } }
         set {
-            let oldValue = isEnabledLock.withLock { current -> Bool in
-                let old = current
-                current = newValue
-                return old
-            }
             // Ordered against queued writes on the same serial queue. `log`
             // accepts a message, then hands the actual write to `writeQueue`;
             // opening or closing the handle off-queue could run in that gap
@@ -37,10 +32,22 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
             // whichever file was swapped in behind it. Going through the
             // queue makes the handle a message sees the one that was current
             // when it was accepted.
-            if newValue, !oldValue {
-                writeQueue.sync { openLogFile() }
-            } else if !newValue, oldValue {
-                writeQueue.sync { closeLogFile() }
+            //
+            // The state check runs inside the queue too, so two concurrent
+            // toggles cannot interleave: the last one wins. The enable path
+            // publishes `isEnabled` only once the handle is installed, so an
+            // accepted message never finds logging enabled with no file.
+            writeQueue.sync {
+                let wasEnabled = isEnabledLock.withLock { $0 }
+                guard newValue != wasEnabled else { return }
+                if newValue {
+                    openLogFile()
+                } else {
+                    // Stop accepting writes before the footer is written, so no
+                    // line can land after it.
+                    isEnabledLock.withLock { $0 = false }
+                    closeLogFile()
+                }
             }
         }
     }
@@ -116,6 +123,105 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         qos: .utility
     )
 
+    // MARK: - Rotation State
+
+    /// How the log file is rotated and how long old files are kept.
+    ///
+    /// Set by the main app from its settings and sent to the MenuBarItemService
+    /// XPC target alongside the log path, so both processes prune the shared
+    /// directory by the same rules. Rotation itself stays with the app: only
+    /// the process that mints the file may mint the next one.
+    struct RotationPolicy: Codable, Equatable, Sendable {
+        /// Rotate once the file reaches this size. `0` disables size rotation.
+        var maxFileSizeBytes: UInt64 = 0
+        /// Rotate this many seconds after the segment was opened. `0` disables
+        /// time rotation.
+        var rotationInterval: TimeInterval = 0
+        /// Delete log files older than this many days.
+        var retentionDays: Int = 2
+        /// Never keep more than this many log files, so a small size limit
+        /// cannot pile up hundreds of segments inside the retention window.
+        var maxFileCount: Int = 50
+
+        /// The widest values any of these settings may take.
+        ///
+        /// The ceilings are far above anything the settings UI offers; they
+        /// exist so a value that arrives from elsewhere cannot overflow the
+        /// arithmetic that uses it.
+        static let maxRetentionDays = 3650
+        static let maxRetainedFileCount = 10000
+        static let maxRotationInterval: TimeInterval = 365 * 86400
+        static let maxSizeBytes: UInt64 = 1 << 40 // 1 TiB
+
+        /// Returns the policy with every field forced into a usable range.
+        ///
+        /// A policy can arrive over XPC, where the sender is only as
+        /// trustworthy as the peer requirement — and builds signed without a
+        /// team identifier have none. Left unchecked, a negative retention
+        /// would put the cutoff in the future and delete every log, a zero file
+        /// count would do the same, `Int.min` would trap the subtraction that
+        /// computes the allowance, and a non-finite interval would poison the
+        /// rotation timer.
+        func sanitized() -> RotationPolicy {
+            var policy = self
+            policy.retentionDays = min(max(1, retentionDays), Self.maxRetentionDays)
+            policy.maxFileCount = min(max(1, maxFileCount), Self.maxRetainedFileCount)
+            policy.maxFileSizeBytes = min(maxFileSizeBytes, Self.maxSizeBytes)
+            policy.rotationInterval = rotationInterval.isFinite
+                ? min(max(0, rotationInterval), Self.maxRotationInterval)
+                : 0
+            return policy
+        }
+    }
+
+    private let policyLock = OSAllocatedUnfairLock(initialState: RotationPolicy())
+
+    /// The current rotation policy.
+    var rotationPolicy: RotationPolicy {
+        policyLock.withLock { $0 }
+    }
+
+    /// Updates the rotation policy and reschedules the maintenance timer.
+    ///
+    /// The policy is sanitized here rather than at each call site: one of them
+    /// is an XPC message from a peer this process does not fully trust.
+    func setRotationPolicy(_ policy: RotationPolicy) {
+        policyLock.withLock { $0 = policy.sanitized() }
+        writeQueue.async { [weak self] in
+            self?.rescheduleMaintenanceTimer()
+        }
+    }
+
+    /// Whether this process owns rotation and pruning. True only in the process
+    /// that minted the file via `openLogFile()`; the XPC target attaches to a
+    /// path handed to it and merely follows.
+    private let isRotationOwnerLock = OSAllocatedUnfairLock(initialState: false)
+
+    /// Called after the owner rotates, so the app can point the XPC service at
+    /// the file that is current now. Stored as a closure because this type
+    /// lives in `Shared` and cannot reach the app-only XPC connection.
+    ///
+    /// Deliberately takes no argument: the handler reads ``currentLogFile``
+    /// when it sends, so a handler that runs late cannot push a path that has
+    /// already been rotated away.
+    private let onRotateLock = OSAllocatedUnfairLock<(@Sendable () -> Void)?>(initialState: nil)
+
+    var onRotate: (@Sendable () -> Void)? {
+        get { onRotateLock.withLock { $0 } }
+        set { onRotateLock.withLock { $0 = newValue } }
+    }
+
+    /// Timer that polls file size and elapsed time. `writeQueue` only.
+    private var maintenanceTimer: DispatchSourceTimer?
+
+    /// When the current segment was opened, on a clock that does not move when
+    /// the user or the network changes the system time. `writeQueue` only.
+    private var segmentOpenedAt = ContinuousClock.now
+
+    /// Bytes this process has written since the last size check, used to
+    /// throttle `fstat` on the hot write path. `writeQueue` only.
+    private var bytesSinceSizeCheck = 0
+
     private init() {
         // Intentionally empty: `DiagnosticLogger` is a singleton, and log file setup is deferred until logging is enabled.
     }
@@ -130,21 +236,30 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
     /// straddle a one-second boundary at startup and produce two
     /// separate files). Safe to call repeatedly; the existing handle
     /// is closed before the new one is opened.
-    func attachToFile(at fileURL: URL) {
-        let wasEnabled = isEnabledLock.withLock { current -> Bool in
-            let was = current
-            current = true
-            return was
-        }
-        // Close and open as one unit on the write queue, for the reason given
-        // on `isEnabled`. Doing them as two separate hops would leave a gap
-        // in which an accepted message could be written to the handle being
-        // torn down, or to neither.
-        writeQueue.sync {
-            if wasEnabled {
-                closeLogFile()
-            }
-            openLogFile(at: fileURL)
+    ///
+    /// - Returns: Whether this process is now writing to `fileURL`. A `false`
+    ///   result means the file could not be opened and the previous segment is
+    ///   still in use, which the caller has to report back rather than leaving
+    ///   the app believing the two processes agree on a file.
+    @discardableResult
+    func attachToFile(at fileURL: URL) -> Bool {
+        // Attaching follows a path chosen elsewhere, so this process never owns
+        // rotation or pruning.
+        isRotationOwnerLock.withLock { $0 = false }
+        // Swap on the write queue, for the reason given on `isEnabled`. Doing
+        // it off-queue would leave a gap in which an accepted message could be
+        // written to the handle being torn down, or to neither. `openLogFile`
+        // opens the new file before closing the old one, so a failed open keeps
+        // the current segment rather than dropping logging entirely.
+        return writeQueue.sync {
+            // The app re-sends the current path on rotation and on retry, so
+            // the same file can arrive twice. Re-opening it would write a
+            // second header and a stop footer into the file being written,
+            // which reads as if logging had restarted.
+            let alreadyAttached = currentLogFileLock.withLock { $0 == fileURL }
+                && fileHandleLock.withLock { $0 != nil }
+            guard !alreadyAttached else { return true }
+            return openLogFile(at: fileURL)
         }
     }
 
@@ -153,6 +268,9 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
     /// turned on; the chosen URL is then shared with the XPC service
     /// via attachToFile(at:).
     private func openLogFile() {
+        // The process that mints the file owns rotation and pruning.
+        isRotationOwnerLock.withLock { $0 = true }
+
         let dir = logDirectory
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
@@ -162,22 +280,87 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
             return
         }
 
-        let fileName = "thaw_\(fileNameFormatter.string(from: Date())).log"
-        openLogFile(at: dir.appendingPathComponent(fileName))
+        let baseName = "thaw_\(fileNameFormatter.string(from: Date()))"
+        let fileURL = Self.uniqueLogFileURL(in: dir, baseName: baseName) {
+            FileManager.default.fileExists(atPath: $0.path)
+        }
+        openLogFile(at: fileURL)
     }
 
-    /// Opens the given file with O_APPEND and writes the per-process
-    /// header. Shared by the main app's fresh-mint path and the XPC
-    /// service's attach path so both processes use identical open and
+    /// Opens the given file, writes the per-process header, and installs it as
+    /// the current log file. Shared by the main app's fresh-mint path, the XPC
+    /// service's attach path, and rotation, so all three use identical open and
     /// header logic.
-    private func openLogFile(at fileURL: URL) {
+    ///
+    /// - Returns: Whether `fileURL` is now the file being written to.
+    @discardableResult
+    private func openLogFile(at fileURL: URL) -> Bool {
+        guard installLogFile(at: fileURL, footerForPrevious: "Diagnostic logging stopped") else {
+            // Nothing was disturbed: keep writing to the previous segment when
+            // there is one, and only give up when there is not.
+            if currentLogFileLock.withLock({ $0 == nil }) {
+                isEnabledLock.withLock { $0 = false }
+            }
+            return false
+        }
+
+        // Published last: an accepted message must never find logging enabled
+        // before there is a file to write it to.
+        isEnabledLock.withLock { $0 = true }
+        osLog.info("Diagnostic logging started: \(fileURL.path, privacy: .public)")
+
+        rescheduleMaintenanceTimer()
+        // Queued rather than run here: enabling logging waits on this queue from
+        // the main actor, and sweeping a directory full of logs is not something
+        // to hold it for.
+        let directory = fileURL.deletingLastPathComponent()
+        writeQueue.async { [weak self] in
+            self?.cleanupOldLogFiles(in: directory, protecting: [fileURL])
+        }
+        return true
+    }
+
+    /// Opens `fileURL`, writes its header, then swaps it in as the current
+    /// handle and closes the previous one with `footerForPrevious`.
+    ///
+    /// The new file is opened before the old one is closed, so a failed open
+    /// leaves the current segment untouched and returns `false` rather than
+    /// dropping logging on the floor.
+    private func installLogFile(at fileURL: URL, footerForPrevious: String) -> Bool {
+        guard let newHandle = openHandle(at: fileURL) else {
+            return false
+        }
+        writeHeader(to: newHandle)
+
+        let previousHandle = fileHandleLock.withLock { handle -> FileHandle? in
+            let previous = handle
+            handle = newHandle
+            return previous
+        }
+        currentLogFileLock.withLock { $0 = fileURL }
+        bytesSinceSizeCheck = 0
+        segmentOpenedAt = ContinuousClock.now
+
+        if let previousHandle {
+            let ts = timestampFormatter.string(from: Date())
+            let footer = "\n\(ts) [DiagnosticLogger] \(footerForPrevious)\n"
+            if let data = footer.data(using: .utf8) {
+                previousHandle.write(data)
+            }
+            try? previousHandle.close()
+        }
+        return true
+    }
+
+    /// Opens `fileURL` for appending, creating its directory if needed.
+    /// Returns `nil` when the directory or the file cannot be opened.
+    private func openHandle(at fileURL: URL) -> FileHandle? {
         let dir = fileURL.deletingLastPathComponent()
         do {
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         } catch {
             osLog.error("Failed to create log directory at \(dir.path): \(error)")
-            isEnabledLock.withLock { $0 = false }
-            return
+            return nil
         }
 
         // Open with O_APPEND so the main app and the XPC service can
@@ -190,17 +373,20 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         // smaller than PIPE_BUF on local filesystems; O_CREAT creates
         // the file if absent without touching an existing one. Swift's
         // FileHandle initializers do not expose these flags, hence the
-        // POSIX call.
-        let fd = open(fileURL.path, O_WRONLY | O_APPEND | O_CREAT, 0o644)
+        // POSIX call. O_NOFOLLOW refuses to open through a symlink at the
+        // final component, and 0o600 keeps logs — which carry window titles
+        // and process names — readable only by the user who owns them.
+        let fd = open(fileURL.path, O_WRONLY | O_APPEND | O_CREAT | O_NOFOLLOW, 0o600)
         guard fd >= 0 else {
             osLog.error("Failed to open log file at \(fileURL.path): errno \(errno)")
-            isEnabledLock.withLock { $0 = false }
-            return
+            return nil
         }
-        let handle = FileHandle(fileDescriptor: fd, closeOnDealloc: true)
-        fileHandleLock.withLock { $0 = handle }
-        currentLogFileLock.withLock { $0 = fileURL }
+        return FileHandle(fileDescriptor: fd, closeOnDealloc: true)
+    }
 
+    /// Writes the per-process header into the given handle. `writeQueue` only:
+    /// `timestampFormatter` is not thread-safe.
+    private func writeHeader(to handle: FileHandle) {
         // Each process writes its own header into the shared file.
         // The Process line distinguishes them; chronological order
         // is preserved by the per-line timestamps.
@@ -226,15 +412,12 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         if let data = header.data(using: .utf8) {
             handle.write(data)
         }
-
-        osLog.info("Diagnostic logging started: \(fileURL.path, privacy: .public)")
-
-        // Clean up old log files (keep last 5)
-        cleanupOldLogFiles(in: dir, keepCount: 5)
     }
 
     /// Closes the current log file.
     private func closeLogFile() {
+        maintenanceTimer?.cancel()
+        maintenanceTimer = nil
         fileHandleLock.withLock { handle in
             if let handle {
                 let ts = timestampFormatter.string(from: Date())
@@ -250,47 +433,139 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         osLog.info("Diagnostic logging stopped")
     }
 
-    /// Removes old log files, keeping only the most recent `keepCount`.
-    private func cleanupOldLogFiles(in directory: URL, keepCount: Int) {
-        writeQueue.async { [weak self] in
-            guard let self else { return }
-            do {
-                let files = try FileManager.default.contentsOfDirectory(
-                    at: directory,
-                    includingPropertiesForKeys: [.creationDateKey],
-                    options: .skipsHiddenFiles
-                )
-                let logFiles = files
-                    .filter { $0.pathExtension == "log" }
-                    .sorted { a, b in
-                        let dateA = (try? a.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
-                        let dateB = (try? b.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
-                        return dateA > dateB
-                    }
+    // MARK: - Rotation
 
-                if logFiles.count > keepCount {
-                    for file in logFiles.dropFirst(keepCount) {
-                        // Each removal is isolated so one stubborn file cannot
-                        // abort the rest of the prune and leave the directory
-                        // permanently above `keepCount`.
-                        do {
-                            try FileManager.default.removeItem(at: file)
-                            osLog.debug("Removed old log file: \(file.lastPathComponent, privacy: .public)")
-                        } catch CocoaError.fileNoSuchFile {
-                            // The main app and the MenuBarItemService XPC target
-                            // prune the same shared directory on every open, so
-                            // losing the race to a concurrent pruner is expected
-                            // and not worth a diagnostic.
-                        } catch {
-                            osLog.warning(
-                                "Failed to remove old log file \(file.lastPathComponent, privacy: .public): \(error)"
-                            )
-                        }
-                    }
+    /// Rotates to a freshly minted log file.
+    ///
+    /// Owner-only, `writeQueue` only. The new file is opened before the old one
+    /// is closed, so a failed open leaves the current segment in place.
+    private func rotateLogFile() {
+        guard isRotationOwnerLock.withLock({ $0 }) else { return }
+        guard let previous = currentLogFileLock.withLock({ $0 }) else { return }
+        let dir = previous.deletingLastPathComponent()
+
+        let baseName = "thaw_\(fileNameFormatter.string(from: Date()))"
+        let newURL = Self.uniqueLogFileURL(in: dir, baseName: baseName) {
+            FileManager.default.fileExists(atPath: $0.path)
+        }
+
+        guard installLogFile(at: newURL, footerForPrevious: "Rotated to \(newURL.lastPathComponent)") else {
+            osLog.error("Rotation failed to open \(newURL.path, privacy: .public); staying on the current segment")
+            return
+        }
+
+        osLog.info("Rotated diagnostic log to \(newURL.path, privacy: .public)")
+
+        // Tell the app to point the service at whatever is current now. The
+        // handler only starts the round trip, so calling it here costs the
+        // write queue nothing, and going through another queue first would only
+        // add a way for two notifications to arrive out of order.
+        onRotateLock.withLock { $0 }?()
+
+        // The XPC target keeps writing to `previous` until it re-attaches, so
+        // that segment stays even when the policy would otherwise prune it.
+        writeQueue.async { [weak self] in
+            self?.cleanupOldLogFiles(in: dir, protecting: [newURL, previous])
+        }
+    }
+
+    /// Recreates the timer that polls file size and elapsed time.
+    ///
+    /// Owner-only, `writeQueue` only. Also covers growth driven solely by the
+    /// XPC target, which the app's own write path would never notice.
+    private func rescheduleMaintenanceTimer() {
+        maintenanceTimer?.cancel()
+        maintenanceTimer = nil
+
+        guard isEnabled, isRotationOwnerLock.withLock({ $0 }) else { return }
+        let policy = policyLock.withLock { $0 }
+        guard policy.maxFileSizeBytes > 0 || policy.rotationInterval > 0 else { return }
+
+        let timer = DispatchSource.makeTimerSource(queue: writeQueue)
+        timer.schedule(deadline: .now() + Self.maintenanceInterval, repeating: Self.maintenanceInterval)
+        timer.setEventHandler { [weak self] in
+            self?.maintenanceTick()
+        }
+        maintenanceTimer = timer
+        timer.resume()
+    }
+
+    /// How often the maintenance timer checks size and elapsed time.
+    private static let maintenanceInterval: TimeInterval = 5
+
+    /// Rotates when the file has outgrown the size limit or the segment has
+    /// outlived the interval. `writeQueue` only.
+    private func maintenanceTick() {
+        let policy = policyLock.withLock { $0 }
+
+        if policy.maxFileSizeBytes > 0, let size = currentFileSize(), size >= policy.maxFileSizeBytes {
+            rotateLogFile()
+            return
+        }
+        if policy.rotationInterval > 0,
+           segmentOpenedAt.duration(to: .now) >= .seconds(policy.rotationInterval)
+        {
+            rotateLogFile()
+        }
+    }
+
+    /// The current log file's size on disk, or `nil` when there is no handle.
+    ///
+    /// Read through `fstat` rather than a per-process byte counter so that
+    /// bytes written by the XPC target into the same file count too.
+    private func currentFileSize() -> UInt64? {
+        fileHandleLock.withLock { handle -> UInt64? in
+            guard let fd = handle?.fileDescriptor else { return nil }
+            var info = stat()
+            guard fstat(fd, &info) == 0 else { return nil }
+            return UInt64(info.st_size)
+        }
+    }
+
+    /// Removes log files the retention policy no longer covers, never touching
+    /// `protected`. `writeQueue` only.
+    private func cleanupOldLogFiles(in directory: URL, protecting protected: [URL]) {
+        let policy = policyLock.withLock { $0 }
+        do {
+            let contents = try FileManager.default.contentsOfDirectory(
+                at: directory,
+                includingPropertiesForKeys: [.creationDateKey],
+                options: .skipsHiddenFiles
+            )
+            let logFiles = contents
+                .filter { $0.pathExtension == "log" }
+                .map { url -> (url: URL, created: Date) in
+                    let created = (try? url.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
+                    return (url, created)
                 }
-            } catch {
-                osLog.warning("Failed to clean up old log files: \(error)")
+
+            let staleFiles = Self.filesToPrune(
+                logFiles,
+                retentionDays: policy.retentionDays,
+                maxCount: policy.maxFileCount,
+                now: Date(),
+                protected: Set(protected)
+            )
+
+            for file in staleFiles {
+                // Each removal is isolated so one stubborn file cannot
+                // abort the rest of the prune and leave the directory
+                // permanently above the policy.
+                do {
+                    try FileManager.default.removeItem(at: file)
+                    osLog.debug("Removed old log file: \(file.lastPathComponent, privacy: .public)")
+                } catch CocoaError.fileNoSuchFile {
+                    // The main app and the MenuBarItemService XPC target
+                    // share the directory, so losing the race to a concurrent
+                    // pruner is expected and not worth a diagnostic.
+                } catch {
+                    osLog.warning(
+                        "Failed to remove old log file \(file.lastPathComponent, privacy: .public): \(error)"
+                    )
+                }
             }
+        } catch {
+            osLog.warning("Failed to clean up old log files: \(error)")
         }
     }
 
@@ -316,15 +591,118 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
     func log(level: Level, category: String, message: String) {
         guard isEnabled else { return }
 
-        let timestamp = timestampFormatter.string(from: Date())
-        let line = "\(timestamp) [\(level.rawValue)] [\(category)] \(message)\n"
-
-        guard let data = line.data(using: .utf8) else { return }
+        // Capturing the instant here keeps the line's timestamp honest, while
+        // the formatting itself happens on the queue: `DateFormatter` is not
+        // thread-safe and `log` is called from every thread in the app.
+        let now = Date()
 
         writeQueue.async { [weak self] in
-            self?.fileHandleLock.withLock { handle in
+            guard let self else { return }
+            let timestamp = timestampFormatter.string(from: now)
+            let line = "\(timestamp) [\(level.rawValue)] [\(category)] \(message)\n"
+            guard let data = line.data(using: .utf8) else { return }
+            fileHandleLock.withLock { handle in
                 handle?.write(data)
             }
+            checkSizeAfterWrite(byteCount: data.count)
+        }
+    }
+
+    /// Rotates when this process's own writes have pushed the file past the
+    /// size limit. `writeQueue` only.
+    ///
+    /// The accumulator keeps `fstat` off the per-line path: it runs once per
+    /// 64 KB written rather than once per message. Growth driven by the XPC
+    /// target is caught by the maintenance timer instead.
+    private func checkSizeAfterWrite(byteCount: Int) {
+        guard isRotationOwnerLock.withLock({ $0 }) else { return }
+        let maxFileSizeBytes = policyLock.withLock { $0.maxFileSizeBytes }
+        guard maxFileSizeBytes > 0 else { return }
+
+        bytesSinceSizeCheck += byteCount
+        guard bytesSinceSizeCheck >= Self.sizeCheckByteInterval else { return }
+        bytesSinceSizeCheck = 0
+
+        if let size = currentFileSize(), size >= maxFileSizeBytes {
+            rotateLogFile()
+        }
+    }
+
+    /// How many bytes this process writes between `fstat` size checks.
+    private static let sizeCheckByteInterval = 64 * 1024
+}
+
+// MARK: - Rotation Helpers
+
+/// Explicitly nonisolated: these run on the logger's write queue, and the
+/// target's default actor isolation is MainActor.
+nonisolated extension DiagnosticLogger {
+    /// Returns the log files that retention no longer covers.
+    ///
+    /// A file is pruned when it is older than `retentionDays`, or when the
+    /// newer files already fill `maxCount`; between two files of the same age
+    /// the survivor is the one whose path sorts first, so the choice is not
+    /// left to directory order. `protected` files — the current segment and,
+    /// during rotation, the one just closed — are always kept, because a
+    /// descriptor may still be open on them, and they count against `maxCount`.
+    ///
+    /// The result is ordered newest first, so a caller that stops early deletes
+    /// the least valuable files last.
+    static func filesToPrune(
+        _ files: [(url: URL, created: Date)],
+        retentionDays: Int,
+        maxCount: Int,
+        now: Date,
+        protected: Set<URL>
+    ) -> [URL] {
+        let cutoff = now.addingTimeInterval(-Double(retentionDays) * 86400)
+        // Written as a comparison rather than a subtraction: `maxCount` reaches
+        // this from a policy that may not have been sanitized, and `Int.min`
+        // would trap.
+        let cap = max(0, maxCount)
+        let allowance = cap > protected.count ? cap - protected.count : 0
+
+        let candidates = files
+            .filter { !protected.contains($0.url) }
+            .sorted { lhs, rhs in
+                lhs.created == rhs.created
+                    ? lhs.url.path < rhs.url.path
+                    : lhs.created > rhs.created // newest first
+            }
+
+        var kept = 0
+        var stale: [URL] = []
+        for file in candidates {
+            if file.created < cutoff || kept >= allowance {
+                stale.append(file.url)
+            } else {
+                kept += 1
+            }
+        }
+        return stale
+    }
+
+    /// Returns a log file URL in `directory` for `baseName` that no file
+    /// already occupies, appending `_2`, `_3`, … on collision.
+    ///
+    /// The timestamp in a log file name is second-granular, so rotating twice
+    /// within the same second — or rotating in the second the app started —
+    /// would otherwise reuse a name and append to a segment already in use.
+    static func uniqueLogFileURL(
+        in directory: URL,
+        baseName: String,
+        exists: (URL) -> Bool
+    ) -> URL {
+        let base = directory.appendingPathComponent("\(baseName).log")
+        guard exists(base) else { return base }
+
+        var suffix = 2
+        while true {
+            let candidate = directory.appendingPathComponent("\(baseName)_\(suffix).log")
+            if !exists(candidate) {
+                return candidate
+            }
+            suffix += 1
         }
     }
 }

--- a/Thaw/Main/AppState.swift
+++ b/Thaw/Main/AppState.swift
@@ -100,6 +100,18 @@ final class AppState {
     /// view body, so the exemption has no UI-observability effect.
     @ObservationIgnored
     private lazy var setupTask = Task { @MainActor in
+        // Rotation mints a new file, and the XPC service is still holding the
+        // old one. Installed before logging starts so even the first rotation
+        // brings the service along.
+        DiagnosticLogger.shared.onRotate = {
+            Task { await MenuBarItemService.Connection.shared.syncLogging() }
+        }
+
+        // Opening a log file prunes the directory, so the stored retention has
+        // to be in place before logging starts — the settings model that would
+        // otherwise supply it is not built until later in this task.
+        DiagnosticLogger.shared.setRotationPolicy(AdvancedSettings.persistedRotationPolicy())
+
         #if DEBUG
             // Debug builds always have diagnostic logging on so logs are
             // captured during development without depending on the toggle.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
@@ -24,6 +24,22 @@ extension MenuBarItemService {
         /// The connection's diagnostic logger.
         private let diagLog: DiagLog
 
+        /// Tracks the one logging configuration the service is allowed to be
+        /// missing at a time.
+        private struct LoggingSyncState {
+            /// Whether a request is on the wire right now. Only one may be:
+            /// replies can overtake each other, and the loser would leave the
+            /// service pointed at a file the app has already rotated away.
+            var isSending = false
+            /// Whether the service still owes a configuration. Set when a push
+            /// fails, and when the XPC session is dropped — a service that
+            /// restarts has no idea which file the app is writing to, and
+            /// nothing else would ever tell it.
+            var isPending = false
+        }
+
+        private let loggingSync: OSAllocatedUnfairLock<LoggingSyncState>
+
         /// Creates a new connection.
         private init() {
             let queue = DispatchQueue.targetingGlobal(
@@ -32,7 +48,11 @@ extension MenuBarItemService {
                 attributes: .concurrent
             )
             let diagLog = DiagLog(category: "MenuBarItemService.Connection")
-            self.session = Session(queue: queue, diagLog: diagLog)
+            let loggingSync = OSAllocatedUnfairLock(initialState: LoggingSyncState())
+            self.loggingSync = loggingSync
+            self.session = Session(queue: queue, diagLog: diagLog) {
+                loggingSync.withLock { $0.isPending = true }
+            }
             self.diagLog = diagLog
         }
 
@@ -47,16 +67,10 @@ extension MenuBarItemService {
             // subsequent traffic. When file logging is off in the main
             // app currentLogFile is nil and the XPC service simply logs
             // to OSLog only, matching the prior release-build behaviour.
-            if let logFile = DiagnosticLogger.shared.currentLogFile {
-                let response = await session.sendAsync(request: .configureLogging(filePath: logFile.path))
-                if response == nil {
-                    diagLog.error("configureLogging request returned nil")
-                } else if case .configureLogging = response {
-                    // success
-                } else {
-                    diagLog.error("configureLogging request returned invalid response \(String(describing: response))")
-                }
-            }
+            //
+            // Sent unconditionally: even with logging off, this hands over the
+            // retention policy the service prunes the shared directory by.
+            await syncLogging()
 
             let response = await session.sendAsync(request: .start)
             guard let response else {
@@ -70,10 +84,86 @@ extension MenuBarItemService {
             }
         }
 
+        /// Points the service at the diagnostic log file the app is writing to
+        /// right now, or turns its file logging off when there is none, and
+        /// hands over the retention policy along with it.
+        ///
+        /// Called at startup, on every log rotation, and when the user changes
+        /// a diagnostics setting. The state is read here, at send time, rather
+        /// than captured by the caller: a notification that was queued before a
+        /// rotation would otherwise point the service at the file that rotation
+        /// has already replaced.
+        func syncLogging() async {
+            // One sender at a time. A second caller only marks the work as
+            // outstanding: the sender already running will pick it up, and the
+            // state it reads then is newer than anything this caller could
+            // pass along.
+            let isSender = loggingSync.withLock { state -> Bool in
+                state.isPending = true
+                guard !state.isSending else { return false }
+                state.isSending = true
+                return true
+            }
+            guard isSender else { return }
+            defer { loggingSync.withLock { $0.isSending = false } }
+
+            var attemptsLeft = Self.loggingSyncAttempts
+            while loggingSync.withLock({ state -> Bool in
+                let wasPending = state.isPending
+                state.isPending = false
+                return wasPending
+            }) {
+                if await sendLoggingConfiguration() {
+                    attemptsLeft = Self.loggingSyncAttempts
+                    continue
+                }
+
+                // Put the work back and try again shortly. Leaving it to the
+                // next request would be enough on a busy app, but a quiet one
+                // could sit for minutes with the service writing to a file this
+                // process has already rotated away.
+                loggingSync.withLock { $0.isPending = true }
+                attemptsLeft -= 1
+                guard attemptsLeft > 0 else { break }
+                try? await Task.sleep(for: .seconds(2))
+            }
+        }
+
+        /// How many times a failing configuration push is retried before it is
+        /// left for the next request to carry.
+        private static let loggingSyncAttempts = 3
+
+        /// Sends the current logging configuration once.
+        ///
+        /// - Returns: Whether the service accepted it.
+        private func sendLoggingConfiguration() async -> Bool {
+            let request = MenuBarItemService.Request.configureLogging(
+                filePath: DiagnosticLogger.shared.currentLogFile?.path,
+                rotationPolicy: DiagnosticLogger.shared.rotationPolicy
+            )
+            let response = await session.sendAsync(request: request)
+            guard case .configureLogging = response else {
+                diagLog.error("configureLogging request returned \(String(describing: response))")
+                return false
+            }
+            return true
+        }
+
+        /// Re-sends the logging configuration when a push failed or the session
+        /// was replaced, so the service is never left writing to a file the app
+        /// has moved on from.
+        private func syncLoggingIfNeeded() async {
+            guard loggingSync.withLock({ $0.isPending }) else { return }
+            await syncLogging()
+        }
+
         /// Returns the source process identifiers for the given windows in a
         /// single batch XPC request, avoiding concurrent thread explosion
         /// in the XPC service.
         func sourcePIDs(for windows: [WindowInfo]) async -> [pid_t?] {
+            // The app's most frequent request, and so the cheapest place to
+            // notice that the service is owed a logging configuration.
+            await syncLoggingIfNeeded()
             let response = await session.sendAsync(request: .sourcePIDs(windows))
             guard let response else {
                 diagLog.error("Source PIDs batch request returned nil")
@@ -109,9 +199,15 @@ extension MenuBarItemService {
             private let queue: DispatchQueue
             private let diagLog: DiagLog
 
-            init(queue: DispatchQueue, diagLog: DiagLog) {
+            /// Called when a session is dropped, so state the peer only learns
+            /// by being told — the diagnostic log path — can be sent again to
+            /// whatever process comes back.
+            private let onInvalidate: @Sendable () -> Void
+
+            init(queue: DispatchQueue, diagLog: DiagLog, onInvalidate: @escaping @Sendable () -> Void) {
                 self.queue = queue
                 self.diagLog = diagLog
+                self.onInvalidate = onInvalidate
             }
 
             func getSession() throws -> XPCSession {
@@ -166,10 +262,13 @@ extension MenuBarItemService {
                 guard let cancelledSession else {
                     return
                 }
-                sessionLock.withLock { session in
-                    if session === cancelledSession {
-                        session = nil
-                    }
+                let dropped = sessionLock.withLock { session -> Bool in
+                    guard session === cancelledSession else { return false }
+                    session = nil
+                    return true
+                }
+                if dropped {
+                    onInvalidate()
                 }
             }
 
@@ -188,8 +287,8 @@ extension MenuBarItemService {
         private let diagLog: DiagLog
 
         /// Creates a new session.
-        init(queue: DispatchQueue, diagLog: DiagLog) {
-            self.storage = Storage(queue: queue, diagLog: diagLog)
+        init(queue: DispatchQueue, diagLog: DiagLog, onInvalidate: @escaping @Sendable () -> Void) {
+            self.storage = Storage(queue: queue, diagLog: diagLog, onInvalidate: onInvalidate)
             self.diagLog = diagLog
         }
 

--- a/Thaw/Settings/Models/AdvancedSettings.swift
+++ b/Thaw/Settings/Models/AdvancedSettings.swift
@@ -132,7 +132,7 @@ final class AdvancedSettings {
     /// - Otherwise snaps to `1 / clamp(round(1 / interval), 1, ceiling)`,
     ///   where the ceiling is ``MenuBarItemImageCache/maxIconRefreshRate``.
     /// - Idempotent: already-on-grid values round-trip unchanged.
-    nonisolated static func normalizedIconRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
+    static nonisolated func normalizedIconRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
         guard interval > 0 else { return 0 }
         let ceiling = MenuBarItemImageCache.maxIconRefreshRate
         let fps = min(max((1.0 / interval).rounded(), 1), ceiling)
@@ -151,7 +151,112 @@ final class AdvancedSettings {
             #else
                 DiagnosticLogger.shared.isEnabled = enableDiagnosticLogging
             #endif
+            // The XPC service holds its own handle on the shared file, so a
+            // toggle has to reach it too: a file to follow, or nothing to stop.
+            Task { await MenuBarItemService.Connection.shared.syncLogging() }
         }
+    }
+
+    /// The size, in megabytes, a diagnostic log file may reach before it is
+    /// rotated to a new file.
+    var diagnosticLogMaxSizeMB = Defaults.DefaultValue.diagnosticLogMaxSizeMB {
+        didSet {
+            guard oldValue != diagnosticLogMaxSizeMB else { return }
+            Defaults.set(diagnosticLogMaxSizeMB, forKey: .diagnosticLogMaxSizeMB)
+            applyLogRotationPolicy(pushingToService: true)
+        }
+    }
+
+    /// How many days diagnostic log files are kept before they are deleted.
+    var diagnosticLogRetentionDays = Defaults.DefaultValue.diagnosticLogRetentionDays {
+        didSet {
+            guard oldValue != diagnosticLogRetentionDays else { return }
+            Defaults.set(diagnosticLogRetentionDays, forKey: .diagnosticLogRetentionDays)
+            applyLogRotationPolicy(pushingToService: true)
+        }
+    }
+
+    /// How often diagnostic logs are rotated on a schedule, on top of the size
+    /// limit.
+    var diagnosticLogRotationInterval = Defaults.DefaultValue.diagnosticLogRotationInterval {
+        didSet {
+            guard oldValue != diagnosticLogRotationInterval else { return }
+            Defaults.set(diagnosticLogRotationInterval.rawValue, forKey: .diagnosticLogRotationInterval)
+            applyLogRotationPolicy(pushingToService: true)
+        }
+    }
+
+    /// True while ``loadInitialState()`` runs.
+    ///
+    /// Assigning a loaded value trips that property's `didSet`, so without this
+    /// the service would be sent a policy once per setting, each one built from
+    /// a half-loaded model, before the connection has even started.
+    @ObservationIgnored
+    private var isLoadingInitialState = false
+
+    /// The largest log size the app will ask the logger for.
+    ///
+    /// Far above anything the settings stepper offers; it exists only so a
+    /// value read back from a profile or from UserDefaults cannot overflow the
+    /// conversion to bytes.
+    private static let maxDiagnosticLogSizeMB = 1_000_000
+
+    /// Hands the current rotation settings to the diagnostic logger, and — once
+    /// the app is running — to the XPC service that shares the log directory.
+    ///
+    /// - Parameter pushingToService: Whether to forward the policy over XPC.
+    ///   Left off during initialization, when the connection has not started
+    ///   yet and `Connection.start()` sends the initial configuration anyway.
+    func applyLogRotationPolicy(pushingToService: Bool = false) {
+        DiagnosticLogger.shared.setRotationPolicy(
+            Self.rotationPolicy(
+                maxSizeMB: diagnosticLogMaxSizeMB,
+                retentionDays: diagnosticLogRetentionDays,
+                interval: diagnosticLogRotationInterval
+            )
+        )
+
+        guard pushingToService, !isLoadingInitialState else { return }
+        Task { await MenuBarItemService.Connection.shared.syncLogging() }
+    }
+
+    /// Builds a rotation policy from the given settings.
+    static func rotationPolicy(
+        maxSizeMB: Int,
+        retentionDays: Int,
+        interval: LogRotationInterval
+    ) -> DiagnosticLogger.RotationPolicy {
+        var policy = DiagnosticLogger.RotationPolicy()
+        // Clamped before the multiplication: UserDefaults can hold values the
+        // stepper would never produce, and `UInt64(huge) * 1024 * 1024` traps
+        // on overflow.
+        let megabytes = min(max(0, maxSizeMB), maxDiagnosticLogSizeMB)
+        policy.maxFileSizeBytes = UInt64(megabytes) * 1024 * 1024
+        policy.retentionDays = max(1, retentionDays)
+        policy.rotationInterval = interval.seconds
+        return policy
+    }
+
+    /// Reads a rotation policy straight out of the stored settings.
+    ///
+    /// Diagnostic logging starts before this model is built, and opening a log
+    /// file prunes the directory. Without this the first prune of every launch
+    /// would run against the default retention and delete files that a longer
+    /// setting was meant to keep.
+    static func persistedRotationPolicy() -> DiagnosticLogger.RotationPolicy {
+        var maxSizeMB = Defaults.DefaultValue.diagnosticLogMaxSizeMB
+        var retentionDays = Defaults.DefaultValue.diagnosticLogRetentionDays
+        var interval = Defaults.DefaultValue.diagnosticLogRotationInterval
+
+        Defaults.ifPresent(key: .diagnosticLogMaxSizeMB, assign: &maxSizeMB)
+        Defaults.ifPresent(key: .diagnosticLogRetentionDays, assign: &retentionDays)
+        Defaults.ifPresent(key: .diagnosticLogRotationInterval) { (rawValue: String) in
+            if let stored = LogRotationInterval(rawValue: rawValue) {
+                interval = stored
+            }
+        }
+
+        return rotationPolicy(maxSizeMB: maxSizeMB, retentionDays: retentionDays, interval: interval)
     }
 
     /// A Boolean value that controls whether profile-apply overflows menu bar
@@ -281,6 +386,9 @@ final class AdvancedSettings {
 
     /// Loads the model's initial state.
     private func loadInitialState() {
+        isLoadingInitialState = true
+        defer { isLoadingInitialState = false }
+
         Defaults.ifPresent(key: .enableAlwaysHiddenSection, assign: &enableAlwaysHiddenSection)
         Defaults.ifPresent(key: .useOptionClickToShowAlwaysHiddenSection, assign: &useOptionClickToShowAlwaysHiddenSection)
         Defaults.ifPresent(key: .useDoubleClickToShowAlwaysHiddenSection, assign: &useDoubleClickToShowAlwaysHiddenSection)
@@ -293,6 +401,13 @@ final class AdvancedSettings {
         Defaults.ifPresent(key: .showMenuBarTooltips, assign: &showMenuBarTooltips)
         Defaults.ifPresent(key: .iconRefreshInterval, assign: &iconRefreshInterval)
         Defaults.ifPresent(key: .enableDiagnosticLogging, assign: &enableDiagnosticLogging)
+        Defaults.ifPresent(key: .diagnosticLogMaxSizeMB, assign: &diagnosticLogMaxSizeMB)
+        Defaults.ifPresent(key: .diagnosticLogRetentionDays, assign: &diagnosticLogRetentionDays)
+        Defaults.ifPresent(key: .diagnosticLogRotationInterval) { (rawValue: String) in
+            if let interval = LogRotationInterval(rawValue: rawValue) {
+                diagnosticLogRotationInterval = interval
+            }
+        }
         Defaults.ifPresent(key: .enableMenuBarItemOverflow, assign: &enableMenuBarItemOverflow)
         Defaults.ifPresent(key: .automaticArrangementEnabled, assign: &automaticArrangementEnabled)
         Defaults.ifPresent(key: .useThawBarOnNotchOverflow, assign: &useThawBarOnNotchOverflow)
@@ -311,6 +426,11 @@ final class AdvancedSettings {
         Defaults.ifPresent(key: .searchSectionOrder) { (rawValues: [String]) in
             searchSectionOrder = Self.sanitizedSearchSectionOrder(from: rawValues)
         }
+
+        // One authoritative apply once every setting is in place. The `didSet`
+        // observers tripped above each applied a partially loaded policy, and
+        // none of them reached the service.
+        applyLogRotationPolicy()
     }
 
     /// Returns a search-section order that contains each `MenuBarSection.Name`

--- a/Thaw/Settings/Models/LogRotationInterval.swift
+++ b/Thaw/Settings/Models/LogRotationInterval.swift
@@ -1,0 +1,39 @@
+//
+//  LogRotationInterval.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+/// How often diagnostic logs are rotated on a schedule, independently of the
+/// size limit.
+nonisolated enum LogRotationInterval: String, CaseIterable, Identifiable {
+    case off
+    case hourly
+    case daily
+
+    var id: String {
+        rawValue
+    }
+
+    /// The interval in seconds, or `0` when scheduled rotation is off.
+    var seconds: TimeInterval {
+        switch self {
+        case .off: 0
+        case .hourly: 3600
+        case .daily: 86400
+        }
+    }
+
+    /// Localized string key representation.
+    var localized: LocalizedStringKey {
+        switch self {
+        case .off: "Off"
+        case .hourly: "Hourly"
+        case .daily: "Daily"
+        }
+    }
+}

--- a/Thaw/Settings/Models/SettingsResetter.swift
+++ b/Thaw/Settings/Models/SettingsResetter.swift
@@ -65,6 +65,9 @@ extension AppSettings {
         advanced.showMenuBarTooltips = Defaults.DefaultValue.showMenuBarTooltips
         advanced.iconRefreshInterval = Defaults.DefaultValue.iconRefreshInterval
         advanced.enableDiagnosticLogging = Defaults.DefaultValue.enableDiagnosticLogging
+        advanced.diagnosticLogMaxSizeMB = Defaults.DefaultValue.diagnosticLogMaxSizeMB
+        advanced.diagnosticLogRetentionDays = Defaults.DefaultValue.diagnosticLogRetentionDays
+        advanced.diagnosticLogRotationInterval = Defaults.DefaultValue.diagnosticLogRotationInterval
         advanced.enableMenuBarItemOverflow = Defaults.DefaultValue.enableMenuBarItemOverflow
         advanced.useThawBarOnNotchOverflow = Defaults.DefaultValue.useThawBarOnNotchOverflow
         advanced.automaticArrangementEnabled = Defaults.DefaultValue.automaticArrangementEnabled

--- a/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -101,6 +101,29 @@ struct AdvancedSettingsPane: View {
                 .padding(.trailing, 75)
             }
 
+            if settings.enableDiagnosticLogging {
+                LabeledContent("Maximum log file size") {
+                    Stepper(value: $settings.diagnosticLogMaxSizeMB, in: 1 ... 100) {
+                        Text("\(settings.diagnosticLogMaxSizeMB) MB")
+                    }
+                    .fixedSize()
+                }
+                .annotation("Start a new log file once the current one reaches this size.")
+
+                LabeledContent("Keep logs for") {
+                    Stepper(value: $settings.diagnosticLogRetentionDays, in: 1 ... 30) {
+                        Text("^[\(settings.diagnosticLogRetentionDays) day](inflect: true)")
+                    }
+                    .fixedSize()
+                }
+
+                IcePicker("Rotate by time", selection: $settings.diagnosticLogRotationInterval) {
+                    ForEach(LogRotationInterval.allCases) { interval in
+                        Text(interval.localized).tag(interval)
+                    }
+                }
+            }
+
             HStack(spacing: 12) {
                 if settings.enableDiagnosticLogging || DiagnosticLogger.shared.hasLogFiles {
                     Button("Show Log Files in Finder") {

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -191,6 +191,9 @@ nonisolated extension Defaults {
         #else
             static let enableDiagnosticLogging = false
         #endif
+        static let diagnosticLogMaxSizeMB = 10
+        static let diagnosticLogRetentionDays = 2
+        static let diagnosticLogRotationInterval: LogRotationInterval = .off
         static let useOptionClickToShowAlwaysHiddenSection = false
         static let useDoubleClickToShowAlwaysHiddenSection = false
         static let enableMenuBarItemOverflow = true
@@ -280,6 +283,9 @@ nonisolated extension Defaults {
         case iconRefreshInterval = "IconRefreshInterval"
         case showMenuBarTooltips = "ShowMenuBarTooltips"
         case enableDiagnosticLogging = "EnableDiagnosticLogging"
+        case diagnosticLogMaxSizeMB = "DiagnosticLogMaxSizeMB"
+        case diagnosticLogRetentionDays = "DiagnosticLogRetentionDays"
+        case diagnosticLogRotationInterval = "DiagnosticLogRotationInterval"
         case useOptionClickToShowAlwaysHiddenSection = "UseOptionClickToShowAlwaysHiddenSection"
         case useDoubleClickToShowAlwaysHiddenSection = "UseDoubleClickToShowAlwaysHiddenSection"
         case enableMenuBarItemOverflow = "EnableMenuBarItemOverflow"

--- a/ThawTests/Shared/DiagnosticLoggerFileTests.swift
+++ b/ThawTests/Shared/DiagnosticLoggerFileTests.swift
@@ -11,8 +11,8 @@ import Testing
 @testable import Thaw
 
 /// Covers the on-disk half of ``DiagnosticLogger``: attaching to a file,
-/// appending instead of truncating, closing, and the five-file rotation that
-/// keeps a user's `~/Library/Logs/Thaw` directory from growing without bound.
+/// appending instead of truncating, closing, and the retention pass that keeps
+/// a user's `~/Library/Logs/Thaw` directory from growing without bound.
 ///
 /// This is the mechanism behind user-submitted diagnostics and it is shared
 /// verbatim with the MenuBarItemService XPC target, so the rotation and
@@ -67,19 +67,39 @@ struct DiagnosticLoggerFileTests {
         }
     }
 
-    @Test("Re-attaching to the same file appends a second header instead of truncating")
-    func reattachingAppends() async throws {
+    @Test("Attaching to a file that already holds lines appends instead of truncating")
+    func attachingAppendsToAnExistingFile() async throws {
+        try await withTemporaryLogDirectory { tmp in
+            let file = tmp.appendingPathComponent("thaw.log")
+            // Stands in for the other process having written first: two
+            // processes share one file, so opening it must not lose what is
+            // already there.
+            try Data("written by the other process\n".utf8).write(to: file)
+
+            DiagnosticLogger.shared.attachToFile(at: file)
+
+            let text = contents(of: file)
+            #expect(text.contains("written by the other process"))
+            #expect(text.contains("Thaw Diagnostic Log"))
+        }
+    }
+
+    @Test("Re-attaching to the file already open changes nothing")
+    func reattachingToTheSameFileIsANoOp() async throws {
         try await withTemporaryLogDirectory { tmp in
             let file = tmp.appendingPathComponent("thaw.log")
 
             DiagnosticLogger.shared.attachToFile(at: file)
             DiagnosticLogger.shared.attachToFile(at: file)
 
-            // Two processes share one file, so the second open must not lose
-            // what the first one wrote.
+            // The app re-sends the current path on every rotation and on retry,
+            // so the same path arrives repeatedly. Reopening it would stamp a
+            // second header and a stop footer into the file being written, which
+            // reads as if logging had restarted mid-capture.
             let text = contents(of: file)
-            #expect(occurrences(of: "Thaw Diagnostic Log", in: text) == 2)
-            #expect(occurrences(of: "Diagnostic logging stopped", in: text) == 1)
+            #expect(occurrences(of: "Thaw Diagnostic Log", in: text) == 1)
+            #expect(occurrences(of: "Diagnostic logging stopped", in: text) == 0)
+            #expect(DiagnosticLogger.shared.currentLogFile == file)
         }
     }
 
@@ -171,51 +191,67 @@ struct DiagnosticLoggerFileTests {
         }
     }
 
-    // MARK: Rotation
+    // MARK: Retention
 
-    @Test("Opening a log file prunes the directory down to the five newest logs")
-    func rotationKeepsTheFiveNewestLogs() async throws {
+    /// Pins the retention policy for one test.
+    ///
+    /// The policy lives on the shared logger, so a value left behind by another
+    /// suite would otherwise decide the outcome here.
+    private func useRetentionPolicy(retentionDays: Int, maxFileCount: Int = 50) {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.retentionDays = retentionDays
+        policy.maxFileCount = maxFileCount
+        DiagnosticLogger.shared.setRotationPolicy(policy)
+    }
+
+    @Test("Opening a log file prunes the logs that fell out of the retention window")
+    func retentionDropsLogsPastTheWindow() async throws {
         try await withTemporaryLogDirectory { tmp in
+            useRetentionPolicy(retentionDays: 2)
+            // Seeds are aged one day apart, oldest first: seed-0 is 7 days old,
+            // seed-6 is one day old.
             let seeded = try seedAgedLogFiles(count: 7, in: tmp)
             let file = tmp.appendingPathComponent("current.log")
 
             DiagnosticLogger.shared.attachToFile(at: file)
 
-            let pruned = await waitUntil { logFileNames(in: tmp).count == 5 }
-            #expect(pruned, "rotation left \(logFileNames(in: tmp).count) log files")
+            // Only the one-day-old seed is still inside a two-day window, and
+            // the file just opened is never a candidate.
+            let pruned = await waitUntil { logFileNames(in: tmp).count == 2 }
+            #expect(pruned, "retention left \(logFileNames(in: tmp).count) log files")
 
-            // The file just opened is the newest, so it survives alongside the
-            // four youngest seeds; the three oldest seeds are the casualties.
             let survivors = Set(logFileNames(in: tmp))
             #expect(survivors.contains("current.log"))
-            #expect(survivors.isSuperset(of: seeded.suffix(4)))
-            #expect(survivors.isDisjoint(with: seeded.prefix(3)))
+            #expect(survivors.contains(seeded[6]))
+            #expect(survivors.isDisjoint(with: seeded.prefix(6)))
         }
     }
 
-    @Test("Rotation only prunes log files and leaves other files alone")
-    func rotationIgnoresNonLogFiles() async throws {
+    @Test("Retention only prunes log files and leaves other files alone")
+    func retentionIgnoresNonLogFiles() async throws {
         try await withTemporaryLogDirectory { tmp in
+            useRetentionPolicy(retentionDays: 2)
             try seedAgedLogFiles(count: 7, in: tmp)
             let keepsake = tmp.appendingPathComponent("notes.txt")
             try Data("keep me".utf8).write(to: keepsake)
 
             DiagnosticLogger.shared.attachToFile(at: tmp.appendingPathComponent("current.log"))
 
-            let pruned = await waitUntil { logFileNames(in: tmp).count == 5 }
-            #expect(pruned, "rotation left \(logFileNames(in: tmp).count) log files")
+            let pruned = await waitUntil { logFileNames(in: tmp).count == 2 }
+            #expect(pruned, "retention left \(logFileNames(in: tmp).count) log files")
             #expect(FileManager.default.fileExists(atPath: keepsake.path))
         }
     }
 
-    @Test("A directory holding five or fewer logs is left untouched")
-    func rotationLeavesASmallDirectoryAlone() async throws {
+    @Test("A directory whose logs are all inside the window is left untouched")
+    func retentionLeavesRecentLogsAlone() async throws {
         try await withTemporaryLogDirectory { tmp in
+            // Every seed is days old, but the window is a month wide.
+            useRetentionPolicy(retentionDays: 30)
             let seeded = try seedAgedLogFiles(count: 4, in: tmp)
 
             DiagnosticLogger.shared.attachToFile(at: tmp.appendingPathComponent("current.log"))
 
-            // Five files total is exactly the keep count, so nothing may go.
             // Give the write queue a chance to misbehave before asserting.
             let overPruned = await waitUntil(timeout: .milliseconds(500)) {
                 logFileNames(in: tmp).count < 5
@@ -225,15 +261,17 @@ struct DiagnosticLoggerFileTests {
         }
     }
 
-    @Test("One undeletable log does not stop rotation from pruning the rest")
-    func rotationContinuesPastAnUndeletableLog() async throws {
+    @Test("One undeletable log does not stop retention from pruning the rest")
+    func retentionContinuesPastAnUndeletableLog() async throws {
         try await withTemporaryLogDirectory { tmp in
+            useRetentionPolicy(retentionDays: 2)
+            // Ages run 8 days (seed-0) down to one day (seed-7).
             let seeded = try seedAgedLogFiles(count: 8, in: tmp)
 
-            // Rotation walks the doomed files newest-first, so making the
+            // Retention walks the doomed files newest-first, so making the
             // *first* casualty undeletable is what proves the loop carries on:
-            // the three older ones are only reached after the failure.
-            let stubborn = tmp.appendingPathComponent("seed-3.log")
+            // the older ones are only reached after the failure.
+            let stubborn = tmp.appendingPathComponent("seed-6.log")
             try FileManager.default.setAttributes([.immutable: true], ofItemAtPath: stubborn.path)
             defer {
                 // The flag has to go before the enclosing helper deletes `tmp`,
@@ -243,17 +281,18 @@ struct DiagnosticLoggerFileTests {
 
             DiagnosticLogger.shared.attachToFile(at: tmp.appendingPathComponent("current.log"))
 
-            // Five keepers plus the one that refused to go. Before the per-file
-            // error handling this settled at nine: the failure aborted the loop
-            // and every remaining deletion was skipped.
-            let pruned = await waitUntil { logFileNames(in: tmp).count == 6 }
-            #expect(pruned, "rotation left \(logFileNames(in: tmp).count) log files")
+            // The one-day-old seed, the file just opened, and the one that
+            // refused to go. Without the per-file error handling this settles at
+            // nine: the failure aborts the loop and every later deletion is
+            // skipped.
+            let pruned = await waitUntil { logFileNames(in: tmp).count == 3 }
+            #expect(pruned, "retention left \(logFileNames(in: tmp).count) log files")
 
             let survivors = Set(logFileNames(in: tmp))
-            #expect(survivors.contains("seed-3.log"))
-            #expect(survivors.isDisjoint(with: seeded.prefix(3)))
-            #expect(survivors.isSuperset(of: seeded.suffix(4)))
+            #expect(survivors.contains("seed-6.log"))
+            #expect(survivors.contains(seeded[7]))
             #expect(survivors.contains("current.log"))
+            #expect(survivors.isDisjoint(with: seeded.prefix(6)))
         }
     }
 
@@ -268,12 +307,40 @@ struct DiagnosticLoggerFileTests {
                 .appendingPathComponent("nested", isDirectory: true)
                 .appendingPathComponent("thaw.log")
 
-            DiagnosticLogger.shared.attachToFile(at: file)
+            let attached = DiagnosticLogger.shared.attachToFile(at: file)
 
-            // `attachToFile` optimistically flips the flag on, so a failed open
-            // has to flip it back or the app would think it were logging.
+            // With no earlier segment to fall back on there is nothing to write
+            // to, so logging has to stay off rather than look enabled.
+            #expect(!attached)
             #expect(!DiagnosticLogger.shared.isEnabled)
             #expect(DiagnosticLogger.shared.currentLogFile == nil)
+        }
+    }
+
+    @Test("A failed attach keeps writing to the segment already open")
+    func failedAttachKeepsThePreviousFile() async throws {
+        try await withTemporaryLogDirectory { tmp in
+            let good = tmp.appendingPathComponent("good.log")
+            DiagnosticLogger.shared.attachToFile(at: good)
+
+            let blocker = tmp.appendingPathComponent("blocker")
+            try Data().write(to: blocker)
+            let unopenable = blocker
+                .appendingPathComponent("nested", isDirectory: true)
+                .appendingPathComponent("thaw.log")
+
+            let attached = DiagnosticLogger.shared.attachToFile(at: unopenable)
+
+            // Losing the open must not cost the lines still being written: the
+            // previous file stays, and the caller is told so it can retry.
+            #expect(!attached)
+            #expect(DiagnosticLogger.shared.isEnabled)
+            #expect(DiagnosticLogger.shared.currentLogFile == good)
+
+            let marker = "still writing after a failed attach"
+            DiagnosticLogger.shared.log(level: .info, category: "Test", message: marker)
+            let landed = await waitUntil { contents(of: good).contains(marker) }
+            #expect(landed, "the marker never reached the surviving log file")
         }
     }
 

--- a/ThawTests/Shared/DiagnosticLoggerTests.swift
+++ b/ThawTests/Shared/DiagnosticLoggerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import Foundation
 import Testing
 @testable import Thaw
 
@@ -110,5 +111,270 @@ struct DiagnosticLoggerLevelTests {
 
         #expect(rawValues.count == levels.count,
                 "All levels should have distinct raw values")
+    }
+}
+
+// MARK: - Retention Tests
+
+/// Covers which log files ``DiagnosticLogger/filesToPrune(_:retentionDays:maxCount:now:protected:)``
+/// selects for deletion.
+///
+/// The decision is pure — dates and URLs in, URLs out — so these run against
+/// paths that need not exist. Deleting the wrong file loses the log a user was
+/// about to attach to a bug report, so each rule is pinned separately.
+///
+/// Reads only: nothing here reaches the shared ``DiagnosticLogger`` or the file
+/// system, so the suite is safe to run in parallel with the rest.
+@Suite("Diagnostic log retention")
+struct DiagnosticLoggerRetentionTests {
+    private let directory = URL(fileURLWithPath: "/tmp/ThawLogsTests", isDirectory: true)
+
+    private func logFile(_ name: String) -> URL {
+        directory.appendingPathComponent(name)
+    }
+
+    private func daysAgo(_ days: Double, from now: Date) -> Date {
+        now.addingTimeInterval(-days * 86400)
+    }
+
+    @Test("A file older than the retention window is pruned, a newer one is kept")
+    func prunesFilesPastRetentionWindow() {
+        let now = Date()
+        let fresh = logFile("thaw_fresh.log")
+        let old = logFile("thaw_old.log")
+
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: fresh, created: daysAgo(0.5, from: now)),
+             (url: old, created: daysAgo(5, from: now))],
+            retentionDays: 2,
+            maxCount: 100,
+            now: now,
+            protected: []
+        )
+
+        #expect(stale == [old])
+    }
+
+    @Test("Protected files survive both the age limit and the count cap")
+    func neverPrunesProtectedFiles() {
+        let now = Date()
+        let current = logFile("thaw_current.log")
+        let previous = logFile("thaw_previous.log")
+
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: current, created: daysAgo(10, from: now)),
+             (url: previous, created: daysAgo(9, from: now))],
+            retentionDays: 2,
+            maxCount: 1,
+            now: now,
+            protected: [current, previous]
+        )
+
+        #expect(stale.isEmpty,
+                "The current and just-rotated segments may still have open descriptors")
+    }
+
+    @Test("Files beyond the count cap are pruned oldest first")
+    func enforcesCountCap() {
+        let now = Date()
+        let newest = logFile("thaw_1.log")
+        let middle = logFile("thaw_2.log")
+        let oldest = logFile("thaw_3.log")
+
+        // All three are well inside the retention window; only the cap applies.
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: newest, created: daysAgo(0.1, from: now)),
+             (url: middle, created: daysAgo(0.2, from: now)),
+             (url: oldest, created: daysAgo(0.3, from: now))],
+            retentionDays: 30,
+            maxCount: 2,
+            now: now,
+            protected: []
+        )
+
+        #expect(stale == [oldest])
+    }
+
+    @Test("Nothing is pruned while inside both limits")
+    func keepsFilesInsideBothLimits() {
+        let now = Date()
+
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: logFile("thaw_a.log"), created: daysAgo(0.1, from: now)),
+             (url: logFile("thaw_b.log"), created: daysAgo(0.2, from: now))],
+            retentionDays: 2,
+            maxCount: 100,
+            now: now,
+            protected: []
+        )
+
+        #expect(stale.isEmpty)
+    }
+
+    @Test("Everything unprotected goes when the cap is smaller than the protected set")
+    func prunesEverythingWhenProtectedFillsTheCap() {
+        let now = Date()
+        let current = logFile("thaw_current.log")
+        let spare = logFile("thaw_spare.log")
+
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: current, created: now),
+             (url: spare, created: daysAgo(0.1, from: now))],
+            retentionDays: 30,
+            maxCount: 1,
+            now: now,
+            protected: [current]
+        )
+
+        // The protected file alone fills the cap, so nothing else may stay —
+        // and the subtraction that works that out must not go negative.
+        #expect(stale == [spare])
+    }
+
+    @Test("Files of the same age are pruned in a stable order")
+    func breaksAgeTiesByPath() {
+        let now = Date()
+        let sameMoment = daysAgo(0.5, from: now)
+        let first = logFile("thaw_a.log")
+        let second = logFile("thaw_b.log")
+
+        // Only one of the two fits under the cap. Directory order must not
+        // decide which; the tie is broken by path, so `thaw_a.log` survives.
+        let stale = DiagnosticLogger.filesToPrune(
+            [(url: second, created: sameMoment), (url: first, created: sameMoment)],
+            retentionDays: 30,
+            maxCount: 1,
+            now: now,
+            protected: []
+        )
+
+        #expect(stale == [second])
+    }
+}
+
+// MARK: - Rotation Policy Tests
+
+/// Covers ``DiagnosticLogger/RotationPolicy/sanitized()``.
+///
+/// A policy reaches the MenuBarItemService target over XPC, and a build signed
+/// without a team identifier accepts messages from any local process, so these
+/// values are untrusted input. Left as they arrive they can delete every log or
+/// trap the arithmetic that decides what to keep.
+///
+/// Reads only: safe to run in parallel with the rest.
+@Suite("Diagnostic log rotation policy")
+struct DiagnosticLoggerRotationPolicyTests {
+    @Test("A retention of zero or less becomes a day")
+    func clampsRetentionToAtLeastOneDay() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.retentionDays = -5
+
+        // A negative retention would put the cutoff in the future, which reads
+        // as "every log is too old".
+        #expect(policy.sanitized().retentionDays == 1)
+    }
+
+    @Test("A file count of zero becomes one")
+    func clampsFileCountToAtLeastOne() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.maxFileCount = 0
+
+        #expect(policy.sanitized().maxFileCount == 1)
+    }
+
+    @Test("An extreme file count cannot survive to overflow the allowance")
+    func clampsExtremeFileCount() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.maxFileCount = .min
+
+        let sanitized = policy.sanitized()
+        #expect(sanitized.maxFileCount == 1)
+
+        // The value that used to trap: subtracting the protected count from it.
+        let stale = DiagnosticLogger.filesToPrune(
+            [],
+            retentionDays: sanitized.retentionDays,
+            maxCount: sanitized.maxFileCount,
+            now: Date(),
+            protected: [URL(fileURLWithPath: "/tmp/ThawLogsTests/thaw.log")]
+        )
+        #expect(stale.isEmpty)
+    }
+
+    @Test("A non-finite rotation interval turns scheduled rotation off")
+    func rejectsNonFiniteInterval() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.rotationInterval = .nan
+        #expect(policy.sanitized().rotationInterval == 0)
+
+        // Infinity is not finite either, so it means "never", not "always".
+        policy.rotationInterval = .infinity
+        #expect(policy.sanitized().rotationInterval == 0)
+    }
+
+    @Test("Sizes and intervals are held under their ceilings")
+    func clampsSizeAndInterval() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.maxFileSizeBytes = .max
+        policy.rotationInterval = .greatestFiniteMagnitude
+
+        let sanitized = policy.sanitized()
+        #expect(sanitized.maxFileSizeBytes == DiagnosticLogger.RotationPolicy.maxSizeBytes)
+        #expect(sanitized.rotationInterval == DiagnosticLogger.RotationPolicy.maxRotationInterval)
+    }
+
+    @Test("A policy the settings UI can produce passes through untouched")
+    func leavesReasonableValuesAlone() {
+        var policy = DiagnosticLogger.RotationPolicy()
+        policy.maxFileSizeBytes = 10 * 1024 * 1024
+        policy.rotationInterval = 3600
+        policy.retentionDays = 2
+        policy.maxFileCount = 50
+
+        #expect(policy.sanitized() == policy)
+    }
+}
+
+// MARK: - File Name Tests
+
+/// Covers the collision handling in
+/// ``DiagnosticLogger/uniqueLogFileURL(in:baseName:exists:)``.
+///
+/// Log file names carry a second-granular timestamp, so rotating twice inside
+/// one second would otherwise reuse a name and append to a segment already in
+/// use. Existence is injected, so these run without touching the file system.
+///
+/// Reads only: safe to run in parallel with the rest.
+@Suite("Diagnostic log file names")
+struct DiagnosticLoggerFileNameTests {
+    private let directory = URL(fileURLWithPath: "/tmp/ThawLogsTests", isDirectory: true)
+    private let baseName = "thaw_2026-06-07_09-48-52"
+
+    @Test("An unused name is taken as is")
+    func usesBaseNameWhenFree() {
+        let url = DiagnosticLogger.uniqueLogFileURL(in: directory, baseName: baseName) { _ in false }
+
+        #expect(url.lastPathComponent == "thaw_2026-06-07_09-48-52.log")
+    }
+
+    @Test("A taken name gains a numeric suffix")
+    func appendsSuffixOnCollision() {
+        let taken: Set<URL> = [directory.appendingPathComponent("\(baseName).log")]
+
+        let url = DiagnosticLogger.uniqueLogFileURL(in: directory, baseName: baseName) { taken.contains($0) }
+
+        #expect(url.lastPathComponent == "thaw_2026-06-07_09-48-52_2.log")
+    }
+
+    @Test("The suffix keeps climbing until a name is free")
+    func incrementsSuffixUntilFree() {
+        let taken: Set<URL> = [
+            directory.appendingPathComponent("\(baseName).log"),
+            directory.appendingPathComponent("\(baseName)_2.log"),
+        ]
+
+        let url = DiagnosticLogger.uniqueLogFileURL(in: directory, baseName: baseName) { taken.contains($0) }
+
+        #expect(url.lastPathComponent == "thaw_2026-06-07_09-48-52_3.log")
     }
 }


### PR DESCRIPTION
# Summary

Diagnostic logging writes one file per session, and that file grows until the session ends. A long session leaves a log that is too large to attach to a bug report, which is what #732 asks about.

This adds rotation. A new file starts once the current one reaches a size limit, and optionally on a schedule. Retention now keeps files by age instead of keeping a fixed five.

This is the work from #738, rebuilt against `release/v2.1.0` as requested there. The old branch no longer applied: the base moved on by 227 commits, the tests moved to Swift Testing, and the XPC protocol lost its single-window `sourcePID` request.

## Linked issue (required)

Closes: #732

## PR Type

- [x] Feature

## Area

- [x] settings

## Does this PR introduce a breaking change?

- [x] No

The app and the bundled XPC service ship together, so the `configureLogging` payload change cannot meet an older peer. Settings read back with `decodeIfPresent` and their defaults, so existing preferences load unchanged.

## What is the new behavior?

Rotation starts a new log file once the current one reaches 10 MB, and can also rotate hourly or daily. Retention deletes files older than two days and never keeps more than 50, replacing the previous "keep the five newest". All three are settings, in Advanced under Diagnostics.

The app owns rotation, because only the process that mints a file may mint the next one. Both processes still prune the directory they share, so the retention policy now travels to `MenuBarItemService` along with the log path. That path became optional: `nil` turns the service's file logging off, which also fixes a smaller bug where toggling diagnostics after launch never reached the service.

One sender in `MenuBarItemService.Connection` handles every reason the service needs telling: a rotation, a settings change, a failed push, or a dropped session. It reads the current path when it sends and keeps a single request in flight, so a late notification cannot leave the two processes on different files. A failed push is retried, and the service answers with an error when it cannot open the file rather than reporting success it did not achieve.

A few things came out of review while porting:

Log files are now created with `0o600` and `O_NOFOLLOW`. They carry window titles and process names, so world-readable was the wrong default.

Rotation opens the new file before closing the old one. If the open fails, the current segment keeps taking writes instead of logging stopping.

A policy that arrives over XPC is clamped before use. A build signed without a team identifier accepts messages from any local process, and an unchecked policy there could delete every log (negative retention puts the cutoff in the future) or trap the arithmetic that decides what to keep (`Int.min`).

Scheduled rotation measures elapsed time with `ContinuousClock`, so changing the system clock does not skip or delay it.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below).
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles, `dependency-sca` is green.

The branch targets `release/v2.1.0`, as asked in #738.

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS'` (2547 tests in 324 suites, all passing)
- `xcodebuild test ... -only-testing:ThawTests/DiagnosticLoggerFileTests -only-testing:ThawTests/DiagnosticLoggerRetentionTests`

## Known limitations / follow-ups

Five existing tests in `DiagnosticLoggerFileTests` changed, because the behavior they pin changed on purpose:

The four rotation tests pinned "prune down to the five newest". They now pin the age based window, using the same seeded files, and one of them still covers the case where an undeletable file must not stop the rest of the prune.

"Re-attaching to the same file appends a second header" is now two tests. Attaching to a file that already holds lines still appends rather than truncating, but re-attaching to the file already open does nothing. The app re-sends the current path on rotation and on retry, and reopening it would stamp a second header and a stop footer into the file being written.

Deliberately out of scope:

The new settings are not carried in profiles. #899 removed `enableDiagnosticLogging` from the snapshot because a profile switch turned logging off in the middle of the capture it was meant to record, and these settings have the same problem.

New UI strings are not added to `Localizable.xcstrings`. Running the extraction here rewrites the whole catalog, which seemed worse than leaving three strings for your own pass.

The path check in `Listener` is still open to TOCTOU: it resolves and prefix-checks the path before the open, and `O_NOFOLLOW` only covers the last component. Closing that properly means restricting the request to a basename and opening with `openat` against a directory descriptor. It is the existing check rather than something this PR introduces, so it seemed like a separate change.

## Other information

The controls sit in Advanced under Diagnostics, next to the toggle they belong to, since that is where the section lives on this branch. If they belong in the Tools tab from your screenshot in #738, they should move with the section rather than separately.

Verified by build and the full test suite. The settings layout was also checked in a local run of an earlier revision of this work.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790235428&installation_model_id=431242&pr_number=974&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F974&signature=e73e3d25dc723a2d8f774cd8d629e50a1502d781d9f8675bcda8124946904d81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->