### PR TITLE
fix(settings): make the diagnostics values editable and annotate every row

### DIFF
--- a/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AdvancedSettingsPane.swift
@@ -102,25 +102,43 @@ struct AdvancedSettingsPane: View {
             }
 
             if settings.enableDiagnosticLogging {
-                LabeledContent("Maximum log file size") {
-                    Stepper(value: $settings.diagnosticLogMaxSizeMB, in: 1 ... 100) {
-                        Text("\(settings.diagnosticLogMaxSizeMB) MB")
-                    }
-                    .fixedSize()
+                LabeledContent("Maximum log file size (MB)") {
+                    numberField(
+                        "Maximum log file size in megabytes",
+                        value: $settings.diagnosticLogMaxSizeMB,
+                        bounds: Self.logSizeBounds
+                    )
                 }
                 .annotation("Start a new log file once the current one reaches this size.")
 
-                LabeledContent("Keep logs for") {
-                    Stepper(value: $settings.diagnosticLogRetentionDays, in: 1 ... 30) {
-                        Text("^[\(settings.diagnosticLogRetentionDays) day](inflect: true)")
-                    }
-                    .fixedSize()
+                LabeledContent("Keep logs for (days)") {
+                    numberField(
+                        "Days to keep log files",
+                        value: $settings.diagnosticLogRetentionDays,
+                        bounds: Self.logRetentionBounds
+                    )
+                }
+                .annotation {
+                    Text(
+                        """
+                        Delete older log files after this many days, or sooner if more than 50 pile up. \
+                        The file being written is always kept.
+                        """
+                    )
                 }
 
                 IcePicker("Rotate by time", selection: $settings.diagnosticLogRotationInterval) {
                     ForEach(LogRotationInterval.allCases) { interval in
                         Text(interval.localized).tag(interval)
                     }
+                }
+                .annotation {
+                    Text(
+                        """
+                        Also start a new log file once the current one has been open for an hour or a day. \
+                        The size limit still applies.
+                        """
+                    )
                 }
             }
 
@@ -148,6 +166,52 @@ struct AdvancedSettingsPane: View {
             }
         }
     }
+
+    /// A number the user can either type or step through.
+    ///
+    /// A value shown next to a stepper as plain text reads as something the app
+    /// filled in and the user cannot change, and clicking to the far end of a
+    /// range is slow. The field carries the value, the stepper nudges it, and
+    /// both answer to the same hidden label so VoiceOver names them.
+    private func numberField(
+        _ label: LocalizedStringKey,
+        value: Binding<Int>,
+        bounds: NumberBounds
+    ) -> some View {
+        HStack(spacing: 6) {
+            TextField(label, value: value, formatter: bounds.formatter)
+                .labelsHidden()
+                .textFieldStyle(.roundedBorder)
+                .frame(width: 52)
+                .multilineTextAlignment(.trailing)
+                .monospacedDigit()
+
+            Stepper(label, value: value, in: bounds.range)
+                .labelsHidden()
+                .controlSize(.small)
+        }
+    }
+
+    /// A stepper's range together with the formatter that holds typed input
+    /// inside it, so the two cannot drift apart.
+    private struct NumberBounds {
+        let range: ClosedRange<Int>
+        let formatter: NumberFormatter
+
+        init(_ range: ClosedRange<Int>) {
+            self.range = range
+
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .none
+            formatter.allowsFloats = false
+            formatter.minimum = NSNumber(value: range.lowerBound)
+            formatter.maximum = NSNumber(value: range.upperBound)
+            self.formatter = formatter
+        }
+    }
+
+    private static let logSizeBounds = NumberBounds(1 ... 100)
+    private static let logRetentionBounds = NumberBounds(1 ... 30)
 
     private var displayedSearchSectionNames: [MenuBarSection.Name] {
         settings.searchSectionOrder.filter { name in


### PR DESCRIPTION
# Summary

Follow-up to #974, which added the three diagnostics settings. Running the merged build turned up three things about how they present.

The values were static text inside `LabeledContent`, which macOS draws in the secondary color. That styling is meant for a value the user cannot change, so "10 MB" and "2 days" looked disabled. The stepper arrows also rendered before the value they belong to, and only the first of the three rows had a hint under it.

There is no separate issue for this. Happy to open one if you would rather have it tracked.

## Linked issue (required)

Closes: N/A

## PR Type

- [x] Bug fix
- [x] Enhancement

## Area

- [x] settings

## Does this PR introduce a breaking change?

- [x] No

Presentation only. The settings, their keys, and their defaults are untouched.

## What is the new behavior?

Each number now sits in a text field with a compact stepper beside it, the same shape `AutomationSettingsPane` already uses for the hook timeout. The value is editable, which is what a stepper implies, and reaching 100 MB no longer means clicking ninety times. A `NumberFormatter` keeps a typed value inside the range the stepper allows, and the range and the formatter are built from one declaration so they cannot drift apart.

Units moved into the row label, so it reads "Keep logs for (days)" with a bare number in the field. Putting the unit next to the value would have meant concatenating a plural, which does not survive translation.

Both the field and the stepper now carry the row's label, hidden with `labelsHidden()`, so VoiceOver has something to announce. Previously the stepper's label was an `EmptyView`.

The two rows that had no hint have one, and the retention hint mentions the 50 file cap, since a file inside the retention window can still be pruned when the directory grows past it. The schedule hint no longer suggests that the interval always fires before the size limit, because either can come first, and the interval runs from the moment the file was opened rather than on a calendar.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below).
- [ ] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles, `dependency-sca` is green.

No tests were added: the change is layout and labeling, and the pane has no snapshot coverage to extend. The behavior underneath it is already covered by the suites from #974.

The branch targets `release/v2.1.0`, same as #974.

Test commands run:

- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS'`
- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -configuration Debug -destination 'platform=macOS'` (2548 tests in 324 suites, all passing)

## Known limitations / follow-ups

The three new UI strings are still not in `Localizable.xcstrings`, for the same reason as last time: running the extraction here rewrites the whole catalog.

The field width is fixed at 52 points, which fits three digits. Nothing in the current ranges needs more.

## Other information

Checked in a local build: the values are editable, take a typed number, and stay inside their range.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790237866&installation_model_id=431242&pr_number=976&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F976&signature=64c4f4696cda1702fd506dc31182b35078a0d2efde3c2d652386968ee0935590"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->