### PR TITLE
fix: parked-divider recovery, editor drag persistence, and placeholder re-resolve (#978, #980, #923, #981, #983)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and the Sparkle appcast, unless overridden with the `release_notes` input.
 
 Please report issues at [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
 
-Hey everyone. Thaw 2.0 rebuilds the app around macOS 26 (Tahoe): Liquid Glass throughout, a redesigned settings surface, an automation layer built on `thaw://`, and a menu bar pipeline rewritten around item identity, layout persistence, and knowing when to leave the bar alone. The cycle ran sixteen releases: `1.3.0-beta.1` shipped Settings Profiles in April, fifteen betas followed, and five release candidates carried the work home. Nearly everything after beta.15 came out of field logs, real menu bars misbehaving in ways no test caught. This entry walks the run by theme. The detailed per-fix notes live in the RC entries in the [full changelog](https://github.com/thaw-app/Thaw/blob/development/CHANGELOG.md).
+Hey everyone. Thaw 2.0 rebuilds the app around macOS 26 (Tahoe): Liquid Glass throughout, a redesigned settings surface, an automation layer built on `thaw://`, and a menu bar pipeline rewritten around item identity, layout persistence, and knowing when to leave the bar alone. The cycle ran twenty-two releases: `1.3.0-beta.1` shipped Settings Profiles in April, fifteen betas followed, and six release candidates carried the work home. Nearly everything after beta.15 came out of field logs, real menu bars misbehaving in ways no test caught. This entry walks the run by theme. The detailed per-fix notes live in the RC entries in the [full changelog](https://github.com/thaw-app/Thaw/blob/development/CHANGELOG.md).
 
 ---
 ### Upgrade notes
@@ -178,10 +178,7 @@ If you find Thaw useful and want to support its development:
 - Patreon: https://www.patreon.com/c/stonerl
 - PayPal: https://www.paypal.me/tonifoerster
 
-## [2.0.0-unreleased.rc]
-
-<!-- Rename this heading to the real tag before cutting the release:
-     release.yml ships only the section whose heading matches the tag. -->
+## [2.0.0-rc-unreleased]
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,26 +7,62 @@ The `release.yml` workflow reads the section matching the release tag
 (`## [tag]`) and uses it as the release notes for both the GitHub Release
 and the Sparkle appcast, unless overridden with the `release_notes` input.
 
-## [Unreleased]
-
 ## [2.0.0]
 
-Please report issues at
-[github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
+Please report issues at [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
 
-Hey everyone. Thaw 2.0 rebuilds the app around macOS 26 (Tahoe): Liquid
-Glass throughout, a redesigned settings surface, an automation layer built
-on `thaw://`, and a menu bar pipeline rewritten around item identity,
-layout persistence, and knowing when to leave the bar alone. The cycle is
-sixteen releases long: `1.3.0-beta.1` shipped Settings Profiles in April,
-fifteen betas followed it, and six release-candidate builds carried the
-work home. Nearly everything after beta.15 came out of field logs — real
-menu bars misbehaving in ways no test caught. This entry walks the whole
-run by theme; the RC sections below keep the detailed per-fix notes.
+Hey everyone. Thaw 2.0 rebuilds the app around macOS 26 (Tahoe): Liquid Glass throughout, a redesigned settings surface, an automation layer built on `thaw://`, and a menu bar pipeline rewritten around item identity, layout persistence, and knowing when to leave the bar alone. The cycle ran sixteen releases: `1.3.0-beta.1` shipped Settings Profiles in April, fifteen betas followed, and five release candidates carried the work home. Nearly everything after beta.15 came out of field logs, real menu bars misbehaving in ways no test caught. This entry walks the run by theme. The detailed per-fix notes live in the RC entries in the [full changelog](https://github.com/thaw-app/Thaw/blob/development/CHANGELOG.md).
+
+---
+### Upgrade notes
+
+1. **From 1.x:** Thaw 2.0 requires macOS 26. On macOS 14 or 15 you stay on
+   `1.3.0-beta.1` (#427).
+2. **From any 2.0 RC:** in-place Sparkle update. Failure-ledger marks clear
+   on build change, and an explicit `defaults write` override still beats
+   any shipped default.
+3. **Per-display spacing:** the schema changed during the beta cycle; older
+   profiles fall back to the active display's value rather than failing to
+   load.
+4. **Update feed:** new installs use `thaw-app/updates`; existing installs
+   on the legacy stonerl feed keep receiving the mirrored appcast.
+
+Known issues carried from the RCs are listed at the end of each RC entry in
+the [full changelog](https://github.com/thaw-app/Thaw/blob/development/CHANGELOG.md).
+
+### What's next
+
+**2.1.0 is on its way to the beta channel.** It adds:
+
+- Item groups that stay together and move as one unit.
+- Item triggers that run scripts and react to Focus, a geofence, camera or mic use, or a script's own result (#735, #965).
+- Zen mode, per-Space profiles, and per-Space appearance overrides (#958,
+  #960).
+- [Simple Mode](https://github.com/orgs/thaw-app/discussions/550), a Tools pane, spacer items you create yourself, and a standalone layout editor.
+- A hotkey for automatic rehiding (#665), a Thaw Bar with its own shape and tint, and one Per display section in place of the repeated blocks.
+- Hidden icons that refresh at the slider rate (#942) and diagnostic logs that rotate by size and time (#974).
+
+Screen Recording also becomes optional in practice. Items with no capture draw their owning app's icon, so the Thaw Bar, the menu bar layout pane, and Search work with Accessibility alone instead of refusing to draw.
+
+**Thaw 3.0.0 brings macOS 27 support**, on the nightly / alpha channel, which
+you can select once you are on macOS 27. Thaw 3.0 is a rebuilt menu bar core. It adds:
+
+- A quick-edit panel you summon with a hotkey.
+- Hover spotlighting, so a search result lights up the item in the bar itself.
+- A panel that descends from the notch with media transport.
+- Control Center widgets, App Intents for Shortcuts, and `thawctl` as a headless
+  CLI.
+
+**Full Changelog**: https://github.com/thaw-app/Thaw/compare/1.3.0-beta.1...2.0.0
+
+<p align="center">
+  <a href="https://www.raycast.com/diazdesandi/thaw"><img alt="Works with Raycast" src="https://raw.githubusercontent.com/thaw-app/brand-assets/main/badges/works-with-raycast.svg" height="36" /></a>
+  <a href="https://getdroppy.app/"><img alt="Works with Droppy" src="https://raw.githubusercontent.com/thaw-app/brand-assets/main/badges/works-with-droppy.svg" height="36" /></a>
+</p>
 
 ---
 
-### Highlights
+### Features
 
 #### Built for macOS 26
 
@@ -38,7 +74,7 @@ run by theme; the RC sections below keep the detailed per-fix notes.
 
 The feature that started the cycle, from `1.3.0-beta.1`, implemented by @nightah:
 
-- Save your entire Thaw configuration as a profile and switch instantly — create, duplicate, rename, and delete profiles; import and export them for backup or sharing; update an existing profile with the current layout, configuration, or both.
+- Save your entire Thaw configuration as a profile and switch instantly: create, duplicate, rename, and delete profiles; import and export them for backup or sharing; update an existing profile with the current layout, configuration, or both.
 - Display Auto-Switch applies a display's assigned profile when you connect it.
 - Focus Filter integration switches profiles as Focus modes activate and restores the previous one after.
 - Profile hotkeys switch between favourites from the keyboard.
@@ -57,34 +93,38 @@ The feature that started the cycle, from `1.3.0-beta.1`, implemented by @nightah
 
 - Configurable background and shape tint: none, solid, or gradient with light/dark variants, a Regular/Clear glass picker backed by `NSGlassEffectView`, borders, shadows, and opacity sliders. Tints render behind menu bar items at user-chosen opacity.
 - Adaptive modes sample the wallpaper color behind the bar per display, cache colors before sleep, restore them on wake without a white flash, and stagger recapture for slow external displays until the color settles.
-- The `.notch` shape kind splits the background at the physical notch, with a notch margin slider (0–15 px) and four-corner end-cap control; it behaves as full width on displays without a notch.
+- The `.notch` shape kind splits the background at the physical notch, with a margin slider (0 to 15 px) and four-corner end-cap control; it behaves as full width on displays without a notch.
 - Per-display menu bar spacing applies dynamically, preserves settings for disconnected displays, skips the full relaunch when only resolution changed (#551), warns before spacing relaunches with the choice saved per profile (#691), prompts before first apply, and falls back to a global template.
 
 #### Thaw Bar & IceBar
 
-- Horizontal, vertical, and grid layouts; left/right alignment options; panel resizing that follows its content; pill shapes that match the container; grid columns with per-column max widths.
-- Independent shape and border settings for the overlay versus Thaw Bar (#248), and a per-display option to route only the always-hidden section to Thaw Bar (#751).
+- Horizontal, vertical, and grid layouts, left/right alignment options, panel resizing that follows its content, pill shapes that match the container, and grid columns with per-column max widths.
+- Independent shape and border settings for the overlay versus Thaw Bar (#248), plus a per-display option to route only the always-hidden section to Thaw Bar (#751).
 - Item reveal survives CPU load, a grace period stops the "no items" flash on display changes, and the live window ID is re-checked after sleep.
 - Icon foreground colors adapt to each screen's menu bar background, including notched MacBooks and secondary displays.
 
+---
+
+### Reliability
+
 #### Item identity & restoration
 
-- Section restoration follows one deterministic path — baseIdentifier match to saved order, else macOS placement — replacing the namespace fallbacks that pulled unsaved items visible on restart. Blocked items are skipped instead of forced, and placed items stop drifting back into the new-items section.
+- Section restoration follows one deterministic path (baseIdentifier match to saved order, else macOS placement), replacing the namespace fallbacks that pulled unsaved items visible on restart. Blocked items are skipped instead of forced, and placed items stop drifting back into the new-items section.
 - Startup settling waits on source-PID resolution rather than timers, auto-relocation is suppressed while settling runs, and stale PID resolution can no longer mis-namespace items after cmd-drag moves.
 - A serialized cache gate prevents concurrent rebuild races, and lightweight 60-second polling catches late-registering items from background-only apps that never become frontmost.
 - The item cache re-checks after every app launch so late arrivals sort into place, confirms stability across two reads, and keeps `displayID` handling off the main thread.
-- LayoutReconciler consolidated the scattered icon-restore paths into one phase-based orchestrator with deferred post-apply refreshes and chevron position persistence.
+- LayoutReconciler consolidates the scattered icon-restore paths into one phase-based orchestrator with deferred post-apply refreshes and chevron position persistence.
 - Menu bar height queries lost the `-1` sentinel that poisoned the height cache, and item bounds verify against the window server so temporary system items (recording indicators, mic, camera) leave no stale ghosts.
 
-#### Control Center–hosted items
+#### Control Center-hosted items
 
 - MarkerPairResolver identifies proxies hosted by Control Center (Little Snitch among them) through width-matched marker windows.
-- On single-display Macs a headless virtual display forces marker windows to publish, resolving those widgets to their real owners (#643); the phantom display was later hardened to 640×480 off-main, held briefly, with a one-strike blacklist (#661), and it never appears in Thaw's own display enumeration. Orphans stay put — they are never relocated.
+- On single-display Macs a headless virtual display forces marker windows to publish, resolving those widgets to their real owners (#643). The phantom display was later hardened to 640×480 off-main, held briefly, with a one-strike blacklist (#661), and it never appears in Thaw's own display enumeration. Orphans stay put and are never relocated.
 - Title-offset items (AirBuddy, SpamSieve, Cotypist) resolve by corroborated title with a width backstop, system status-item clones are excluded regardless of namespace (#662), and generic slots stay unresolved for the marker pass rather than guessing (#690).
 
 #### Notch overflow
 
-- Items that would hide behind the notch on MacBook displays are properly managed, ejected to Thaw Bar instead of lost (from `1.3.0-beta.1`).
+- Items that would hide behind the notch on MacBook displays are managed instead of lost, ejected to Thaw Bar (since `1.3.0-beta.1`).
 - Overflow budgeting stopped double-counting spacing that ejected correctly-placed profile items at default settings, runs only against settled geometry (#681), and keeps the visible control item in place during ejection.
 
 #### Interaction & everyday fixes
@@ -96,12 +136,18 @@ The feature that started the cycle, from `1.3.0-beta.1`, implemented by @nightah
 - The search panel keeps its text between openings if asked, regains focus from the hotkey, and lets sections reorder and filter; layout-bar drags land across sections cleanly without false move alerts.
 - Settings gained sidebar auto-fit, freed window sizing, per-pane polish, hidden dependent toggles when a section is disabled, and an option to disable icon refresh entirely (0 FPS).
 
-#### Performance, memory & platform
+The headline of the RC cycle was reliability: deterministic ordering with stable identities replaced the drift that let saved layouts scramble, reorder storms are bounded instead of endless, persist gates stop transient states from being written as user intent, and control-item pairing, notch overflow budgeting, scan cost, name memory, and divider recovery were rebuilt from field logs. Cold-start restore works, the 47 GiB memory growth is gone, hidden previews render, and the bar stops repairing itself into collapse. Details live in the RC entries in the [full changelog](https://github.com/thaw-app/Thaw/blob/development/CHANGELOG.md).
+
+---
+
+### Platform
+
+#### Performance, memory & engineering
 
 - Swift strict concurrency landed in beta.3 and deepened to Swift 6.2 with MainActor default isolation on the app target; locks migrated to `OSAllocatedUnfairLock`.
-- ScreenCaptureKit replaced the SkyLight capture paths that leaked; the XPC item service answers one batch request instead of 40–64 concurrent per-window calls, which ended the jetsam kills; wallpaper capture went away entirely.
+- ScreenCaptureKit replaced the SkyLight capture paths that leaked; the XPC item service answers one batch request instead of 40 to 64 concurrent per-window calls, which ended the jetsam kills; wallpaper capture went away entirely.
 - The image cache got an LRU/concurrency overhaul with lossless disk keys, retain cycles in live refresh were closed, duplicate entries after reconnect removed, and caches rebuild on display connect/disconnect.
-- Icon refresh normalized onto one grid — off, or `1/n` seconds for integer n in 1…30.
+- Icon refresh normalized onto one grid: off, or `1/n` seconds for integer n in 1…30.
 
 #### Distribution, security & localization
 
@@ -109,17 +155,11 @@ The feature that started the cycle, from `1.3.0-beta.1`, implemented by @nightah
 - OSV dependency scanning gates releases, CodeQL analysis runs in CI, SonarCloud findings were cleared, explicit Xcode versions pin reproducible builds, and the project holds OpenSSF Best Practices Gold.
 - Crowdin-driven localization with plural-aware strings and separated copy strings for cleaner translation; the tour ships complete in Spanish.
 
-#### Release-candidate reliability work
-
-This was the headline of the RC cycle — deterministic ordering with stable identities replaced the drift that let saved layouts scramble; reorder storms are bounded instead of endless; persist gates stop transient states from being written as user intent; control-item pairing, notch overflow budgeting, scan cost, name memory, and divider recovery were rebuilt from field logs. Cold-start restore works, the 47 GiB memory growth is gone, hidden previews render, and the bar stops repairing itself into collapse. Details live in the RC sections below.
-
 ---
 
 ### Contributors
 
-Thaw 2.0 was built by Toni Förster (@stonerl), René Jiménez
-(@diazdesandi), and Amir Zarrinkafsh (@nightah), with contributions,
-reports, diagnostics, translations, and patient testing from:
+Thaw 2.0.0 was built by Toni Förster (@stonerl), René Jiménez (@diazdesandi), and Amir Zarrinkafsh (@nightah), with contributions, reports, diagnostics, translations, and patient testing from:
 
 @aliaskar-rockeater · @alvst · @andredlng · @auspic7 · @beantownbytes · @billchirico · @bpresles · @brucemakes012 · @bytepl · @CamilleGuillory · @cbguder · @danielhopkins · @davidnichols-ops · @Daventure91 · @eli-yip · @exsesx · @gitmichaelqiu · @howardhey · @hxu · @JamesLautner · @jamesyc · @Jizzy015 · @kn666 · @kylewhirl · @lathe-agent-oa · @looseboy · @lucifercraig12345-create · @MashnoorKek · @nk-tedo-001 · @SAY-5 · @ShiroKSH · @Skyearn · @slatlasdev · @stu-carter · @subway-jack · @t4sh · @TheBenMeadows · @VailElla · @volcbs · @warmup72 · @wizaard88 · @yoodu · @YuriNachos · @ZeterMordio · @Zophiekat
 
@@ -128,18 +168,6 @@ and every translator working through Crowdin.
 Thank you. This release would not exist without you.
 
 ---
-
-### Upgrade notes
-
-1. **From 1.x:** Thaw 2.0 requires macOS 26. On macOS 14 or 15 you stay on `1.3.0-beta.1` (#427).
-2. **Per-display spacing:** the schema changed during the beta cycle; older profiles fall back to the active display's value rather than failing to load.
-3. **From any 2.0 RC:** in-place Sparkle update. Failure-ledger marks clear on build change, and an explicit `defaults write` override still beats any shipped default.
-4. **Update feed:** new installs use `thaw-app/updates`; existing installs on the legacy stonerl feed keep receiving the mirrored appcast.
-5. **AX click delivery** is on by default and no longer shown in Settings; `defaults delete com.stonerl.Thaw UseAXClickDelivery` restores that default if you had turned it off during the RCs.
-
-Known issues carried from the RCs are listed at the end of each RC section below.
-
-**Full Changelog**: https://github.com/thaw-app/Thaw/compare/1.3.0-beta.1...2.0.0
 
 ### Support
 
@@ -150,80 +178,122 @@ If you find Thaw useful and want to support its development:
 - Patreon: https://www.patreon.com/c/stonerl
 - PayPal: https://www.paypal.me/tonifoerster
 
+## [2.0.0-unreleased.rc]
+
+<!-- Rename this heading to the real tag before cutting the release:
+     release.yml ships only the section whose heading matches the tag. -->
+
+### Changed
+
+- The update channel picker in Settings › About offers Stable, Beta, and
+  Alpha instead of Stable and Development. The old "Development" setting
+  subscribed to alpha and beta together, so there was no way to take
+  release candidates without also taking the rewrite. Beta continues to
+  mean release candidates of this app and still receives stable releases
+  alongside them. Alpha is a parallel track carrying the rewritten app
+  built against a new macOS, and it no longer drags the release candidates
+  along with it. Alpha appears in the picker only on the macOS the
+  rewrite targets, sharing its threshold with the startup compatibility
+  warning that points users at it. Existing "Development" subscribers
+  migrate to Beta, not Alpha.
+
+### Fixed
+
+- A hidden section that collapsed to zero width no longer stays collapsed.
+  The divider recovery could not reach the state it repairs: it ran only
+  when an apply reported a boundary mismatch, but the applies that mattered
+  refused before computing one, and a divider can strand while the
+  visible/hidden boundary reads consistent. A refused apply now counts as
+  evidence, the streak that arms the rebuild survives a clean cycle, and
+  the parked test reads both edges so a healthy collapsed section is never
+  mistaken for a stranded one (#978).
+- A relaunch clears a stranded divider again. macOS had autosaved the
+  hidden divider to the left of the always-hidden one, and "keeping its
+  stored position" during a rebuild restored the value that stranded it, so
+  the app came back up already broken. An inverted stored position is now
+  replaced with one that orders the two chevrons correctly (#978).
+- Thaw no longer places the always-hidden divider beside an anchor that is
+  itself parked offscreen. The drop point derives from the anchor's leading
+  edge, so anchoring on a parked item dragged both further out — the path
+  behind the mass hidden-to-always-hidden re-sectioning users reported, and
+  behind a stranded divider acquiring a second fault (#978, #980).
+- A profile no longer commits its saved section order when the apply that
+  produced it left planned moves unenacted, so a partial arrangement cannot
+  become the saved one (#978, #980).
+- Dragging an item between sections in the layout editor now survives a
+  restart. The move was recorded after placement had settled, by which
+  point the save had already been skipped as being inside the post-move
+  cooldown; the restore then read the drag as drift and reverted it (#983).
+- Dragging an item onto a collapsed section in the layout editor is now
+  refused with an alert naming the section, instead of spending eight
+  attempts dragging the item offscreen and reporting a generic failure. A
+  collapsed section's divider expands into an offscreen spacer, so the drop
+  point sat thousands of points off the display (#923).
+- An item's placeholder in the layout editor picks up its app's icon once
+  the app becomes launchable, instead of keeping the generic symbol for the
+  life of the view. The re-resolved icon is now also drawn in the same pass
+  rather than waiting on an unrelated redraw (#981).
+- The alert shown when a drag lands on a collapsed section's parked divider
+  read "The hidden section section is collapsed"; it also had no entry in
+  the string catalog, so it stayed English in localized builds.
+
 ## [2.0.0-rc.5]
 
 Please report issues at
 [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
 
-This is planned as the last release candidate before 2.0 stable. Almost all
-of it comes out of field logs, and in nearly every report the layout
-machinery damages the arrangement it was trying to restore: a divider
-rebuild swept a healthy bar into the hidden section, a repair loop fought
-the notch overflow eject move by move, a save outran the restore it raced,
-and a lost always-hidden divider went unnoticed while its section drained
-into Visible (#958, #863). A second track drove the scan-cost work: full
-source-PID scans asked every running application for an extras menu bar,
-which made the whole system stutter, and until resolution caught up every
-item answered to "Menu Bar Item" (#956).
+Planned as the last release candidate before 2.0 stable. Almost all of it comes from field logs, and the reports fall into two clusters: layout repair that damaged the arrangement it was trying to fix (#958, #863), and scans that re-probed every running application until the machine stuttered and every item answered to "Menu Bar Item" (#956).
 
 ---
 
-### Highlights
+### Upgrade from 2.0.0-rc.4
 
-- **The bar stops repairing itself into collapse** — both hidden-divider recoveries discarded a stale autosave position by writing the fresh-install seed through the guard-bypassing route; the divider landed back beside the visible chevron and the next save persisted the collapsed span. On the five-hour log attached to #958, a routine notch overflow scored one boundary mismatch, the rebuild fired, and three seconds later the visible section held nothing but Thaw's own icon.
-- **Boundary repair moves items instead of dragging the divider across them** — Phase 1 reached for one drag of H_ctrl whenever any managed item read on the wrong side of it. Where that drag would have crossed the entire visible section, the bar collapsed to a 33-point span and the apply still reported a clean classification afterwards. Small mismatches now walk the offending items back to the divider one drag each, and the divider drag is reserved for the empty-side cases it was built for (#879, #958).
-- **The overflow planner and the repair pass stop fighting** — on bars persistently over the notch budget, every apply ejected the same item and then recalled it as wrongly concealed, two synthetic drags per cycle for as long as the bar stayed over budget. This matches the "icons jumping randomly and relocating between layouts" reports. Ejected items are now exempt from the boundary tally until the budget frees up (#958).
-- **Items keep their names while source-PID resolution catches up** — naming requires knowing which process created an item, and the first cache pass deliberately runs without waiting for the accessibility scan; for its duration every item answered to the generic "Menu Bar Item" on hover and in Search. An item now falls back to the name it resolved to last time. Control Center's generic Item-N slots are refused, because their key encodes hosting order rather than identity and a wrong name gets clicked; custom names still take precedence (#956).
-- **Slow item owners get room to answer before Thaw gives up** — the move budget started at 100 ms, but escalation averaged each raise against the standing value, so even eight attempts reached only 476 ms, and every unresponsive-owner failure was filed twice, consuming the ledger's mark threshold in one instant. Defaults are now 250 ms (350 for Bento Boxes), growth is adopted as computed up to a one-second ceiling, failures are filed once, and marking takes three. Fixes the cursor hijack of #687 and the misplaced relaunched items of #960.
-- **Scans stop re-probing every running application** — roughly 16 of ~170 running applications have an extras menu bar, but the negative answer did not survive cache cleanup, so nearly every scan re-probed the full application list at ~400 ms steady-state and ~2.8 s during startup. Negative answers now survive cleanup and launches. A zero-area window can no longer start a scan on its own behalf, and the diagnostic names any app whose probe takes longer than 50 ms (#956).
-- **Hidden previews render again** — orphaned Control Center slots from an earlier Thaw process carry zero width, corrupt the composite-slicing geometry, and discard every preview batch, so all hidden and always-hidden previews in Settings → Layout came back empty (#962, thanks @alvst).
+1. Update in place through Sparkle.
+2. Move budgets now default to 250 ms, or 350 for Bento Boxes. An explicit
+   `defaults write` override still takes precedence over either value.
 
 ---
 
-### Menu bar & layout
+### Main fixes
 
-#### Source-PID scanning
-
-- The negative-cache flag was cleared for every reused app on every cache cleanup, and cleanup is driven by `NSWorkspace.runningApplications`, which changes whenever any process starts or exits; the #956 log shows 46 cleanups in seven minutes. The flag is now a deadline that survives cleanup and backs off as consecutive empty checks accumulate. Early rungs stay inside the startup window, so an application that publishes its status item shortly after launch is still found quickly.
-- Consecutive-miss counts are remembered per bundle identifier across launches and seed the first scan of a session, which measured 3.85 s in the log. Seeding is deliberately the ladder's first rung rather than the rung the count earns: memory is trusted to say where to look and never what was found, so skipping an application can reorder work but cannot attribute an item to the wrong owner.
-- A zero-area window has no centre worth comparing against an accessibility frame, yet an unresolved window is what selects scan drivers; one such window started eight of nine scans in seven minutes with nothing else on the bar asking for one. Zero-area windows no longer select themselves. Bounds are re-read on every request, so a window that gains area stops being skipped.
-- Scan summaries now log total wall time and name any single app whose extras-bar probe exceeds 50 ms, since accessibility reads are serviced by the target process and bounded only by the unresponsive timeout.
-
-#### Save gates
-
-- `saveSectionOrder` honours the same five-second post-move cooldown `applySavedLayout` uses, except when the user's own move is the most recent one, so a Layout-editor drag does not undo itself. In the #958 log the save landed one millisecond after the restore stood down.
-- The multi-display gate counted items classified as visible, so a relocation that stranded items in the wrong section erased its own evidence: it fired correctly with sixteen visible items and passed when four were left, which was the save that did the damage. The gate now reads whether the menu bar changed display since the cache cycle being compared, a signal that survives misclassification because it does not read the items at all.
-
-#### Divider recovery
-
-- A hidden-divider rebuild stamps a seed position only when the bar holds no managed items. Discarding the stale `NSStatusItem` is still what gives the divider a window on the current bar, and the follow-up apply walks it to the saved boundary, a move the seeded rebuild could not make anyway while parked off screen (#958).
-- The H_ctrl boundary move no longer anchors on Thaw's own chevron. When every profile item has been dragged to the other side, anchoring on the last remaining candidate drags H_ctrl past it and conceals it; returning nil leaves the boundary alone and hands the work to the per-item LCS pass, which has barred Thaw's own items as anchors since #924. The two nil cases log separately (#958).
-- Parked dividers are measured at their leading edge instead of their centre. A collapsed hidden divider is 5000 points wide, so its centre sat 2500 points right of the divider and read as on-screen on multi-display arrangements, defeating both the parked-divider drag guard (#899) and the rebuild detector; five hours of log recorded neither warning.
-- Chevron relocation and always-hidden control-item ordering skip when the hidden divider fails the on-screen check, so neither drops its target into the parked zone beside a physically parked divider. The existing recovery paths already handle the states these guards refuse.
-- An enabled always-hidden section whose divider stops resolving gets its status item recreated once per episode after three authoritative cycles with no reading, and stored position is kept rather than seeded. Provisional AX-frame correlations never advance, reset, or re-arm the streak. The #863 re-plug log showed `alwaysHidden=nil` on every cycle for 12+ hours while the whole always-hidden section drained into Visible and the collapsed arrangement persisted (#863).
-- The one-pixel drop-point bias now applies to every control-item divider regardless of width. Expanded, thousands-of-points-wide dividers still produced placements landing one point into the wrong section: a divider's width provides visual concealment, not hit-test slack (#923).
+1. Hidden-divider recovery no longer collapses the bar. Both recovery paths discarded a stale autosave position by writing the fresh-install seed through the route that bypasses the guard, so the divider landed back beside the visible chevron and the next save persisted the collapsed span. On the five-hour log attached to #958, a routine notch overflow scored one boundary mismatch, the rebuild fired, and three seconds later the visible section held nothing but Thaw's own icon.
+2. Boundary repair moves items instead of dragging the divider across them. Phase 1 reached for one drag of H_ctrl whenever any managed item sat on the wrong side of it; when that drag would have crossed the entire visible section, the bar collapsed to a 33-point span and the apply still reported a clean classification afterwards. Small mismatches now walk the offending items back one drag each, and the divider drag stays reserved for the empty-side cases it was built for (#879, #958).
+3. Ejected items stop bouncing between the overflow planner and the repair pass. On bars persistently over the notch budget, every apply ejected the same item and then recalled it as wrongly concealed, two synthetic drags per cycle for as long as the bar stayed over budget. That matches the "icons jumping randomly and relocating between layouts" reports. Ejected items are now exempt from the boundary tally until the budget frees up (#958).
+4. Items keep their names while source-PID resolution catches up. Naming requires knowing which process created an item, and the first cache pass deliberately runs without waiting for the accessibility scan, so for its duration every item answered to the generic "Menu Bar Item" on hover and in Search. An item now falls back to the name it resolved to last time. Control Center's generic Item-N slots are refused because their key encodes hosting order rather than identity and a wrong name gets clicked; custom names still take precedence (#956).
+5. Slow item owners get room to answer. The move budget started at 100 ms, but escalation averaged each raise against the standing value, so even eight attempts reached only 476 ms, and every unresponsive-owner failure was filed twice, burning through the ledger's mark threshold right away. Defaults are now 250 ms (350 for Bento Boxes), growth is adopted as computed up to a one-second ceiling, failures are filed once, and marking takes three. Fixes the cursor hijack of #687 and the misplaced relaunched items of #960.
 
 ---
 
-### Appearance, capture & IceBar
+### Source-PID scanning
 
-- Preview batches exclude degenerate zero-width windows from the bounds union. Capture APIs drop them from the composite while including them in the union dragged its geometry across the gap between displays, the widths stopped matching, and the whole batch was discarded. The windows that surfaced this were Control Center-hosted slots orphaned by an earlier Thaw process: Control Center owns them, so they outlive restarts, and their bundle-ID names keep them out of `ControlItemPair`'s strip list (#962).
+- The negative-cache flag was cleared for every reused app on every cache cleanup, and cleanup runs whenever any process starts or exits because `NSWorkspace.runningApplications` drives it; the #956 log shows 46 cleanups in seven minutes. The flag is now a deadline that survives cleanup and backs off as consecutive empty checks accumulate. Early rungs stay inside the startup window, so an application that publishes its status item shortly after launch is still found quickly.
+- Consecutive-miss counts are remembered per bundle identifier across launches and seed the first scan of a session, which measured 3.85 s in the log. Seeding decides where to look, never what was found: skipping an application can reorder work but cannot attribute an item to the wrong owner.
+- A zero-area window no longer selects scan drivers. An unresolved window is what picks the driver, and one zero-area window started eight of nine scans in seven minutes with nothing else on the bar asking for one. Bounds are re-read on every request, so a window that gains area stops being skipped.
+- Scan summaries now log total wall time and name any single app whose extras-bar probe exceeds 50 ms, since accessibility reads are serviced by the target process and bounded only by its unresponsive timeout.
 
----
+### Save gates
+
+- `saveSectionOrder` honours the same five-second post-move cooldown as `applySavedLayout`, except when the user's own move was the most recent one, so a Layout-editor drag cannot undo itself. In the #958 log the save landed one millisecond after the restore stood down.
+- The multi-display gate counted visible items, so a relocation that stranded items in the wrong section erased its own evidence: it fired correctly with sixteen visible items and passed when four were left, which was the save that did the damage. It now reads whether the menu bar changed display since the cache cycle being compared, a signal that never looks at the items and therefore survives misclassification.
+
+### Divider recovery
+
+- A hidden-divider rebuild stamps a seed position only when the bar holds no managed items. Discarding the stale `NSStatusItem` still gives the divider a window on the current bar, and the follow-up apply walks it to the saved boundary (#958).
+- The H_ctrl boundary move no longer anchors on Thaw's own chevron. When every profile item has been dragged to the other side, anchoring on the last remaining candidate dragged H_ctrl past it and concealed it; returning nil leaves the boundary alone and hands the work to the per-item LCS pass, which has barred Thaw's own items as anchors since #924. The two nil cases log separately (#958).
+- Parked dividers are measured at their leading edge instead of their centre. A collapsed hidden divider is 5000 points wide, so its centre sat 2500 points to the right and read as on-screen on multi-display arrangements, defeating both the parked-divider drag guard (#899) and the rebuild detector; five hours of log recorded neither warning.
+- Chevron relocation and always-hidden control-item ordering skip when the hidden divider fails the on-screen check, so neither drops its target into the parked zone beside a physically parked divider. Existing recovery paths already handle the states these guards refuse.
+- An enabled always-hidden section whose divider stops resolving gets its status item recreated once per episode, after three authoritative cycles with no reading, and keeps its stored position rather than seeding. Provisional AX-frame correlations never advance, reset, or re-arm the streak. The #863 re-plug log showed `alwaysHidden=nil` on every cycle for 12+ hours while the whole always-hidden section drained into Visible (#863).
+- The one-pixel drop-point bias now applies to every control-item divider regardless of width. Expanded dividers thousands of points wide still produced placements landing one point into the wrong section: a divider's width provides visual concealment, not hit-test slack (#923).
+
+### Appearance & capture
+
+- Preview batches exclude degenerate zero-width windows from the bounds union. Capture APIs dropped them from the composite while including them in the union, which dragged the geometry across the gap between displays, mismatched the widths, and discarded the whole batch. The windows behind this were Control Center-hosted slots orphaned by an earlier Thaw process: Control Center owns them, they outlive restarts, and their bundle-ID names keep them out of `ControlItemPair`'s strip list (#962, thanks @alvst).
 
 ### Dependencies & docs
 
 - Sparkle bumped in the swift group (#971); github-actions group bumped with four updates (#972).
 - README OpenSSF badges switched to live shieldcn scorecard/openssf endpoints (#920); contributor image source updated; repository notice added.
 - FUNDING.yml gained Ko-fi and PayPal entries.
-
----
-
-### Upgrade notes
-
-1. **From 2.0.0-rc.4:** in-place Sparkle update.
-2. **Move budgets:** defaults rose to 250 ms (350 for Bento Boxes); an explicit `defaults write` override still takes precedence over either.
-
 ## [2.0.0-rc.4]
 
 Please report issues at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -178,7 +178,10 @@ If you find Thaw useful and want to support its development:
 - Patreon: https://www.patreon.com/c/stonerl
 - PayPal: https://www.paypal.me/tonifoerster
 
-## [2.0.0-rc-unreleased]
+## [2.0.0-unreleased]
+
+_Fixes made after 2.0.0-rc.5. Never tagged on their own; they ship inside
+the 2.0.0 stable build, so they are not repeated in its release notes._
 
 ### Changed
 

--- a/Thaw/Main/AppDelegate.swift
+++ b/Thaw/Main/AppDelegate.swift
@@ -92,7 +92,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             }
         #endif
 
-        MacOSCompatibilityWarning.showIfNeeded()
+        MacOSCompatibilityWarning.showIfNeeded(updatesManager: appState.updatesManager)
 
         // Warn if another menu bar manager is running.
         ConflictingAppDetector.showWarningIfNeeded()

--- a/Thaw/Main/Updates.swift
+++ b/Thaw/Main/Updates.swift
@@ -217,10 +217,13 @@ final class UpdatesManager: NSObject {
             // Checking for updates hangs in debug mode.
             NSWorkspace.shared.open(Constants.releasesURL)
         #else
-            updateChannel = .alpha
             isCheckingAfterCompatibilityWarning = true
+            // Order matters: storing the channel schedules the one background
+            // check this needs, and that task only checks once the updater is
+            // running. Asking again here would open a second session Sparkle
+            // would drop.
             startUpdaterIfNeeded()
-            updater.checkForUpdatesInBackground()
+            updateChannel = .alpha
         #endif
     }
 

--- a/Thaw/Main/Updates.swift
+++ b/Thaw/Main/Updates.swift
@@ -48,24 +48,56 @@ final class UpdatesManager: NSObject {
         updaterController.updater
     }
 
-    /// A Boolean value that indicates whether the user wants to receive beta updates.
-    var allowsBetaUpdates: Bool {
+    /// The update channel the user is subscribed to.
+    var updateChannel: UpdateChannel {
         get {
             // Computed over UserDefaults, so the @Observable macro cannot
             // track it automatically; register/notify Observation manually
             // (same pattern as the Sparkle-backed properties below).
-            access(keyPath: \.allowsBetaUpdates)
-            return Defaults.store.bool(forKey: "AllowsBetaUpdates")
+            access(keyPath: \.updateChannel)
+            return Self.storedUpdateChannel()
         }
         set {
-            withMutation(keyPath: \.allowsBetaUpdates) {
-                Defaults.store.set(newValue, forKey: "AllowsBetaUpdates")
+            withMutation(keyPath: \.updateChannel) {
+                Defaults.store.set(newValue.rawValue, forKey: "UpdateChannel")
+                // Keep the superseded flag in step so downgrading to a build
+                // that only knows the Bool leaves the user off stable rather
+                // than silently back on it.
+                Defaults.store.set(newValue != .stable, forKey: "AllowsBetaUpdates")
             }
             Task {
                 guard hasStartedUpdater else { return }
                 updater.checkForUpdatesInBackground()
             }
         }
+    }
+
+    /// Reads the stored channel, falling back to the flag that preceded it.
+    ///
+    /// Builds before the split offered a single "Development" setting whose
+    /// subscribers received alpha and beta together. They migrate to beta,
+    /// not alpha: alpha is now a different app on a different feed, and
+    /// moving someone onto it without them asking would swap the product
+    /// out from under them.
+    static nonisolated func storedUpdateChannel(
+        on version: OperatingSystemVersion = ProcessInfo.processInfo.operatingSystemVersion
+    ) -> UpdateChannel {
+        let stored: UpdateChannel = if let raw = Defaults.store.string(forKey: "UpdateChannel"),
+                                       let channel = UpdateChannel(rawValue: raw)
+        {
+            channel
+        } else {
+            Defaults.store.bool(forKey: "AllowsBetaUpdates") ? .beta : .stable
+        }
+        // A channel the running system cannot be offered is not honored
+        // either, or a user who selected alpha and then moved back to a
+        // supported macOS would stay pinned to the rewrite's feed and be
+        // offered nothing at all. Beta rather than stable: they had opted
+        // out of stable, and that much of the choice still applies.
+        guard stored.isAvailable(on: version) else {
+            return .beta
+        }
+        return stored
     }
 
     /// `automaticallyChecksForUpdates`/`automaticallyDownloadsUpdates` are
@@ -177,10 +209,7 @@ extension UpdatesManager: SPUUpdaterDelegate {
 
     /// Determines which update channels are allowed.
     func allowedChannels(for _: SPUUpdater) -> Set<String> {
-        if Defaults.store.bool(forKey: "AllowsBetaUpdates") {
-            return ["alpha", "beta"]
-        }
-        return []
+        Self.storedUpdateChannel().allowedSparkleChannels
     }
 
     func updater(_: SPUUpdater, willScheduleUpdateCheckAfterDelay _: TimeInterval) {
@@ -231,5 +260,79 @@ extension UpdatesManager: @MainActor SPUStandardUserDriverDelegate {
             return
         }
         appState.userNotificationManager.removeDeliveredNotifications(with: [.updateCheck])
+    }
+}
+
+// MARK: - UpdateChannel
+
+/// A stream of releases the user can subscribe to.
+///
+/// All three share the feed named by `SUFeedURL` and differ only in which
+/// `sparkle:channel` tags they accept: beta takes `beta`, alpha takes
+/// `alpha`, and neither takes the other. Alpha is not the same product as
+/// the other two, being the rewrite built against the next macOS, but it
+/// does not need a feed of its own to stay apart from beta.
+///
+/// It cannot stay apart from stable, though. Sparkle's `allowedChannels`
+/// only widens what an updater accepts: an item carrying no `sparkle:channel`
+/// is on the default channel, and per `SPUUpdaterDelegate`, "the default
+/// channel is always included in the allowed set". Every subscriber therefore
+/// sees the stable items. They stop mattering because Sparkle offers the
+/// newest allowed item, and the rewrite's version line runs ahead of the
+/// shipping app's, so a stable release can never outrank an alpha one.
+nonisolated enum UpdateChannel: String, CaseIterable, Identifiable {
+    /// Released builds.
+    case stable
+    /// Release candidates and betas of the shipping app.
+    case beta
+    /// The rewritten app, for testing against a new macOS.
+    case alpha
+
+    var id: String {
+        rawValue
+    }
+
+    /// The channels that can be offered on a system running `version`.
+    static func availableCases(on version: OperatingSystemVersion) -> [UpdateChannel] {
+        allCases.filter { $0.isAvailable(on: version) }
+    }
+
+    /// Whether this channel can be offered on a system running `version`.
+    ///
+    /// Alpha is the rewrite built against the macOS this build does not
+    /// support, so it is offered only there. Showing it earlier would
+    /// advertise a track whose builds the user cannot run, and hide the
+    /// shipping app behind an update that would never arrive.
+    func isAvailable(on version: OperatingSystemVersion) -> Bool {
+        switch self {
+        case .stable, .beta:
+            true
+        case .alpha:
+            version.majorVersion >= MacOSCompatibilityWarning.firstUnsupportedMajorVersion
+        }
+    }
+
+    /// The `sparkle:channel` values an appcast item may carry and still be
+    /// offered to a subscriber of this channel.
+    ///
+    /// Sparkle always adds the default channel to the allowed set, so every
+    /// subscriber sees the untagged stable items too. That is harmless while
+    /// stable stays on the 2.x line: Sparkle offers the newest allowed item,
+    /// and an alpha subscriber's 3.x item outranks anything stable can carry.
+    var allowedSparkleChannels: Set<String> {
+        switch self {
+        case .stable: []
+        case .beta: ["beta"]
+        case .alpha: ["alpha"]
+        }
+    }
+
+    /// A string to show in the interface.
+    var localized: LocalizedStringKey {
+        switch self {
+        case .stable: LocalizedStringKey("Stable")
+        case .beta: LocalizedStringKey("Beta")
+        case .alpha: LocalizedStringKey("Alpha")
+        }
     }
 }

--- a/Thaw/Main/Updates.swift
+++ b/Thaw/Main/Updates.swift
@@ -27,6 +27,16 @@ final class UpdatesManager: NSObject {
     /// Tracks whether the updater has been started.
     private var hasStartedUpdater = false
 
+    /// Tracks whether the running check was started by the macOS
+    /// compatibility alert.
+    ///
+    /// That alert promises the user a build for a macOS this one does not
+    /// support. A background check that finds nothing is silent, so the
+    /// promise has to survive the check to be kept: an empty alpha feed
+    /// sends them to the releases page rather than nowhere.
+    @ObservationIgnored
+    private var isCheckingAfterCompatibilityWarning = false
+
     /// Storage for internal observers.
     @ObservationIgnored
     private var cancellables = Set<AnyCancellable>()
@@ -193,6 +203,40 @@ final class UpdatesManager: NSObject {
             updater.checkForUpdates()
         #endif
     }
+
+    /// Subscribes to the alpha channel and looks for the build that supports
+    /// the running macOS, falling back to the releases page.
+    ///
+    /// Called from ``MacOSCompatibilityWarning`` once the user accepts the
+    /// offer. The check runs in the background so that the only thing the
+    /// user sees is its outcome: either Sparkle presenting the alpha build,
+    /// or the releases page, which is where the promise lands while the feed
+    /// still carries no alpha item.
+    func checkForAlphaUpdateAfterCompatibilityWarning() {
+        #if DEBUG
+            // Checking for updates hangs in debug mode.
+            NSWorkspace.shared.open(Constants.releasesURL)
+        #else
+            updateChannel = .alpha
+            isCheckingAfterCompatibilityWarning = true
+            startUpdaterIfNeeded()
+            updater.checkForUpdatesInBackground()
+        #endif
+    }
+
+    /// Answers the compatibility alert's promise with the releases page, if
+    /// the check it started is the one that just ended empty.
+    ///
+    /// A check that finds nothing also aborts with `SUNoUpdateError`, and one
+    /// that never reaches the feed only aborts, so both endings call this and
+    /// the flag decides which of them arrived first.
+    private func resolveCompatibilityCheckWithReleasesPage() {
+        guard isCheckingAfterCompatibilityWarning else {
+            return
+        }
+        isCheckingAfterCompatibilityWarning = false
+        NSWorkspace.shared.open(Constants.releasesURL)
+    }
 }
 
 // MARK: UpdatesManager: SPUUpdaterDelegate
@@ -210,6 +254,14 @@ extension UpdatesManager: SPUUpdaterDelegate {
     /// Determines which update channels are allowed.
     func allowedChannels(for _: SPUUpdater) -> Set<String> {
         Self.storedUpdateChannel().allowedSparkleChannels
+    }
+
+    func updaterDidNotFindUpdate(_: SPUUpdater) {
+        resolveCompatibilityCheckWithReleasesPage()
+    }
+
+    func updater(_: SPUUpdater, didAbortWithError _: any Error) {
+        resolveCompatibilityCheckWithReleasesPage()
     }
 
     func updater(_: SPUUpdater, willScheduleUpdateCheckAfterDelay _: TimeInterval) {
@@ -231,6 +283,12 @@ extension UpdatesManager: @MainActor SPUStandardUserDriverDelegate {
         _: SUAppcastItem,
         andInImmediateFocus immediateFocus: Bool
     ) -> Bool {
+        // The compatibility alert asked for this check on the user's behalf,
+        // so its result is shown rather than deferred to a notification they
+        // may never have granted.
+        if isCheckingAfterCompatibilityWarning {
+            return true
+        }
         if NSApp.isActive {
             return immediateFocus
         } else {
@@ -243,10 +301,14 @@ extension UpdatesManager: @MainActor SPUStandardUserDriverDelegate {
         forUpdate update: SUAppcastItem,
         state: SPUUserUpdateState
     ) {
+        // The update window itself answers the compatibility alert, so a
+        // notification beside it would say the same thing twice.
+        let answersCompatibilityWarning = isCheckingAfterCompatibilityWarning
+        isCheckingAfterCompatibilityWarning = false
         guard let appState else {
             return
         }
-        if !state.userInitiated {
+        if !state.userInitiated, !answersCompatibilityWarning {
             appState.userNotificationManager.addRequest(
                 with: .updateCheck,
                 title: String(localized: "A new update is available"),

--- a/Thaw/Main/Updates.swift
+++ b/Thaw/Main/Updates.swift
@@ -37,6 +37,13 @@ final class UpdatesManager: NSObject {
     @ObservationIgnored
     private var isCheckingAfterCompatibilityWarning = false
 
+    /// Opens a URL on the user's behalf.
+    ///
+    /// Injectable so a test can watch the compatibility alert's fallback fire
+    /// without handing the running system a browser window.
+    @ObservationIgnored
+    var openURL: @MainActor (URL) -> Void = { NSWorkspace.shared.open($0) }
+
     /// Storage for internal observers.
     @ObservationIgnored
     private var cancellables = Set<AnyCancellable>()
@@ -213,11 +220,13 @@ final class UpdatesManager: NSObject {
     /// or the releases page, which is where the promise lands while the feed
     /// still carries no alpha item.
     func checkForAlphaUpdateAfterCompatibilityWarning() {
+        beginCompatibilityCheck()
         #if DEBUG
-            // Checking for updates hangs in debug mode.
-            NSWorkspace.shared.open(Constants.releasesURL)
+            // Checking for updates hangs in debug mode, so the promise is
+            // answered here rather than by a check that never runs.
+            updateChannel = .alpha
+            resolveCompatibilityCheckWithReleasesPage()
         #else
-            isCheckingAfterCompatibilityWarning = true
             // Order matters: storing the channel schedules the one background
             // check this needs, and that task only checks once the updater is
             // running. Asking again here would open a second session Sparkle
@@ -233,12 +242,41 @@ final class UpdatesManager: NSObject {
     /// A check that finds nothing also aborts with `SUNoUpdateError`, and one
     /// that never reaches the feed only aborts, so both endings call this and
     /// the flag decides which of them arrived first.
-    private func resolveCompatibilityCheckWithReleasesPage() {
+    /// Arms the promise the compatibility alert just made, so that whichever
+    /// way the check ends, the ending is recognized as this one's.
+    func beginCompatibilityCheck() {
+        isCheckingAfterCompatibilityWarning = true
+    }
+
+    func resolveCompatibilityCheckWithReleasesPage() {
         guard isCheckingAfterCompatibilityWarning else {
             return
         }
         isCheckingAfterCompatibilityWarning = false
-        NSWorkspace.shared.open(Constants.releasesURL)
+        openURL(Constants.releasesURL)
+    }
+
+    /// Whether a scheduled update should be shown now rather than deferred.
+    ///
+    /// The compatibility alert asked for its check on the user's behalf, so
+    /// its result is shown rather than deferred to a notification they may
+    /// never have granted.
+    func shouldShowScheduledUpdate(inImmediateFocus immediateFocus: Bool, appIsActive: Bool) -> Bool {
+        if isCheckingAfterCompatibilityWarning {
+            return true
+        }
+        return appIsActive ? immediateFocus : false
+    }
+
+    /// Whether an update being shown should also be announced by notification,
+    /// closing the compatibility check on the way.
+    ///
+    /// The update window itself answers the alert, so a notification beside it
+    /// would say the same thing twice.
+    func shouldNotifyAboutUpdate(userInitiated: Bool) -> Bool {
+        let answersCompatibilityWarning = isCheckingAfterCompatibilityWarning
+        isCheckingAfterCompatibilityWarning = false
+        return !userInitiated && !answersCompatibilityWarning
     }
 }
 
@@ -286,17 +324,7 @@ extension UpdatesManager: @MainActor SPUStandardUserDriverDelegate {
         _: SUAppcastItem,
         andInImmediateFocus immediateFocus: Bool
     ) -> Bool {
-        // The compatibility alert asked for this check on the user's behalf,
-        // so its result is shown rather than deferred to a notification they
-        // may never have granted.
-        if isCheckingAfterCompatibilityWarning {
-            return true
-        }
-        if NSApp.isActive {
-            return immediateFocus
-        } else {
-            return false
-        }
+        shouldShowScheduledUpdate(inImmediateFocus: immediateFocus, appIsActive: NSApp.isActive)
     }
 
     func standardUserDriverWillHandleShowingUpdate(
@@ -304,20 +332,14 @@ extension UpdatesManager: @MainActor SPUStandardUserDriverDelegate {
         forUpdate update: SUAppcastItem,
         state: SPUUserUpdateState
     ) {
-        // The update window itself answers the compatibility alert, so a
-        // notification beside it would say the same thing twice.
-        let answersCompatibilityWarning = isCheckingAfterCompatibilityWarning
-        isCheckingAfterCompatibilityWarning = false
-        guard let appState else {
+        guard shouldNotifyAboutUpdate(userInitiated: state.userInitiated), let appState else {
             return
         }
-        if !state.userInitiated, !answersCompatibilityWarning {
-            appState.userNotificationManager.addRequest(
-                with: .updateCheck,
-                title: String(localized: "A new update is available"),
-                body: String(localized: "Version \(update.displayVersionString) (\(update.versionString)) is now available")
-            )
-        }
+        appState.userNotificationManager.addRequest(
+            with: .updateCheck,
+            title: String(localized: "A new update is available"),
+            body: String(localized: "Version \(update.displayVersionString) (\(update.versionString)) is now available")
+        )
     }
 
     func standardUserDriverDidReceiveUserAttention(forUpdate _: SUAppcastItem) {

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -64,7 +64,17 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
     private lazy var tooltipController = CustomTooltipController(text: item.displayName, view: self)
     private var tooltipTrackingArea: NSTrackingArea?
-    private let placeholderImage: NSImage?
+    /// The image drawn inside the placeholder bubble when no capture is
+    /// cached. Re-resolved lazily in ``drawPlaceholder`` so an app that was
+    /// not launchable when this view was created can still supply its icon
+    /// once it is (#981). The view is reused across cache refreshes when the
+    /// item's identity is stable, so without this the generic symbol baked
+    /// in at init stays even after the app is running and could have been
+    /// read.
+    private var placeholderImage: NSImage?
+    /// Whether ``placeholderImage`` already came from a resolved app icon, so
+    /// ``drawPlaceholder`` does not re-run the lookup on every draw.
+    private var placeholderResolvedFromApp = false
 
     /// The image displayed inside the view.
     private var cachedImage: MenuBarItemImageCache.CapturedImage? {
@@ -87,7 +97,9 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     init(appState: AppState, item: MenuBarItem) {
         self.item = item
         self.appState = appState
-        self.placeholderImage = Self.makePlaceholderImage(for: item)
+        let (image, resolvedFromApp) = Self.makePlaceholderImage(for: item)
+        self.placeholderImage = image
+        self.placeholderResolvedFromApp = resolvedFromApp
 
         let initialImage = appState.imageCache.image(for: item.tag)
         self.cachedImage = initialImage
@@ -386,13 +398,16 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         return CGSize(width: width, height: height)
     }
 
-    private static func makePlaceholderImage(for item: MenuBarItem) -> NSImage? {
+    private static func makePlaceholderImage(for item: MenuBarItem) -> (NSImage?, Bool) {
         if let icon = item.sourceApplication?.icon ?? item.owningApplication?.icon {
-            return icon
+            return (icon, true)
         }
-        return NSImage(
-            systemSymbolName: "menubar.rectangle",
-            accessibilityDescription: item.displayName
+        return (
+            NSImage(
+                systemSymbolName: "menubar.rectangle",
+                accessibilityDescription: item.displayName
+            ),
+            false
         )
     }
 
@@ -415,6 +430,19 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
         guard let placeholderImage else {
             return
+        }
+
+        // #981: if the placeholder fell back to the generic symbol at init
+        // because the owning app was not launchable yet, try the app icon
+        // again now. The view is reused across cache refreshes when the
+        // item's identity is stable, so this is the one place a later
+        // resolution surfaces. One lookup per resolution; the flag stops
+        // repeat work once an icon is in hand.
+        if !placeholderResolvedFromApp,
+           let icon = item.sourceApplication?.icon ?? item.owningApplication?.icon
+        {
+            self.placeholderImage = icon
+            placeholderResolvedFromApp = true
         }
 
         let iconBounds = placeholderRect.insetBy(

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -398,8 +398,26 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         return CGSize(width: width, height: height)
     }
 
+    /// The icon of the app that put this item on the bar, or `nil` when the
+    /// owner can only name Control Center.
+    ///
+    /// On macOS 26 every Control Center slot reports Control Center as its
+    /// owner, so an unresolved placeholder would take Control Center's icon
+    /// through the fallback. That is wrong on its face, and caching it as a
+    /// resolved icon also retires the retry below for the owner that shows
+    /// up once the source PID is known.
+    private static func resolvedAppIcon(for item: MenuBarItem) -> NSImage? {
+        if let icon = item.sourceApplication?.icon {
+            return icon
+        }
+        guard item.immovabilityReason != .unresolvedControlCenterPlaceholder else {
+            return nil
+        }
+        return item.owningApplication?.icon
+    }
+
     private static func makePlaceholderImage(for item: MenuBarItem) -> (NSImage?, Bool) {
-        if let icon = item.sourceApplication?.icon ?? item.owningApplication?.icon {
+        if let icon = resolvedAppIcon(for: item) {
             return (icon, true)
         }
         return (
@@ -439,7 +457,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         // resolution surfaces. One lookup per resolution; the flag stops
         // repeat work once an icon is in hand.
         if !placeholderResolvedFromApp,
-           let icon = item.sourceApplication?.icon ?? item.owningApplication?.icon
+           let icon = Self.resolvedAppIcon(for: item)
         {
             self.placeholderImage = icon
             placeholderResolvedFromApp = true

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -428,7 +428,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         backgroundPath.lineWidth = 1
         backgroundPath.stroke()
 
-        guard let placeholderImage else {
+        guard var placeholderImage else {
             return
         }
 
@@ -443,6 +443,11 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         {
             self.placeholderImage = icon
             placeholderResolvedFromApp = true
+            // Draw the resolved icon in this pass. Assigning only the stored
+            // property left the local binding above holding the generic
+            // symbol, so the icon swap waited on an unrelated invalidation
+            // that never comes for items the image cache can't capture.
+            placeholderImage = icon
         }
 
         let iconBounds = placeholderRect.insetBy(

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -245,10 +245,15 @@ final class LayoutBarPaddingView: NSView {
             let targetItem = destination.targetItem
             if targetItem.isControlItem {
                 let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-                if !LayoutSolver.isOnScreen(bounds: targetItem.bounds, screenFrames: screenFrames) {
+                // The destination comes from the frozen arranged views, whose
+                // bounds were captured before the drag began. A divider that
+                // parked in between would still read as on screen, so the
+                // refusal asks the window server where it is now.
+                let targetBounds = targetItem.liveBounds
+                if !LayoutSolver.isOnScreen(bounds: targetBounds, screenFrames: screenFrames) {
                     watchdogTask.cancel()
                     Self.diagLog.warning(
-                        "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (minX=\(targetItem.bounds.minX)); section is collapsed"
+                        "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (minX=\(targetBounds.minX)); section is collapsed"
                     )
                     await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
                     await MainActor.run {

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -275,15 +275,25 @@ final class LayoutBarPaddingView: NSView {
                     skipInputPause: true,
                     watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout
                 )
+                // Record the user move before stabilization so the save
+                // gate's cooldown exemption is armed when stabilizePlacement's
+                // own cache pass reaches it. Recording it only after stabilize
+                // returned meant the first cache pass inside stabilize hit
+                // the 5s move cooldown with no user-move exemption, so the
+                // save was skipped; by the time the exemption armed, the
+                // mid-transition cache gate had re-armed and no accepting
+                // pass coincided with the cooldown window. The drag never
+                // saved (#983). move() threw no error, so the user's drag
+                // did land; the rescue-and-retry catch block below still
+                // owns the case where macOS didn't settle it.
+                appState.itemManager.recordExternalMoveOperation()
                 appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
-                if await stabilizePlacement(
+                _ = await stabilizePlacement(
                     of: item,
                     to: destination,
                     expectedSection: container.section,
                     appState: appState
-                ) {
-                    appState.itemManager.recordExternalMoveOperation()
-                }
+                )
             } catch MenuBarItemManager.EventError.menuTrackingActive {
                 // A menu bar item's menu (Wi-Fi picker, input method panel,
                 // etc.) was open and the move was deferred to avoid tearing
@@ -340,15 +350,17 @@ final class LayoutBarPaddingView: NSView {
                             skipInputPause: true,
                             watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout
                         )
+                        // Same #983 reorder as the primary path: arm the
+                        // save-gate user-move exemption before stabilize so
+                        // its cache pass can persist the retry.
+                        appState.itemManager.recordExternalMoveOperation()
                         appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
-                        if await stabilizePlacement(
+                        _ = await stabilizePlacement(
                             of: item,
                             to: destination,
                             expectedSection: container.section,
                             appState: appState
-                        ) {
-                            appState.itemManager.recordExternalMoveOperation()
-                        }
+                        )
                     } catch MenuBarItemManager.EventError.menuTrackingActive {
                         // Same deferral the outer catch handles: the user
                         // opened a menu bar item's menu while the retry was

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -229,6 +229,45 @@ final class LayoutBarPaddingView: NSView {
                 await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
                 await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
             }
+
+            // Refuse a drag whose destination is one of Thaw's own section
+            // dividers while that divider is parked offscreen (#923). A
+            // collapsed section expands its control item into a spacer whose
+            // leading edge is far offscreen, so .leftOfItem(AH_ctrl) targets
+            // a click point around minX -9189. The synthetic drag yanks the
+            // item offscreen and macOS snaps it straight back, every attempt,
+            // until the budget runs out and the user sees a generic
+            // "operation could not be completed" alert. The apply path already
+            // skips divider moves in this state (#899/#978); the editor drag
+            // was the one caller that still handed the parked divider to
+            // move() directly. Bail out with an actionable message instead of
+            // burning eight attempts.
+            let targetItem = destination.targetItem
+            if targetItem.isControlItem {
+                let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+                if !LayoutSolver.isOnScreen(bounds: targetItem.bounds, screenFrames: screenFrames) {
+                    watchdogTask.cancel()
+                    Self.diagLog.warning(
+                        "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (minX=\(targetItem.bounds.minX)); section is collapsed"
+                    )
+                    await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                    await MainActor.run {
+                        self.isStabilizing = false
+                        self.showOverlay(false)
+                        self.container.canSetArrangedViews = true
+                        if sourceContainer !== self.container {
+                            sourceContainer?.canSetArrangedViews = true
+                        }
+                        let alert = NSAlert()
+                        alert.alertStyle = .warning
+                        alert.messageText = String(localized: "Couldn't move \(item.displayName) right now.")
+                        alert.informativeText = String(localized: "The \(container.section.logString) section is collapsed, so its divider is offscreen. Open the section and try dragging the item again.")
+                        alert.runModal()
+                    }
+                    return
+                }
+            }
+
             do {
                 try await appState.itemManager.move(
                     item: item,

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -261,7 +261,7 @@ final class LayoutBarPaddingView: NSView {
                         let alert = NSAlert()
                         alert.alertStyle = .warning
                         alert.messageText = String(localized: "Couldn't move \(item.displayName) right now.")
-                        alert.informativeText = String(localized: "The \(container.section.logString) section is collapsed, so its divider is offscreen. Open the section and try dragging the item again.")
+                        alert.informativeText = String(localized: "The \(container.section.displayString) section is collapsed, so its divider is offscreen. Open the section and try dragging the item again.")
                         alert.runModal()
                     }
                     return

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -248,12 +248,18 @@ final class LayoutBarPaddingView: NSView {
                 // The destination comes from the frozen arranged views, whose
                 // bounds were captured before the drag began. A divider that
                 // parked in between would still read as on screen, so the
-                // refusal asks the window server where it is now.
-                let targetBounds = targetItem.liveBounds
-                if !LayoutSolver.isOnScreen(bounds: targetBounds, screenFrames: screenFrames) {
+                // refusal asks the window server where it is now. A window the
+                // server cannot answer for is refused too: this gate exists to
+                // keep a stranded divider away from move(), and a stale
+                // snapshot is no evidence that the divider is reachable.
+                let targetBounds = Bridging.getWindowBounds(for: targetItem.windowID)
+                let isReachable = targetBounds.map {
+                    LayoutSolver.isOnScreen(bounds: $0, screenFrames: screenFrames)
+                } ?? false
+                if !isReachable {
                     watchdogTask.cancel()
                     Self.diagLog.warning(
-                        "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (minX=\(targetBounds.minX)); section is collapsed"
+                        "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (\(targetBounds.map { "minX=\($0.minX)" } ?? "no window bounds")); section is collapsed"
                     )
                     await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
                     await MainActor.run {

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -808,7 +808,9 @@ nonisolated enum LayoutSolver {
         /// visible side.
         var wronglyConcealed: Set<String>
 
-        var count: Int { wronglyVisible.count + wronglyConcealed.count }
+        var count: Int {
+            wronglyVisible.count + wronglyConcealed.count
+        }
 
         var isEmpty: Bool {
             wronglyVisible.isEmpty && wronglyConcealed.isEmpty

--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -557,6 +557,20 @@ nonisolated enum LayoutSolver {
         return screenFrames.contains { $0.contains(leadingEdge) }
     }
 
+    /// Whether an item lies entirely off every display.
+    ///
+    /// ``isOnScreen`` tests only the leading edge, which is the right test
+    /// for drag anchors but the wrong one for deciding that a *divider* is
+    /// stranded (#978). Hiding a section expands its control item into a
+    /// spacer (`Lengths.expanded`) whose frame reaches far offscreen to the
+    /// left while its trailing edge stays anchored beside the visible
+    /// section, so every healthy collapsed bar fails the leading-edge test.
+    /// Only a divider displaced past all of its items — no edge on any
+    /// screen — is one the parked-divider recovery may rebuild.
+    static nonisolated func isFullyOffScreen(bounds: CGRect, screenFrames: [CGRect]) -> Bool {
+        !screenFrames.contains { $0.intersects(bounds) }
+    }
+
     // MARK: - Notch overflow
 
     /// Decides which visible items must overflow into hidden to fit the

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -832,7 +832,7 @@ extension MenuBarItemManager {
         // comparison to mean anything: a nil on either side is the ordinary
         // first cycle, not a change.
         let menuBarDisplayChanged: Bool = if let previousCacheDisplayID,
-                                            let currentDisplayID = context.cache.displayID
+                                             let currentDisplayID = context.cache.displayID
         {
             previousCacheDisplayID != currentDisplayID
         } else {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -1009,6 +1009,13 @@ extension MenuBarItemManager {
     /// Rebuilds an authoritatively identified hidden divider after it remains
     /// parked through repeated layout applies that need it on the bar.
     ///
+    /// "Parked" here means stranded: no edge of the divider's frame falls on
+    /// any display (``LayoutSolver/isFullyOffScreen(bounds:screenFrames:)``).
+    /// The leading-edge test is not enough — a healthy collapsed bar expands
+    /// H_ctrl into an offscreen-reaching spacer, and reading that as parked
+    /// would rebuild dividers that are doing their job (#978). Only a
+    /// divider pushed past every item has both edges offscreen.
+    ///
     /// `managedItemCount` decides whether the rebuild may also re-stamp the
     /// seeded position. See ``canSeedRebuiltDividerPosition(managedItemCount:)``.
     func recoverParkedHiddenDividerIfNeeded(
@@ -1018,7 +1025,7 @@ extension MenuBarItemManager {
         managedItemCount: Int
     ) -> Bool {
         guard hiddenBoundaryMismatch > 0,
-              !LayoutSolver.isOnScreen(bounds: hiddenControlItem.bounds, screenFrames: screenFrames)
+              LayoutSolver.isFullyOffScreen(bounds: hiddenControlItem.bounds, screenFrames: screenFrames)
         else {
             parkedHiddenDividerMismatchStreak = 0
             didRecoverParkedHiddenDividerForCurrentMismatch = false

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -993,11 +993,14 @@ extension MenuBarItemManager {
         }
 
         didRecoverHiddenSectionForCurrentCollapse = true
-        let seedPosition = Self.seedPositionForRebuiltDivider(managedItemCount: managedItemCount)
-        MenuBarItemManager.diagLog.warning(
-            "Hidden section remained collapsed for \(hiddenSectionCollapseStreak) authoritative cache passes; rebuilding H_ctrl\(Self.seedDescription(seedPosition))"
+        let seed = Self.seedForRebuiltDivider(
+            managedItemCount: managedItemCount,
+            storedPositions: Self.currentStoredDividerPositions()
         )
-        hiddenControlItem.recreateStatusItem(preferredPosition: seedPosition)
+        MenuBarItemManager.diagLog.warning(
+            "Hidden section remained collapsed for \(hiddenSectionCollapseStreak) authoritative cache passes; rebuilding H_ctrl\(Self.seedDescription(seed))"
+        )
+        hiddenControlItem.recreateStatusItem(preferredPosition: seed.preferredPosition)
 
         Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(100))
@@ -1006,8 +1009,41 @@ extension MenuBarItemManager {
         return true
     }
 
+    /// Why a cycle is asking the parked-divider recovery to look at H_ctrl.
+    ///
+    /// The recovery used to take the Phase 1 boundary mismatch alone, which
+    /// made it unreachable in the state it exists to repair (#978): a
+    /// stranded divider reads as a zero-width hidden section, the zero-width
+    /// guards in `applySavedLayout` and `applyProfileLayout` return before
+    /// Phase 1 runs, so the mismatch was never computed and the streak never
+    /// advanced. A refusal is itself evidence an apply wanted the divider on
+    /// the bar and could not have it, so it counts the same as a mismatch.
+    nonisolated enum ParkedDividerTrigger {
+        /// Phase 1 found items on the wrong side of H_ctrl.
+        case boundaryMismatch(Int)
+        /// An apply refused upstream because the hidden section read as
+        /// having no room between the dividers. `source` names the guard.
+        case refusedApply(source: String)
+
+        /// Whether this cycle actually needed the divider on the bar. A
+        /// mismatch of zero is a healthy cycle; a refusal never is.
+        var needsDividerOnBar: Bool {
+            switch self {
+            case let .boundaryMismatch(count): count > 0
+            case .refusedApply: true
+            }
+        }
+
+        var logDescription: String {
+            switch self {
+            case let .boundaryMismatch(count): "\(count)-item boundary mismatch"
+            case let .refusedApply(source): "refused \(source) apply"
+            }
+        }
+    }
+
     /// Rebuilds an authoritatively identified hidden divider after it remains
-    /// parked through repeated layout applies that need it on the bar.
+    /// parked through repeated layout cycles that need it on the bar.
     ///
     /// "Parked" here means stranded: no edge of the divider's frame falls on
     /// any display (``LayoutSolver/isFullyOffScreen(bounds:screenFrames:)``).
@@ -1016,19 +1052,19 @@ extension MenuBarItemManager {
     /// would rebuild dividers that are doing their job (#978). Only a
     /// divider pushed past every item has both edges offscreen.
     ///
-    /// `managedItemCount` decides whether the rebuild may also re-stamp the
-    /// seeded position. See ``canSeedRebuiltDividerPosition(managedItemCount:)``.
+    /// `managedItemCount` and the stored control item positions decide what
+    /// the rebuild does with the autosaved position. See
+    /// ``MenuBarItemManager/seedForRebuiltDivider(managedItemCount:storedPositions:)``.
     func recoverParkedHiddenDividerIfNeeded(
-        hiddenBoundaryMismatch: Int,
+        trigger: ParkedDividerTrigger,
         hiddenControlItem: MenuBarItem,
         screenFrames: [CGRect],
         managedItemCount: Int
     ) -> Bool {
-        guard hiddenBoundaryMismatch > 0,
+        guard trigger.needsDividerOnBar,
               LayoutSolver.isFullyOffScreen(bounds: hiddenControlItem.bounds, screenFrames: screenFrames)
         else {
-            parkedHiddenDividerMismatchStreak = 0
-            didRecoverParkedHiddenDividerForCurrentMismatch = false
+            resetParkedHiddenDividerRecovery()
             return false
         }
 
@@ -1043,11 +1079,14 @@ extension MenuBarItemManager {
         }
 
         didRecoverParkedHiddenDividerForCurrentMismatch = true
-        let seedPosition = Self.seedPositionForRebuiltDivider(managedItemCount: managedItemCount)
-        MenuBarItemManager.diagLog.warning(
-            "H_ctrl remained parked through \(parkedHiddenDividerMismatchStreak) authoritative mismatch applies; rebuilding it\(Self.seedDescription(seedPosition))"
+        let seed = MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: managedItemCount,
+            storedPositions: MenuBarItemManager.currentStoredDividerPositions()
         )
-        hiddenControl.recreateStatusItem(preferredPosition: seedPosition)
+        MenuBarItemManager.diagLog.warning(
+            "H_ctrl remained parked through \(parkedHiddenDividerMismatchStreak) authoritative applies (\(trigger.logDescription)); rebuilding it\(MenuBarItemManager.seedDescription(seed))"
+        )
+        hiddenControl.recreateStatusItem(preferredPosition: seed.preferredPosition)
 
         Task { [weak self] in
             try? await Task.sleep(for: .milliseconds(100))
@@ -1061,6 +1100,19 @@ extension MenuBarItemManager {
             )
         }
         return true
+    }
+
+    /// Clears the parked-divider streak, so the next strand starts counting
+    /// from zero and is allowed its own rebuild.
+    ///
+    /// Kept separate from the guard that discovers a healthy divider because
+    /// Phase 1 also has to clear it, and clearing it there on a zero mismatch
+    /// alone was half of why the recovery could never fire (#978): a divider
+    /// stranded while the visible/hidden boundary was consistent had its
+    /// streak reset on every cycle.
+    func resetParkedHiddenDividerRecovery() {
+        parkedHiddenDividerMismatchStreak = 0
+        didRecoverParkedHiddenDividerForCurrentMismatch = false
     }
 
     /// Whether bundleID owns a menu bar item Thaw already tracks: an entry

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1550,7 +1550,16 @@ extension MenuBarItemManager {
             // is in AppKit's flipped coordinate space and can diverge for
             // mirrored or transitioning displays.
             let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-            if case .savedOrder = source,
+            // The recovery used to be reserved for .savedOrder applies
+            // (#978): profile-sourced applies — Layout-editor drags, ⌘-drag
+            // re-sorts — never reached it, so the streak could not advance on
+            // exactly the cycles where a user rearranging the bar kept
+            // displacing or exposing the stranded divider. Every apply source
+            // now feeds the recovery. Recreating the status item is still
+            // withheld while a ⌘-drag is live: replacing the window under an
+            // open drag session strands the drag the same way the parked
+            // divider does, and the next apply re-reads and re-counts.
+            if !appState.isDraggingMenuBarItem,
                recoverParkedHiddenDividerIfNeeded(
                    hiddenBoundaryMismatch: hiddenBoundaryMismatch,
                    hiddenControlItem: freshControl.hidden,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1346,9 +1346,9 @@ extension MenuBarItemManager {
         // a control item is cheaper than moving individual items.
         var movedCount = 0
         var didAttemptHCtrl = false
-        /// Set when a boundary repair carried items across H_ctrl instead of
-        /// carrying H_ctrl across them. Either way the sections the AH_ctrl
-        /// planning below reads are stale afterwards.
+        // Set when a boundary repair carried items across H_ctrl instead of
+        // carrying H_ctrl across them. Either way the sections the AH_ctrl
+        // planning below reads are stale afterwards.
         var didCrossHiddenBoundary = false
         var canRepositionControlItems = controlItems.canRepositionControlItems
         // Moves this batch planned for an item that is still on the bar and

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -673,9 +673,31 @@ extension MenuBarItemManager {
     /// disk. Called from each applyProfileLayout success exit so the
     /// on-disk intent only commits once the bar reflects it. No-op for
     /// .savedOrder (that path doesn't overwrite either store).
+    ///
+    /// "Success" is the apply reaching an uncancelled exit, which is not the
+    /// same as the bar having taken the arrangement. An apply that plans
+    /// moves and fails to enact them still lands here, and this is the one
+    /// write to `savedSectionOrder` that never consulted
+    /// ``LayoutSolver/shouldPersistSavedOrder(_:)`` — so a bar whose drags
+    /// were failing had its wreckage committed while every gated save was
+    /// refusing for exactly that reason (#978). The section order is
+    /// withheld on an unfinished batch for the same reason the gated path
+    /// withholds it: recording a partial arrangement hands the next apply a
+    /// target it just moved, and the bar drifts further on every retry
+    /// (#900).
+    ///
+    /// The pinning sets are not withheld. They are the profile's own
+    /// declaration, not a reading of the bar, so a failed batch says nothing
+    /// about whether they are right.
     private func persistProfileStateOnSuccess(source: ApplySource) {
         guard case .profile = source else { return }
         persistPinnedBundleIDs()
+        guard !hasUnfinishedMoveBatch else {
+            MenuBarItemManager.diagLog.warning(
+                "Skipping the profile's saved section order write; the bulk apply left planned moves unenacted"
+            )
+            return
+        }
         persistSavedSectionOrder()
         // Committed: the pre-arm snapshot can no longer be rolled back to.
         priorProfileApplySnapshot = nil
@@ -1965,8 +1987,11 @@ extension MenuBarItemManager {
             // If hidden is empty, AH_ctrl goes next to H_ctrl.
             // If AH is empty, AH_ctrl also goes next to H_ctrl (no
             // boundary needed).
+            // CGDisplayBounds shares the top-left origin space of the item
+            // bounds; NSScreen.frame does not.
+            let ahScreenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
             let desiredHiddenUIDs = itemOrder["hidden"] ?? []
-            let dest: MoveDestination? = if let firstHiddenUID = desiredHiddenUIDs.first,
+            var dest: MoveDestination? = if let firstHiddenUID = desiredHiddenUIDs.first,
                                             let firstHidden = allFreshItems.first(where: { $0.uniqueIdentifier == firstHiddenUID && $0.isMovable })
             {
                 // Place AH_ctrl to the LEFT of the rightmost hidden
@@ -1976,6 +2001,29 @@ extension MenuBarItemManager {
             } else {
                 // Hidden is empty; AH_ctrl goes next to H_ctrl.
                 .leftOfItem(freshControl.hidden)
+            }
+
+            // Never anchor on an offscreen destination. Anchoring beside a
+            // parked item drags AH_ctrl into the parked zone, which is how
+            // #978 acquired its second, worse fault: the AH_ctrl move
+            // targeted `left of ControlItem.Hidden` while H_ctrl sat at
+            // minX=-3596, the drag walked H_ctrl to -9322, and the pair came
+            // out inverted with the hidden section reading zero width. The
+            // reporter traced their strand to this path rather than to the
+            // visible/hidden boundary repair. Same reasoning as the Thaw-icon
+            // relocation guard in enforceControlItemOrder, and the same
+            // leading-edge test, which is the right one for a drag anchor.
+            //
+            // Refusing leaves AH_ctrl where it is and lets the per-item
+            // fallback below place items against it, which moves more items
+            // but strands nothing.
+            if let anchorBounds = dest?.targetItem.liveBounds,
+               !LayoutSolver.isOnScreen(bounds: anchorBounds, screenFrames: ahScreenFrames)
+            {
+                MenuBarItemManager.diagLog.warning(
+                    "Profile layout: skipping the AH_ctrl placement, its anchor is parked offscreen (minX=\(anchorBounds.minX)); moving AH_ctrl beside it would strand both"
+                )
+                dest = nil
             }
 
             if let dest, !Task.isCancelled {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -630,6 +630,45 @@ extension MenuBarItemManager {
         )
     }
 
+    /// Offers a stranded divider a way out before an apply refuses on the
+    /// zero-width hidden section.
+    ///
+    /// The refusal is right in itself: a hidden section with no room between
+    /// the dividers is an untrustworthy reading, and planning against it
+    /// drags items to the wrong side of the bar (#868). But when the reason
+    /// there is no room is that H_ctrl has been pushed off every display, the
+    /// refusal is also what makes the strand permanent (#978). The apply
+    /// returns before Phase 1, the boundary mismatch is never computed, and
+    /// the recovery that would rebuild the divider never advances its streak.
+    /// #978's log caught the shape exactly: one launch produced 17
+    /// `parked offscreen` and 24 `zero width` warnings and not a single
+    /// `Phase 1:` line.
+    ///
+    /// So the guards still refuse — nothing plans against the bad reading —
+    /// but a stranded divider now counts the refusal, and a run of them
+    /// rebuilds it. The rebuild is withheld while a ⌘-drag is live, matching
+    /// the Phase 1 caller: replacing the window under an open drag session
+    /// strands the drag the same way the parked divider does.
+    func recoverStrandedHiddenDividerBeforeRefusing(
+        guardSource: String,
+        controlItems: ControlItemPair,
+        items: [MenuBarItem]
+    ) {
+        guard appState?.isDraggingMenuBarItem != true else { return }
+        _ = recoverParkedHiddenDividerIfNeeded(
+            trigger: .refusedApply(source: guardSource),
+            hiddenControlItem: controlItems.hidden,
+            // CGDisplayBounds shares the top-left origin space of the item
+            // bounds; NSScreen.frame does not.
+            screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) },
+            managedItemCount: items.count { item in
+                (item.canBeHidden || item.tag == .visibleControlItem)
+                    && item.isMovable
+                    && !item.isControlItem
+            }
+        )
+    }
+
     /// Persists the profile's pinning sets and saved section order to
     /// disk. Called from each applyProfileLayout success exit so the
     /// on-disk intent only commits once the bar reflects it. No-op for
@@ -1294,6 +1333,11 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "applyProfileLayout: skipping (savedOrder); hidden section has zero width between the dividers (hidden.minX=\(controlItems.hidden.bounds.minX) windowID=\(controlItems.hidden.windowID), alwaysHidden.maxX=\(controlItems.alwaysHidden?.bounds.maxX.description ?? "nil") windowID=\(controlItems.alwaysHidden?.windowID.description ?? "nil"))"
             )
+            recoverStrandedHiddenDividerBeforeRefusing(
+                guardSource: "applyProfileLayout",
+                controlItems: controlItems,
+                items: items
+            )
             clearProfileState(source: source, items: items)
             return
         }
@@ -1514,9 +1558,21 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.debug(
             "Profile layout Phase 1: liveConcealed=\(liveConcealedCount), liveVisible=\(liveVisibleCount), moveHiddenDivider=\(shouldMoveHiddenDivider)"
         )
-        if hiddenBoundaryMismatch == 0 {
-            parkedHiddenDividerMismatchStreak = 0
-            didRecoverParkedHiddenDividerForCurrentMismatch = false
+        // A zero mismatch alone must not clear the streak. #978's divider
+        // stranded while the visible/hidden boundary was consistent —
+        // `hiddenBoundaryMismatch=0` on the very cycle that logged
+        // `parked offscreen` — so resetting here zeroed the counter on every
+        // pass and the recovery could never reach its threshold. Clear it
+        // only once the divider is demonstrably not stranded, using the same
+        // both-edges test the recovery arms on so the two agree about a
+        // healthy collapsed bar.
+        if hiddenBoundaryMismatch == 0,
+           !LayoutSolver.isFullyOffScreen(
+               bounds: controlItems.hidden.bounds,
+               screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) }
+           )
+        {
+            resetParkedHiddenDividerRecovery()
         }
 
         // ── Sub-phase 1: Restore the visible/hidden boundary ──
@@ -1561,7 +1617,7 @@ extension MenuBarItemManager {
             // divider does, and the next apply re-reads and re-counts.
             if !appState.isDraggingMenuBarItem,
                recoverParkedHiddenDividerIfNeeded(
-                   hiddenBoundaryMismatch: hiddenBoundaryMismatch,
+                   trigger: .boundaryMismatch(hiddenBoundaryMismatch),
                    hiddenControlItem: freshControl.hidden,
                    screenFrames: screenFrames,
                    // Counted from the fresh read rather than the Phase 1 sets,
@@ -2423,24 +2479,151 @@ extension MenuBarItemManager {
         managedItemCount == 0
     }
 
-    /// The preferred position a divider rebuild should stamp, or `nil` to
-    /// rebuild without touching the stored position.
+    /// The stored `NSStatusItem` preferred positions of the three control
+    /// items, as a divider rebuild reads them back off `ControlItemDefaults`.
     ///
-    /// The value matches the one `ControlItem.preflightSetup` seeds for the
-    /// hidden divider, so an empty bar still lands where a fresh install puts
-    /// it.
-    static nonisolated func seedPositionForRebuiltDivider(managedItemCount: Int) -> CGFloat? {
-        canSeedRebuiltDividerPosition(managedItemCount: managedItemCount) ? 1 : nil
+    /// Larger means further left: `ControlItem.preflightSetup` seeds the
+    /// visible item at 0 and the hidden divider at 1, and a healthy bar runs
+    /// `visible < hidden < alwaysHidden` reading right to left. `nil` means
+    /// nothing is stored for that item — the always-hidden divider has no
+    /// seed at all, and carries none while its section is disabled.
+    nonisolated struct StoredDividerPositions {
+        let visible: CGFloat?
+        let hidden: CGFloat?
+        let alwaysHidden: CGFloat?
+    }
+
+    /// Whether the stored hidden-divider position still describes a bar the
+    /// divider can be rebuilt onto.
+    ///
+    /// A rebuild that keeps the stored position is only safe while that
+    /// position orders the dividers correctly. #978's did not: macOS had
+    /// autosaved `hidden=6866` against `alwaysHidden=1034`, putting H_ctrl
+    /// left of AH_ctrl, which is the inversion that reads as a zero-width
+    /// hidden section. Restoring it on the next launch is why a relaunch
+    /// stopped clearing the strand — the app came up already stranded, first
+    /// layout line 0.4s after startup.
+    ///
+    /// Unknown bounds can't falsify the ordering, so they pass: the check
+    /// only reports an ordering it can actually see violated.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func storedHiddenPositionIsOrdered(_ positions: StoredDividerPositions) -> Bool {
+        guard let hidden = positions.hidden else { return true }
+        if let visible = positions.visible, hidden <= visible {
+            return false
+        }
+        if let alwaysHidden = positions.alwaysHidden, hidden >= alwaysHidden {
+            return false
+        }
+        return true
+    }
+
+    /// A stored position to replace an inverted one with, or `nil` when the
+    /// neighbours give nothing to place the divider between.
+    ///
+    /// This restores *ordering*, not geometry. Dropping H_ctrl back between
+    /// the two chevrons is what gives the following apply a bar it can plan
+    /// against; walking the divider to the saved boundary is that apply's
+    /// job, exactly as it is for the empty-bar seed.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func repairedHiddenDividerPosition(
+        _ positions: StoredDividerPositions
+    ) -> CGFloat? {
+        switch (positions.visible, positions.alwaysHidden) {
+        case let (visible?, alwaysHidden?):
+            // Both neighbours corrupt too — a midpoint would just pick a
+            // different wrong answer, so leave the stored value alone and let
+            // the always-hidden path report its own strand.
+            guard alwaysHidden > visible else { return nil }
+            return (visible + alwaysHidden) / 2
+        case let (visible?, nil):
+            return visible + 1
+        case let (nil, alwaysHidden?):
+            return alwaysHidden - 1
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    /// What a divider rebuild should do with the stored preferred position.
+    nonisolated enum RebuiltDividerSeed: Equatable {
+        /// Stamp the value `ControlItem.preflightSetup` writes on a fresh
+        /// install. Only for a bar with no managed items.
+        case freshInstall(CGFloat)
+        /// Rebuild without touching the stored position.
+        case keepStored
+        /// Stamp a replacement because the stored position is inverted.
+        case repaired(CGFloat)
+
+        /// The value to hand `ControlItem.recreateStatusItem`, or `nil` to
+        /// leave the stored position alone.
+        var preferredPosition: CGFloat? {
+            switch self {
+            case let .freshInstall(position): position
+            case .keepStored: nil
+            case let .repaired(position): position
+            }
+        }
+    }
+
+    /// What a divider rebuild should stamp, given the bar it is rebuilding
+    /// onto and the positions currently on disk.
+    ///
+    /// Three outcomes, in order:
+    ///
+    /// - An empty bar takes the fresh-install seed, so it lands where a fresh
+    ///   install puts it.
+    /// - A populated bar whose stored position still orders the dividers
+    ///   keeps it, per ``canSeedRebuiltDividerPosition(managedItemCount:)``.
+    /// - A populated bar whose stored position is inverted takes a repaired
+    ///   one. Keeping an inverted position is what made #978 survive a
+    ///   relaunch: the rebuild logged "keeping its stored position", restored
+    ///   the value that stranded the divider, and re-entered the deadlock.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func seedForRebuiltDivider(
+        managedItemCount: Int,
+        storedPositions: StoredDividerPositions
+    ) -> RebuiltDividerSeed {
+        if canSeedRebuiltDividerPosition(managedItemCount: managedItemCount) {
+            return .freshInstall(1)
+        }
+        guard !storedHiddenPositionIsOrdered(storedPositions),
+              let repaired = repairedHiddenDividerPosition(storedPositions)
+        else {
+            return .keepStored
+        }
+        return .repaired(repaired)
+    }
+
+    /// Reads the stored control item positions a divider rebuild plans
+    /// against.
+    @MainActor
+    static func currentStoredDividerPositions() -> StoredDividerPositions {
+        StoredDividerPositions(
+            visible: ControlItemDefaults[.preferredPosition, ControlItem.Identifier.visible.rawValue],
+            hidden: ControlItemDefaults[.preferredPosition, ControlItem.Identifier.hidden.rawValue],
+            alwaysHidden: ControlItemDefaults[
+                .preferredPosition,
+                ControlItem.Identifier.alwaysHidden.rawValue
+            ]
+        )
     }
 
     /// Log fragment naming what a divider rebuild did with the stored
     /// position, so a field log says which branch ran without the reader
     /// having to infer it from the collapse that follows.
-    static nonisolated func seedDescription(_ seedPosition: CGFloat?) -> String {
-        guard let seedPosition else {
-            return " and keeping its stored position (the bar holds managed items)"
+    static nonisolated func seedDescription(_ seed: RebuiltDividerSeed) -> String {
+        switch seed {
+        case let .freshInstall(position):
+            " at its seeded position (\(position))"
+        case .keepStored:
+            " and keeping its stored position (the bar holds managed items)"
+        case let .repaired(position):
+            " at a repaired position (\(position)); the stored one ordered H_ctrl outside its neighbours"
         }
-        return " at its seeded position (\(seedPosition))"
     }
 
     static nonisolated func baseIdentifier(forSavedIdentifier identifier: String) -> String {
@@ -3108,6 +3291,11 @@ extension MenuBarItemManager {
         guard hiddenSectionHasRoom else {
             MenuBarItemManager.diagLog.warning(
                 "applySavedLayout: skipping (\(trigger)); hidden section has zero width between the dividers (hidden.minX=\(controlItems.hidden.bounds.minX) windowID=\(controlItems.hidden.windowID), alwaysHidden.maxX=\(controlItems.alwaysHidden?.bounds.maxX.description ?? "nil") windowID=\(controlItems.alwaysHidden?.windowID.description ?? "nil"))"
+            )
+            recoverStrandedHiddenDividerBeforeRefusing(
+                guardSource: "applySavedLayout",
+                controlItems: controlItems,
+                items: items
             )
             return false
         }

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -4388,6 +4388,9 @@
         }
       }
     },
+    "Alpha" : {
+      "comment" : "A segment in the update channel picker that displays \"Alpha\"."
+    },
     "Always Hidden" : {
 
     },
@@ -9177,6 +9180,9 @@
         }
       }
     },
+    "Beta" : {
+      "comment" : "A segment in the update channel picker that displays \"Beta\"."
+    },
     "Border" : {
       "comment" : "A toggle that lets the user enable or disable the border around the view.",
       "localizations" : {
@@ -13591,6 +13597,9 @@
           }
         }
       }
+    },
+    "Couldn't move %@ right now." : {
+
     },
     "Couldn't move %@ to the always-hidden section." : {
 
@@ -46047,6 +46056,9 @@
           }
         }
       }
+    },
+    "The %@ section is collapsed, so its divider is offscreen. Open the section and try dragging the item again." : {
+
     },
     "The amount of time to wait before showing a tooltip over a menu bar item." : {
       "comment" : "Label for a slider that controls the delay before showing a tooltip over a menu bar item.",

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -26751,7 +26751,7 @@
         }
       }
     },
-    "macOS 27 Is Not Yet Supported" : {
+    "macOS %lld Is Not Yet Supported" : {
 
     },
     "macOS draws a solid menu bar while Reduce Transparency is on, so %@ cannot tint or reshape it. Turn the setting off to see these effects." : {
@@ -46542,10 +46542,10 @@
         }
       }
     },
-    "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel." : {
+    "This version of Thaw is not yet compatible with macOS %lld. Preview builds are available on GitHub Releases, and support will be delivered through the alpha update channel." : {
 
     },
-    "This version of Thaw is not yet compatible with macOS 27. Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub." : {
+    "This version of Thaw is not yet compatible with macOS %lld. Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub." : {
 
     },
     "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -44985,6 +44985,9 @@
         }
       }
     },
+    "Switch to Alpha Updates" : {
+
+    },
     "Thaw gives you complete control over your menu bar — hide clutter, customize the look, and automate your workflow." : {
       "comment" : "Description of the welcome onboarding slide.",
       "localizations" : {
@@ -46540,6 +46543,9 @@
       }
     },
     "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel." : {
+
+    },
+    "This version of Thaw is not yet compatible with macOS 27. Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub." : {
 
     },
     "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {

--- a/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/AboutSettingsPane.swift
@@ -189,9 +189,10 @@ struct AboutSettingsPane: View {
         HStack {
             Text("Update channel")
             Spacer()
-            Picker("Update channel", selection: $updatesManager.allowsBetaUpdates) {
-                Text("Stable").tag(false)
-                Text("Development").tag(true)
+            Picker("Update channel", selection: $updatesManager.updateChannel) {
+                ForEach(UpdateChannel.availableCases(on: ProcessInfo.processInfo.operatingSystemVersion)) { channel in
+                    Text(channel.localized).tag(channel)
+                }
             }
             .pickerStyle(.segmented)
             .labelsHidden()

--- a/Thaw/Utilities/MacOSCompatibilityWarning.swift
+++ b/Thaw/Utilities/MacOSCompatibilityWarning.swift
@@ -9,8 +9,17 @@
 import AppKit
 
 enum MacOSCompatibilityWarning {
+    /// The first macOS this build does not support, and the one the rewrite
+    /// on ``UpdateChannel/alpha`` is built against.
+    ///
+    /// The two readings are the same number for the same reason: the alert
+    /// below tells the user that support for this release arrives through the
+    /// alpha channel, so the version that triggers the warning has to be the
+    /// version that makes that channel selectable.
+    static nonisolated let firstUnsupportedMajorVersion = 27
+
     static nonisolated func shouldShow(for version: OperatingSystemVersion) -> Bool {
-        version.majorVersion >= 27
+        version.majorVersion >= firstUnsupportedMajorVersion
     }
 
     @MainActor

--- a/Thaw/Utilities/MacOSCompatibilityWarning.swift
+++ b/Thaw/Utilities/MacOSCompatibilityWarning.swift
@@ -22,22 +22,46 @@ enum MacOSCompatibilityWarning {
         version.majorVersion >= firstUnsupportedMajorVersion
     }
 
+    /// Warns about the running macOS and offers the channel that supports it.
+    ///
+    /// The offer is made only when `updatesManager` can act on it and the
+    /// running system can actually be given the alpha channel. Both readings
+    /// come from ``firstUnsupportedMajorVersion``, so the offer stands
+    /// whenever the alert appears; the check is what keeps the alert honest
+    /// if the two ever part. Without it, the user is sent to the releases
+    /// page to pick a build by hand.
     @MainActor
-    static func showIfNeeded() {
-        guard shouldShow(for: ProcessInfo.processInfo.operatingSystemVersion) else { return }
+    static func showIfNeeded(updatesManager: UpdatesManager?) {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        guard shouldShow(for: version) else { return }
+
+        let subscriber = UpdateChannel.alpha.isAvailable(on: version) ? updatesManager : nil
 
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = String(localized: "macOS 27 Is Not Yet Supported")
-        alert.informativeText = String(
-            localized: """
-            This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel.
-            """
-        )
-        alert.addButton(withTitle: String(localized: "View Preview Builds"))
+        if subscriber != nil {
+            alert.informativeText = String(
+                localized: """
+                This version of Thaw is not yet compatible with macOS 27. Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub.
+                """
+            )
+            alert.addButton(withTitle: String(localized: "Switch to Alpha Updates"))
+        } else {
+            alert.informativeText = String(
+                localized: """
+                This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel.
+                """
+            )
+            alert.addButton(withTitle: String(localized: "View Preview Builds"))
+        }
         alert.addButton(withTitle: String(localized: "Continue"))
 
-        if alert.runModal() == .alertFirstButtonReturn {
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+
+        if let subscriber {
+            subscriber.checkForAlphaUpdateAfterCompatibilityWarning()
+        } else {
             NSWorkspace.shared.open(Constants.releasesURL)
         }
     }

--- a/Thaw/Utilities/MacOSCompatibilityWarning.swift
+++ b/Thaw/Utilities/MacOSCompatibilityWarning.swift
@@ -36,21 +36,25 @@ enum MacOSCompatibilityWarning {
         guard shouldShow(for: version) else { return }
 
         let subscriber = UpdateChannel.alpha.isAvailable(on: version) ? updatesManager : nil
+        // The warning fires on every release from the unsupported one onward,
+        // so the copy names the macOS actually running rather than the first
+        // one this build turned away.
+        let release = version.majorVersion
 
         let alert = NSAlert()
         alert.alertStyle = .warning
-        alert.messageText = String(localized: "macOS 27 Is Not Yet Supported")
+        alert.messageText = String(localized: "macOS \(release) Is Not Yet Supported")
         if subscriber != nil {
             alert.informativeText = String(
                 localized: """
-                This version of Thaw is not yet compatible with macOS 27. Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub.
+                This version of Thaw is not yet compatible with macOS \(release). Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub.
                 """
             )
             alert.addButton(withTitle: String(localized: "Switch to Alpha Updates"))
         } else {
             alert.informativeText = String(
                 localized: """
-                This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel.
+                This version of Thaw is not yet compatible with macOS \(release). Preview builds are available on GitHub Releases, and support will be delivered through the alpha update channel.
                 """
             )
             alert.addButton(withTitle: String(localized: "View Preview Builds"))

--- a/Thaw/Utilities/MacOSCompatibilityWarning.swift
+++ b/Thaw/Utilities/MacOSCompatibilityWarning.swift
@@ -22,50 +22,96 @@ enum MacOSCompatibilityWarning {
         version.majorVersion >= firstUnsupportedMajorVersion
     }
 
-    /// Warns about the running macOS and offers the channel that supports it.
+    /// What the alert's default button does.
+    nonisolated enum Action: Equatable {
+        /// Subscribe to the alpha channel and check for the build it carries.
+        case subscribeToAlpha
+        /// Open the releases page so the user can pick a build by hand.
+        case openReleasesPage
+    }
+
+    /// The alert an unsupported system is owed: what it says, and what its
+    /// default button does.
+    nonisolated struct Prompt: Equatable {
+        let title: String
+        let message: String
+        let confirmButtonTitle: String
+        let action: Action
+    }
+
+    /// The prompt for a system, or `nil` when the system is supported and no
+    /// alert is due.
     ///
-    /// The offer is made only when `updatesManager` can act on it and the
-    /// running system can actually be given the alpha channel. Both readings
-    /// come from ``firstUnsupportedMajorVersion``, so the offer stands
-    /// whenever the alert appears; the check is what keeps the alert honest
-    /// if the two ever part. Without it, the user is sent to the releases
-    /// page to pick a build by hand.
-    @MainActor
-    static func showIfNeeded(updatesManager: UpdatesManager?) {
-        let version = ProcessInfo.processInfo.operatingSystemVersion
-        guard shouldShow(for: version) else { return }
+    /// The alpha offer needs somewhere to send the subscription, so
+    /// `canSubscribe` reports whether an updates manager reached the call.
+    /// Alpha availability is checked against the running system rather than
+    /// assumed: the alert must not offer a channel it cannot select. Both
+    /// readings come from ``firstUnsupportedMajorVersion``, so the offer
+    /// stands whenever the alert appears; the check is what keeps the alert
+    /// honest if the two ever part.
+    ///
+    /// The warning fires on every release from the unsupported one onward, so
+    /// the copy names the macOS actually running rather than the first one
+    /// this build turned away.
+    static nonisolated func prompt(
+        for version: OperatingSystemVersion,
+        canSubscribe: Bool
+    ) -> Prompt? {
+        guard shouldShow(for: version) else {
+            return nil
+        }
 
-        let subscriber = UpdateChannel.alpha.isAvailable(on: version) ? updatesManager : nil
-        // The warning fires on every release from the unsupported one onward,
-        // so the copy names the macOS actually running rather than the first
-        // one this build turned away.
         let release = version.majorVersion
+        let title = String(localized: "macOS \(release) Is Not Yet Supported")
 
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = String(localized: "macOS \(release) Is Not Yet Supported")
-        if subscriber != nil {
-            alert.informativeText = String(
+        guard canSubscribe, UpdateChannel.alpha.isAvailable(on: version) else {
+            return Prompt(
+                title: title,
+                message: String(
+                    localized: """
+                    This version of Thaw is not yet compatible with macOS \(release). Preview builds are available on GitHub Releases, and support will be delivered through the alpha update channel.
+                    """
+                ),
+                confirmButtonTitle: String(localized: "View Preview Builds"),
+                action: .openReleasesPage
+            )
+        }
+
+        return Prompt(
+            title: title,
+            message: String(
                 localized: """
                 This version of Thaw is not yet compatible with macOS \(release). Support arrives through the alpha channel, which carries the rewritten app. Thaw can subscribe you and check for a build now. If none has been published yet, it opens the preview builds on GitHub.
                 """
-            )
-            alert.addButton(withTitle: String(localized: "Switch to Alpha Updates"))
-        } else {
-            alert.informativeText = String(
-                localized: """
-                This version of Thaw is not yet compatible with macOS \(release). Preview builds are available on GitHub Releases, and support will be delivered through the alpha update channel.
-                """
-            )
-            alert.addButton(withTitle: String(localized: "View Preview Builds"))
+            ),
+            confirmButtonTitle: String(localized: "Switch to Alpha Updates"),
+            action: .subscribeToAlpha
+        )
+    }
+
+    /// Warns about the running macOS and offers the channel that supports it.
+    @MainActor
+    static func showIfNeeded(updatesManager: UpdatesManager?) {
+        let version = ProcessInfo.processInfo.operatingSystemVersion
+        guard let prompt = prompt(for: version, canSubscribe: updatesManager != nil) else {
+            return
         }
+
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = prompt.title
+        alert.informativeText = prompt.message
+        alert.addButton(withTitle: prompt.confirmButtonTitle)
         alert.addButton(withTitle: String(localized: "Continue"))
 
-        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        guard alert.runModal() == .alertFirstButtonReturn else {
+            return
+        }
 
-        if let subscriber {
-            subscriber.checkForAlphaUpdateAfterCompatibilityWarning()
-        } else {
+        switch prompt.action {
+        case .subscribeToAlpha:
+            updatesManager?.checkForAlphaUpdateAfterCompatibilityWarning()
+        case .openReleasesPage:
             NSWorkspace.shared.open(Constants.releasesURL)
         }
     }

--- a/ThawTests/Main/UpdateChannelTests.swift
+++ b/ThawTests/Main/UpdateChannelTests.swift
@@ -1,0 +1,167 @@
+//
+//  UpdateChannelTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+import Testing
+@testable import Thaw
+
+/// Pins the channel split that separated alpha from beta.
+///
+/// A single `AllowsBetaUpdates` flag used to return `["alpha", "beta"]`
+/// together, so there was no way to take release candidates without also
+/// taking the rewrite. Alpha and beta are now separate opt-ins on the one
+/// feed. Sparkle always includes the default channel in the allowed set, so
+/// no `allowedChannels` value can keep stable releases away from a
+/// subscriber; what keeps them from winning is that Sparkle offers the
+/// newest allowed item, and 3.x outranks anything the 2.x line can carry.
+///
+/// Serialized and run against a scratch defaults suite: the migration reads
+/// and writes real preference keys through the process-wide `Defaults.store`.
+@Suite("Update channels", .serialized)
+struct UpdateChannelTests {
+    /// Sparkle offers an item with no `sparkle:channel` to every subscriber,
+    /// so stable is the absence of an opt-in rather than a channel of its own.
+    @Test("Stable subscribes to no explicit channel")
+    func stableAllowsNoChannels() {
+        #expect(UpdateChannel.stable.allowedSparkleChannels.isEmpty)
+    }
+
+    /// The point of the split: beta must not pull alpha in with it.
+    @Test("Beta takes beta without alpha")
+    func betaExcludesAlpha() {
+        #expect(UpdateChannel.beta.allowedSparkleChannels == ["beta"])
+    }
+
+    /// The other half of the split: alpha must not pull beta in with it.
+    /// Alpha is a parallel track, not a superset of the release candidates.
+    @Test("Alpha takes alpha without beta")
+    func alphaExcludesBeta() {
+        #expect(UpdateChannel.alpha.allowedSparkleChannels == ["alpha"])
+    }
+
+    /// No channel overrides the feed: all three read the `SUFeedURL` from
+    /// `Info.plist`, and the appcast's `sparkle:channel` tags do the sorting.
+    @Test("Every channel reads the same feed")
+    func noChannelOverridesTheFeed() {
+        #expect(UpdateChannel.beta.allowedSparkleChannels
+            .isDisjoint(with: UpdateChannel.alpha.allowedSparkleChannels))
+    }
+
+    // MARK: Availability
+
+    /// The rewrite targets the macOS this build does not support, so the
+    /// channel carrying it stays hidden until the user is on that macOS.
+    @Test("Alpha is hidden before macOS 27", arguments: [25, 26])
+    func alphaHiddenOnSupportedVersions(majorVersion: Int) {
+        let cases = UpdateChannel.availableCases(on: Self.version(majorVersion))
+        #expect(cases == [.stable, .beta])
+        #expect(!UpdateChannel.alpha.isAvailable(on: Self.version(majorVersion)))
+    }
+
+    /// The threshold is shared with the compatibility warning, whose alert
+    /// tells the user that support arrives through this channel.
+    @Test("Alpha is offered from macOS 27 on", arguments: [27, 28])
+    func alphaOfferedOnUnsupportedVersions(majorVersion: Int) {
+        let cases = UpdateChannel.availableCases(on: Self.version(majorVersion))
+        #expect(cases == [.stable, .beta, .alpha])
+    }
+
+    /// The warning and the channel have to move together: the alert points at
+    /// alpha, so a system that sees the alert must be able to select it.
+    @Test("The warning and the alpha gate share a threshold", arguments: [25, 26, 27, 28])
+    func warningAndAlphaGateAgree(majorVersion: Int) {
+        let version = Self.version(majorVersion)
+        #expect(
+            MacOSCompatibilityWarning.shouldShow(for: version)
+                == UpdateChannel.alpha.isAvailable(on: version)
+        )
+    }
+
+    /// Stable and beta are always selectable.
+    @Test("The shipping app's channels are always available", arguments: [25, 26, 27, 28])
+    func shippingChannelsAlwaysAvailable(majorVersion: Int) {
+        #expect(UpdateChannel.stable.isAvailable(on: Self.version(majorVersion)))
+        #expect(UpdateChannel.beta.isAvailable(on: Self.version(majorVersion)))
+    }
+
+    /// Selecting alpha and then returning to a supported macOS must not pin
+    /// the user to a feed that will never offer them anything.
+    @Test("A stored alpha is not honored on a supported macOS")
+    func storedAlphaIsNotHonoredBeforeMacOS27() throws {
+        try withScratchDefaults { suite in
+            suite.set(UpdateChannel.alpha.rawValue, forKey: "UpdateChannel")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(26)) == .beta)
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .alpha)
+        }
+    }
+
+    private static func version(_ majorVersion: Int) -> OperatingSystemVersion {
+        OperatingSystemVersion(majorVersion: majorVersion, minorVersion: 0, patchVersion: 0)
+    }
+
+    // MARK: Storage
+
+    /// Fresh installs start on stable.
+    @Test("No stored preference means stable")
+    func absentPreferenceIsStable() throws {
+        try withScratchDefaults { _ in
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .stable)
+        }
+    }
+
+    /// Existing "Development" subscribers land on beta, not alpha. Migrating
+    /// them to alpha would push the rewrite onto people who opted into a
+    /// setting that predated it.
+    @Test("The superseded flag migrates to beta")
+    func legacyFlagMigratesToBeta() throws {
+        try withScratchDefaults { suite in
+            suite.set(true, forKey: "AllowsBetaUpdates")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .beta)
+        }
+    }
+
+    /// A stable user under the old flag stays stable.
+    @Test("A false superseded flag stays stable")
+    func legacyFlagOffStaysStable() throws {
+        try withScratchDefaults { suite in
+            suite.set(false, forKey: "AllowsBetaUpdates")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .stable)
+        }
+    }
+
+    /// Once the user has picked a channel, the superseded flag no longer
+    /// speaks for them — otherwise choosing alpha would read back as beta.
+    @Test("An explicit channel wins over the superseded flag")
+    func explicitChannelWinsOverLegacyFlag() throws {
+        try withScratchDefaults { suite in
+            suite.set(true, forKey: "AllowsBetaUpdates")
+            suite.set(UpdateChannel.alpha.rawValue, forKey: "UpdateChannel")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .alpha)
+        }
+    }
+
+    /// An unrecognized value (a downgrade from a build with more channels,
+    /// or a hand-edited plist) falls back rather than trapping.
+    @Test("An unknown stored channel falls back to the superseded flag")
+    func unknownChannelFallsBack() throws {
+        try withScratchDefaults { suite in
+            suite.set(true, forKey: "AllowsBetaUpdates")
+            suite.set("canary", forKey: "UpdateChannel")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == .beta)
+        }
+    }
+
+    /// Every channel round-trips through the stored raw value.
+    @Test("Each channel round-trips", arguments: UpdateChannel.allCases)
+    func channelRoundTrips(channel: UpdateChannel) throws {
+        try withScratchDefaults { suite in
+            suite.set(channel.rawValue, forKey: "UpdateChannel")
+            #expect(UpdatesManager.storedUpdateChannel(on: Self.version(27)) == channel)
+        }
+    }
+}

--- a/ThawTests/Main/UpdatesManagerTests.swift
+++ b/ThawTests/Main/UpdatesManagerTests.swift
@@ -1,0 +1,194 @@
+//
+//  UpdatesManagerTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+import Testing
+@testable import Thaw
+
+/// Pins the promise the macOS compatibility alert makes.
+///
+/// The alert tells the user that a build for their macOS arrives through the
+/// alpha channel, then starts a check for it. Sparkle says nothing when a
+/// background check finds nothing, so the promise is tracked across the check
+/// and answered with the releases page when the feed comes back empty. These
+/// tests stand in for the check: they drive the outcomes Sparkle would report.
+///
+/// Serialized and run against a scratch defaults suite, since subscribing to a
+/// channel writes real preference keys through the process-wide
+/// `Defaults.store`.
+@MainActor
+@Suite("Compatibility update check", .serialized)
+struct UpdatesManagerTests {
+    /// Collects the URLs the manager would have handed to the browser.
+    private func manager(opened: @escaping @MainActor (URL) -> Void) -> UpdatesManager {
+        let manager = UpdatesManager()
+        manager.openURL = opened
+        return manager
+    }
+
+    @Test("Accepting the alert subscribes to alpha")
+    func acceptingTheAlertSubscribesToAlpha() throws {
+        try withScratchDefaults { _ in
+            let manager = manager { _ in }
+            manager.checkForAlphaUpdateAfterCompatibilityWarning()
+            #expect(manager.updateChannel == .alpha)
+        }
+    }
+
+    /// A feed with no alpha item is the state of the world until the rewrite
+    /// publishes one, so the fallback is the path most users take.
+    @Test("A check that finds nothing opens the releases page")
+    func emptyFeedOpensReleasesPage() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            manager.resolveCompatibilityCheckWithReleasesPage()
+            #expect(opened == [Constants.releasesURL])
+        }
+    }
+
+    /// Sparkle reports an empty check twice: `updaterDidNotFindUpdate` first,
+    /// then an abort carrying `SUNoUpdateError`. The second must not reopen
+    /// the page.
+    @Test("The promise is answered once")
+    func promiseIsAnsweredOnce() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            manager.resolveCompatibilityCheckWithReleasesPage()
+            manager.resolveCompatibilityCheckWithReleasesPage()
+            #expect(opened.count == 1)
+        }
+    }
+
+    /// Scheduled checks the user never asked for keep ending, and none of them
+    /// owes anyone a browser window.
+    @Test("A check nobody started opens nothing")
+    func unrequestedCheckOpensNothing() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.resolveCompatibilityCheckWithReleasesPage()
+            #expect(opened.isEmpty)
+        }
+    }
+
+    /// The alert's check is shown as soon as it lands. Deferring it to a
+    /// notification would answer the user's click with silence whenever they
+    /// have not granted notifications.
+    @Test("The alert's check is never deferred")
+    func compatibilityCheckIsShownImmediately() throws {
+        try withScratchDefaults { _ in
+            let manager = manager { _ in }
+            manager.beginCompatibilityCheck()
+            #expect(manager.shouldShowScheduledUpdate(inImmediateFocus: false, appIsActive: false))
+        }
+    }
+
+    @Test(
+        "An ordinary scheduled update follows the app's focus",
+        arguments: [(true, true, true), (false, true, false), (true, false, false), (false, false, false)]
+    )
+    func ordinaryScheduledUpdateFollowsFocus(immediateFocus: Bool, appIsActive: Bool, expected: Bool) throws {
+        try withScratchDefaults { _ in
+            let manager = manager { _ in }
+            #expect(
+                manager.shouldShowScheduledUpdate(
+                    inImmediateFocus: immediateFocus,
+                    appIsActive: appIsActive
+                ) == expected
+            )
+        }
+    }
+
+    /// The update window is the answer, so the notification is dropped and the
+    /// promise is closed with it: a later empty check belongs to someone else.
+    @Test("A found update answers the promise without notifying")
+    func foundUpdateAnswersWithoutNotifying() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            #expect(!manager.shouldNotifyAboutUpdate(userInitiated: false))
+
+            manager.resolveCompatibilityCheckWithReleasesPage()
+            #expect(opened.isEmpty)
+        }
+    }
+
+    /// Drives the delegate callbacks Sparkle itself calls, rather than the
+    /// helpers behind them, so the wiring between the two is covered too. The
+    /// updater is built with `startingUpdater: false`, so it schedules
+    /// nothing and reaches no network.
+    @Test("Sparkle reporting an empty check opens the releases page")
+    func sparkleEmptyCheckOpensReleasesPage() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            manager.updaterDidNotFindUpdate(manager.updater)
+            #expect(opened == [Constants.releasesURL])
+        }
+    }
+
+    /// An empty check ends twice: `updaterDidNotFindUpdate`, then an abort
+    /// carrying `SUNoUpdateError`. Only the first ending answers.
+    @Test("The abort that follows an empty check is not a second answer")
+    func abortAfterEmptyCheckDoesNotReopen() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            manager.updaterDidNotFindUpdate(manager.updater)
+            manager.updater(manager.updater, didAbortWithError: CocoaError(.fileNoSuchFile))
+            #expect(opened.count == 1)
+        }
+    }
+
+    /// A check that never reaches the feed still owes the user the page.
+    @Test("An abort on its own answers the promise")
+    func abortAloneAnswersThePromise() throws {
+        try withScratchDefaults { _ in
+            var opened: [URL] = []
+            let manager = manager { opened.append($0) }
+            manager.beginCompatibilityCheck()
+            manager.updater(manager.updater, didAbortWithError: CocoaError(.fileNoSuchFile))
+            #expect(opened == [Constants.releasesURL])
+        }
+    }
+
+    /// What Sparkle is told to accept comes from the stored channel, so the
+    /// picker in Settings reaches the updater.
+    @Test("The allowed channels follow the stored channel")
+    func allowedChannelsFollowStoredChannel() throws {
+        try withScratchDefaults { store in
+            let manager = manager { _ in }
+            store.set(UpdateChannel.beta.rawValue, forKey: "UpdateChannel")
+            #expect(manager.allowedChannels(for: manager.updater) == ["beta"])
+        }
+    }
+
+    @Test("An ordinary background update is still announced")
+    func ordinaryBackgroundUpdateNotifies() throws {
+        try withScratchDefaults { _ in
+            let manager = manager { _ in }
+            #expect(manager.shouldNotifyAboutUpdate(userInitiated: false))
+        }
+    }
+
+    /// An update the user asked for is already on screen in front of them.
+    @Test("A user-initiated update is not announced")
+    func userInitiatedUpdateDoesNotNotify() throws {
+        try withScratchDefaults { _ in
+            let manager = manager { _ in }
+            #expect(!manager.shouldNotifyAboutUpdate(userInitiated: true))
+        }
+    }
+}

--- a/ThawTests/Main/UpdatesManagerTests.swift
+++ b/ThawTests/Main/UpdatesManagerTests.swift
@@ -31,12 +31,21 @@ struct UpdatesManagerTests {
         return manager
     }
 
+    /// Read back through ``UpdatesManager/storedUpdateChannel(on:)`` rather
+    /// than `updateChannel`, whose getter withholds alpha from a system that
+    /// still has a shipping build to run. The alert only appears past that
+    /// line, but the machine running the tests need not be.
     @Test("Accepting the alert subscribes to alpha")
     func acceptingTheAlertSubscribesToAlpha() throws {
         try withScratchDefaults { _ in
             let manager = manager { _ in }
             manager.checkForAlphaUpdateAfterCompatibilityWarning()
-            #expect(manager.updateChannel == .alpha)
+            let unsupported = OperatingSystemVersion(
+                majorVersion: MacOSCompatibilityWarning.firstUnsupportedMajorVersion,
+                minorVersion: 0,
+                patchVersion: 0
+            )
+            #expect(UpdatesManager.storedUpdateChannel(on: unsupported) == .alpha)
         }
     }
 

--- a/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
+++ b/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import CoreGraphics
 import Testing
 @testable import Thaw
 
@@ -251,25 +252,62 @@ struct ParkedHiddenDividerRecoveryTests {
 /// earlier off-screen parkings that never rebuilt and never collapsed.
 @Suite("Rebuilt divider seed position")
 struct RebuiltDividerSeedPositionTests {
+    /// A healthy populated bar: visible rightmost, always-hidden leftmost,
+    /// hidden between them. Larger preferred position means further left.
+    private static let orderedPositions = MenuBarItemManager.StoredDividerPositions(
+        visible: 1008,
+        hidden: 1021,
+        alwaysHidden: 1034
+    )
+
+    /// #978's plist, verbatim. H_ctrl autosaved far left of AH_ctrl, which is
+    /// the inversion that reads as a zero-width hidden section.
+    private static let invertedPositions = MenuBarItemManager.StoredDividerPositions(
+        visible: 1008,
+        hidden: 6866,
+        alwaysHidden: 1034
+    )
+
     @Test("An empty bar still gets the fresh-install seed")
     func emptyBarKeepsTheSeed() {
         #expect(MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: 0))
-        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: 0) == 1)
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: 0,
+            storedPositions: Self.orderedPositions
+        ) == .freshInstall(1))
+    }
+
+    /// The empty-bar branch runs first: nothing is stranded on a bar with no
+    /// items, so an inverted position there is just stale and the fresh
+    /// install seed is still the right answer.
+    @Test("An empty bar takes the seed even from an inverted position")
+    func emptyBarSeedsOverInversion() {
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: 0,
+            storedPositions: Self.invertedPositions
+        ) == .freshInstall(1))
     }
 
     @Test("A single managed item is enough to withhold the seed")
     func oneItemWithholdsTheSeed() {
         #expect(!MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: 1))
-        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: 1) == nil)
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: 1,
+            storedPositions: Self.orderedPositions
+        ) == .keepStored)
     }
 
     /// The reported bar. Nothing about the count itself is special; the point
-    /// is that the populated case never reaches the stamp.
+    /// is that a populated bar with a sane stored position never reaches the
+    /// stamp.
     @Test("The reported bar withholds the seed")
     func reportedBarWithholdsTheSeed() {
         for count in 1 ... 38 {
             #expect(
-                MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: count) == nil,
+                MenuBarItemManager.seedForRebuiltDivider(
+                    managedItemCount: count,
+                    storedPositions: Self.orderedPositions
+                ) == .keepStored,
                 "managedItemCount=\(count) must not re-stamp the seed"
             )
         }
@@ -281,18 +319,127 @@ struct RebuiltDividerSeedPositionTests {
     @Test("A nonsensical count does not unlock the seed")
     func negativeCountDoesNotSeed() {
         #expect(!MenuBarItemManager.canSeedRebuiltDividerPosition(managedItemCount: -1))
-        #expect(MenuBarItemManager.seedPositionForRebuiltDivider(managedItemCount: -1) == nil)
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: -1,
+            storedPositions: Self.orderedPositions
+        ) == .keepStored)
     }
 
-    /// The two branches have to be distinguishable in a field log, because
+    /// The three branches have to be distinguishable in a field log, because
     /// telling them apart is what separated cause from symptom in #958.
     @Test("The log fragment names which branch ran")
     func logFragmentNamesTheBranch() {
-        let seeded = MenuBarItemManager.seedDescription(1)
-        let kept = MenuBarItemManager.seedDescription(nil)
+        let seeded = MenuBarItemManager.seedDescription(.freshInstall(1))
+        let kept = MenuBarItemManager.seedDescription(.keepStored)
+        let repaired = MenuBarItemManager.seedDescription(.repaired(1021))
         #expect(seeded.contains("seeded position"))
         #expect(kept.contains("stored position"))
-        #expect(seeded != kept)
+        #expect(repaired.contains("repaired position"))
+        #expect(Set([seeded, kept, repaired]).count == 3)
+    }
+}
+
+/// Covers the inverted-position half of the parked-divider rebuild (#978).
+///
+/// The #958 fix taught both rebuilds to keep the stored position on a
+/// populated bar, which is right whenever that position still orders the
+/// dividers. #978's did not — macOS had autosaved `Hidden = 6866` against
+/// `AlwaysHidden = 1034` — so "keeping its stored position" restored the
+/// value that stranded the divider. That is why a relaunch stopped clearing
+/// the strand and the app came up already stranded, first layout line 0.4s
+/// after startup.
+@Suite("Stored divider position ordering (#978)")
+struct StoredDividerPositionOrderingTests {
+    private static func positions(
+        visible: CGFloat? = nil,
+        hidden: CGFloat? = nil,
+        alwaysHidden: CGFloat? = nil
+    ) -> MenuBarItemManager.StoredDividerPositions {
+        MenuBarItemManager.StoredDividerPositions(
+            visible: visible,
+            hidden: hidden,
+            alwaysHidden: alwaysHidden
+        )
+    }
+
+    @Test("A healthy bar's stored positions read as ordered")
+    func healthyPositionsAreOrdered() {
+        #expect(MenuBarItemManager.storedHiddenPositionIsOrdered(
+            Self.positions(visible: 1008, hidden: 1021, alwaysHidden: 1034)
+        ))
+    }
+
+    @Test("#978's plist reads as inverted")
+    func reportedPlistIsInverted() {
+        #expect(!MenuBarItemManager.storedHiddenPositionIsOrdered(
+            Self.positions(visible: 1008, hidden: 6866, alwaysHidden: 1034)
+        ))
+    }
+
+    /// The always-hidden section is optional, so its position is often
+    /// absent. H_ctrl must still sit left of the visible item.
+    @Test("Without an always-hidden divider, only the visible bound applies")
+    func visibleBoundAloneStillApplies() {
+        #expect(MenuBarItemManager.storedHiddenPositionIsOrdered(
+            Self.positions(visible: 0, hidden: 1)
+        ))
+        #expect(!MenuBarItemManager.storedHiddenPositionIsOrdered(
+            Self.positions(visible: 1008, hidden: 1008)
+        ))
+    }
+
+    /// An ordering the check cannot see cannot be violated. Reporting an
+    /// unknown position as inverted would hand the rebuild a repair it has no
+    /// evidence for, which is the mistake #958 was about.
+    @Test("Unknown positions do not read as inverted")
+    func unknownPositionsAreOrdered() {
+        #expect(MenuBarItemManager.storedHiddenPositionIsOrdered(Self.positions()))
+        #expect(MenuBarItemManager.storedHiddenPositionIsOrdered(Self.positions(hidden: 6866)))
+        #expect(MenuBarItemManager.storedHiddenPositionIsOrdered(
+            Self.positions(visible: 1008, hidden: 6866)
+        ))
+    }
+
+    /// The repair restores ordering, nothing else. Walking the divider to the
+    /// saved boundary is the follow-up apply's job.
+    @Test("The repair lands between the two chevrons")
+    func repairLandsBetweenTheChevrons() {
+        let repaired = MenuBarItemManager.repairedHiddenDividerPosition(
+            Self.positions(visible: 1008, hidden: 6866, alwaysHidden: 1034)
+        )
+        #expect(repaired == 1021)
+        #expect(repaired.map { $0 > 1008 && $0 < 1034 } == true)
+    }
+
+    @Test("Without an always-hidden divider the repair clears the visible item")
+    func repairClearsTheVisibleItem() {
+        #expect(MenuBarItemManager.repairedHiddenDividerPosition(
+            Self.positions(visible: 1008, hidden: 12)
+        ) == 1009)
+    }
+
+    /// Both neighbours corrupt gives nothing to interpolate between. A
+    /// midpoint would just be a different wrong answer, so the rebuild keeps
+    /// the stored position rather than inventing one.
+    @Test("Corrupt neighbours withhold the repair")
+    func corruptNeighboursWithholdTheRepair() {
+        #expect(MenuBarItemManager.repairedHiddenDividerPosition(
+            Self.positions(visible: 2000, hidden: 6866, alwaysHidden: 1034)
+        ) == nil)
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: 38,
+            storedPositions: Self.positions(visible: 2000, hidden: 6866, alwaysHidden: 1034)
+        ) == .keepStored)
+    }
+
+    /// The end-to-end shape #978 needs: a populated bar, an inverted stored
+    /// position, and a rebuild that replaces it instead of restoring it.
+    @Test("A populated bar with an inverted position gets a repaired seed")
+    func populatedBarRepairsTheInversion() {
+        #expect(MenuBarItemManager.seedForRebuiltDivider(
+            managedItemCount: 38,
+            storedPositions: Self.positions(visible: 1008, hidden: 6866, alwaysHidden: 1034)
+        ) == .repaired(1021))
     }
 }
 

--- a/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
+++ b/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import CoreGraphics
 import Testing
 @testable import Thaw
 
@@ -112,6 +113,79 @@ struct StrandedHiddenDividerTests {
         let collapsedDivider = ParkedDividerLog.bounds(minX: -9189, width: 10000)
         #expect(!LayoutSolver.isOnScreen(
             bounds: collapsedDivider,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+}
+
+/// The AH_ctrl placement's anchor guard (#978, #980).
+///
+/// #978's second, worse fault came in through the always-hidden placement,
+/// not the visible/hidden boundary repair: the AH_ctrl move anchored on
+/// `ControlItem.Hidden` while H_ctrl sat at `minX=-3596`, the drag walked
+/// H_ctrl to `-9322`, and the pair came out inverted with the hidden section
+/// reading zero width. Anchoring a drag beside a parked item is what strands
+/// the item being dragged, which is the same reasoning the Thaw-icon
+/// relocation guard already carried.
+///
+/// The guard reads the leading edge, not both edges. A drag anchor is
+/// exactly the case ``LayoutSolver/isOnScreen(bounds:screenFrames:)`` is the
+/// right test for: the drop point is derived from the anchor's edge, so an
+/// anchor whose leading edge is offscreen gives a drop point that is too.
+@Suite("AH_ctrl placement anchor (#978)")
+struct AlwaysHiddenPlacementAnchorTests {
+    /// The stranded H_ctrl from the follow-up log's 19:44:22 cycle, the one
+    /// the AH_ctrl move anchored on.
+    @Test("#978's stranded H_ctrl is refused as an anchor")
+    func strandedDividerIsRefusedAsAnchor() {
+        #expect(!LayoutSolver.isOnScreen(
+            bounds: ParkedDividerLog.bounds(minX: -3596),
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// Where that drag left H_ctrl. Still refused, so the next cycle cannot
+    /// walk it further.
+    @Test("The post-drag position stays refused")
+    func postDragPositionStaysRefused() {
+        for minX in [-8612.0, -9322.0] as [CGFloat] {
+            #expect(
+                !LayoutSolver.isOnScreen(
+                    bounds: ParkedDividerLog.bounds(minX: minX),
+                    screenFrames: ParkedDividerLog.screenFrames
+                ),
+                "H_ctrl at minX=\(minX) must not be usable as a drag anchor"
+            )
+        }
+    }
+
+    /// An ordinary hidden item anchor on the bar still passes: the guard
+    /// only refuses anchors it can see are off the display, so the common
+    /// placement is untouched.
+    @Test("An on-screen anchor is still usable")
+    func onScreenAnchorIsUsable() {
+        #expect(LayoutSolver.isOnScreen(
+            bounds: ParkedDividerLog.bounds(minX: 1050),
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// A healthy collapsed H_ctrl expands into a spacer whose leading edge
+    /// is far offscreen. Anchoring AH_ctrl on it would still derive an
+    /// offscreen drop point, so the leading-edge test refusing here is the
+    /// intended behaviour, not a false positive — the per-item fallback
+    /// places the items instead.
+    @Test("A collapsed spacer is refused as an anchor too")
+    func collapsedSpacerIsRefusedAsAnchor() {
+        let expandedSpacer = ParkedDividerLog.bounds(minX: -8073, width: 10000)
+        #expect(!LayoutSolver.isOnScreen(
+            bounds: expandedSpacer,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+        // ...and is still not *stranded*, so the divider rebuild leaves it
+        // alone. The two tests answer different questions about one frame.
+        #expect(!LayoutSolver.isFullyOffScreen(
+            bounds: expandedSpacer,
             screenFrames: ParkedDividerLog.screenFrames
         ))
     }

--- a/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
+++ b/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
@@ -29,7 +29,7 @@ struct StrandedHiddenDividerTests {
     func collapsedSpacerIsNotStranded() {
         // Lengths.expanded = 10000; trailing edge inside the 2056-wide
         // display from ParkedDividerLog.
-        let expandedSpacer = ParkedDividerLog.bounds(minX: -8073, width: 10_000)
+        let expandedSpacer = ParkedDividerLog.bounds(minX: -8073, width: 10000)
         #expect(LayoutSolver.isFullyOffScreen(
             bounds: expandedSpacer,
             screenFrames: ParkedDividerLog.screenFrames

--- a/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
+++ b/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
@@ -1,0 +1,101 @@
+//
+//  StrandedHiddenDividerTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// The parked-divider recovery's stranded test (#978).
+///
+/// #978 is a divider displaced past every item — `minX=-2742.0` on a bar
+/// whose owner kept arranging items — that never recovered, because the
+/// recovery read "parked" off the leading edge alone. That test cannot
+/// distinguish a stranded divider from a healthy collapsed one: hiding a
+/// section expands H_ctrl into an offscreen-reaching spacer, so every
+/// normal collapsed bar fails the leading-edge check. These tests pin the
+/// both-edges semantics the recovery now uses, against the same display
+/// geometry as ``ParkedDividerLog``.
+@Suite("Stranded hidden divider detection (#978)")
+struct StrandedHiddenDividerTests {
+    /// A healthy collapsed bar: H_ctrl expanded into its spacer, frame
+    /// reaching far offscreen to the left while the trailing edge stays
+    /// anchored beside the visible section. This frame must NOT count as
+    /// parked, or the recovery would rebuild dividers doing their job.
+    @Test("A collapsed spacer reaching offscreen is not stranded")
+    func collapsedSpacerIsNotStranded() {
+        // Lengths.expanded = 10000; trailing edge inside the 2056-wide
+        // display from ParkedDividerLog.
+        let expandedSpacer = ParkedDividerLog.bounds(minX: -8073, width: 10_000)
+        #expect(LayoutSolver.isFullyOffScreen(
+            bounds: expandedSpacer,
+            screenFrames: ParkedDividerLog.screenFrames
+        ) == false)
+
+        // Contrast: the leading-edge test flags this exact frame, which is
+        // why the recovery had to move off it.
+        #expect(!LayoutSolver.isOnScreen(
+            bounds: expandedSpacer,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// The #978 fault shape: a standard-length divider pushed left past all
+    /// of its items, no edge on any screen. The recovery must see this.
+    @Test("A divider displaced left past every item is stranded")
+    func displacedLeftDividerIsStranded() {
+        let stranded = ParkedDividerLog.bounds(minX: -2742)
+        #expect(LayoutSolver.isFullyOffScreen(
+            bounds: stranded,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// The mirror displacement: shoved rightward off the end of the bar.
+    @Test("A divider displaced right off the bar is stranded")
+    func displacedRightDividerIsStranded() {
+        let stranded = ParkedDividerLog.bounds(minX: ParkedDividerLog.display.maxX + 44)
+        #expect(LayoutSolver.isFullyOffScreen(
+            bounds: stranded,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// A divider sitting at its post beside the visible section.
+    @Test("An on-screen divider is not stranded")
+    func onScreenDividerIsNotStranded() {
+        let onScreen = ParkedDividerLog.bounds(minX: 1050)
+        #expect(!LayoutSolver.isFullyOffScreen(
+            bounds: onScreen,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// A partially visible divider (sliver over the left screen edge) still
+    /// has an edge on a display, so it does not qualify for a rebuild. The
+    /// drag machinery owns that case through its own checks (#899).
+    @Test("A half-visible divider is not stranded")
+    func halfVisibleDividerIsNotStranded() {
+        let sliver = ParkedDividerLog.bounds(minX: -34, width: 39)
+        #expect(!LayoutSolver.isFullyOffScreen(
+            bounds: sliver,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
+
+    /// #978's decisive observation: with 36–40 items concealed and 1–5
+    /// visible, `shouldMoveHiddenDivider` stays false, so neither repair
+    /// direction ran while the divider sat stranded. Pinning the false here
+    /// documents that the fix routes through the rebuild recovery, not
+    /// through flipping this predicate — flipping it would re-open #958's
+    /// full-bar drags.
+    @Test("Both sections populated keeps planning per-item moves")
+    func populatedSectionsPlanPerItemMoves() {
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 40, liveVisibleCount: 1))
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 39, liveVisibleCount: 2))
+        #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 36, liveVisibleCount: 5))
+    }
+}

--- a/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
+++ b/ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift
@@ -98,4 +98,21 @@ struct StrandedHiddenDividerTests {
         #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 39, liveVisibleCount: 2))
         #expect(!LayoutSolver.shouldMoveHiddenDivider(liveConcealedCount: 36, liveVisibleCount: 5))
     }
+
+    /// The Layout editor drag guard (#923). A collapsed always-hidden section
+    /// expands AH_ctrl into a spacer whose leading edge sits far offscreen,
+    /// so `.leftOfItem(AH_ctrl)` would target a click point around minX -9189.
+    /// The editor refuses the drag when `isOnScreen` (leading-edge) reads the
+    /// divider as offscreen. This pins that detection against the #923 log's
+    /// geometry, separate from the both-edges stranded test the recovery uses.
+    @Test("A collapsed-section divider's leading edge reads offscreen for the editor drag guard")
+    func collapsedDividerLeadingEdgeIsOffscreen() {
+        // AH_ctrl at minX=-9189 with the 10000-wide concealment spacer, on
+        // the same 2056-wide display as ParkedDividerLog.
+        let collapsedDivider = ParkedDividerLog.bounds(minX: -9189, width: 10000)
+        #expect(!LayoutSolver.isOnScreen(
+            bounds: collapsedDivider,
+            screenFrames: ParkedDividerLog.screenFrames
+        ))
+    }
 }

--- a/ThawTests/Utilities/MacOSCompatibilityWarningTests.swift
+++ b/ThawTests/Utilities/MacOSCompatibilityWarningTests.swift
@@ -22,6 +22,50 @@ struct MacOSCompatibilityWarningTests {
         #expect(!MacOSCompatibilityWarning.shouldShow(for: version(majorVersion)))
     }
 
+    @Test("A supported macOS is owed no prompt", arguments: [25, 26])
+    func supportedVersionsHaveNoPrompt(majorVersion: Int) {
+        #expect(MacOSCompatibilityWarning.prompt(for: version(majorVersion), canSubscribe: true) == nil)
+    }
+
+    /// The offer needs an updates manager to carry it out. Without one the
+    /// user is still told, and still given somewhere to go.
+    @Test("Without a manager the prompt sends the user to the releases page")
+    func noManagerOffersPreviewBuilds() throws {
+        let prompt = try #require(MacOSCompatibilityWarning.prompt(for: version(27), canSubscribe: false))
+        #expect(prompt.action == .openReleasesPage)
+        #expect(prompt.confirmButtonTitle == String(localized: "View Preview Builds"))
+    }
+
+    @Test("With a manager the prompt offers the alpha channel")
+    func managerOffersAlphaChannel() throws {
+        let prompt = try #require(MacOSCompatibilityWarning.prompt(for: version(27), canSubscribe: true))
+        #expect(prompt.action == .subscribeToAlpha)
+        #expect(prompt.confirmButtonTitle == String(localized: "Switch to Alpha Updates"))
+    }
+
+    /// The alert cannot offer a channel the running system is not allowed to
+    /// select, whatever the manager is willing to do.
+    @Test("An unavailable alpha channel is not offered")
+    func unavailableAlphaIsNotOffered() throws {
+        let unsupported = version(MacOSCompatibilityWarning.firstUnsupportedMajorVersion)
+        #expect(UpdateChannel.alpha.isAvailable(on: unsupported))
+
+        let prompt = try #require(MacOSCompatibilityWarning.prompt(for: unsupported, canSubscribe: true))
+        #expect(prompt.action == .subscribeToAlpha)
+    }
+
+    /// The warning fires on every release from the unsupported one onward, so
+    /// a later macOS must not be told about the first one this build refused.
+    @Test("The copy names the running macOS", arguments: [27, 28, 30])
+    func copyNamesTheRunningRelease(majorVersion: Int) throws {
+        let prompt = try #require(
+            MacOSCompatibilityWarning.prompt(for: version(majorVersion), canSubscribe: true)
+        )
+        #expect(prompt.title.contains("\(majorVersion)"))
+        #expect(prompt.message.contains("macOS \(majorVersion)"))
+        #expect(!prompt.title.contains("macOS 26"))
+    }
+
     private func version(_ majorVersion: Int) -> OperatingSystemVersion {
         OperatingSystemVersion(majorVersion: majorVersion, minorVersion: 0, patchVersion: 0)
     }

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -140,8 +140,8 @@ Subscribers pick one channel in Settings › About. All three read the same
 | Subscriber | Receives |
 | --- | --- |
 | Stable | items with no `sparkle:channel` |
-| Beta | the above, plus `beta` |
-| Alpha | the above, plus `alpha` |
+| Beta | untagged items, plus `beta` |
+| Alpha | untagged items, plus `alpha`, never `beta` |
 
 Beta is cumulative with stable, and that is not a choice: Sparkle's
 `allowedChannels` only widens what an updater accepts. An item with no

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -127,12 +127,12 @@ real release.
 
 ## Channels
 
-Stable and beta share one appcast, which marks beta items with
-`sparkle:channel`; alpha has an appcast of its own. All of them are served from
-the same feed host and updates releases. Tag suffixes map to channels in the
-release workflow (`-beta` / `-rc` → beta, `-alpha` / `-nightly` → alpha), and
-the `channel` input overrides the inference when a tag needs to go somewhere
-its suffix does not imply.
+All three channels share one appcast, served from the feed host named by
+`SUFeedURL`. Stable items carry no `sparkle:channel`; beta and alpha items are
+tagged with theirs. Tag suffixes map to channels in the release workflow
+(`-beta` / `-rc` → beta, `-alpha` / `-nightly` → alpha), and the `channel`
+input overrides the inference when a tag needs to go somewhere its suffix does
+not imply.
 
 Subscribers pick one channel in Settings › About. All three read the same
 `SUFeedURL`; the appcast's `sparkle:channel` tags do the sorting.

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -127,10 +127,65 @@ real release.
 
 ## Channels
 
-Stable, beta, and alpha all use the same feed host and updates releases. The
-appcast marks non-stable items with `sparkle:channel`. Tag suffixes map to
-channels in the release workflow (`-beta` / `-rc` → beta, `-alpha` / `-nightly`
-→ alpha).
+Stable and beta share one appcast, which marks beta items with
+`sparkle:channel`; alpha has an appcast of its own. All of them are served from
+the same feed host and updates releases. Tag suffixes map to channels in the
+release workflow (`-beta` / `-rc` → beta, `-alpha` / `-nightly` → alpha), and
+the `channel` input overrides the inference when a tag needs to go somewhere
+its suffix does not imply.
+
+Subscribers pick one channel in Settings › About. All three read the same
+`SUFeedURL`; the appcast's `sparkle:channel` tags do the sorting.
+
+| Subscriber | Receives |
+| --- | --- |
+| Stable | items with no `sparkle:channel` |
+| Beta | the above, plus `beta` |
+| Alpha | the above, plus `alpha` |
+
+Beta is cumulative with stable, and that is not a choice: Sparkle's
+`allowedChannels` only widens what an updater accepts. An item with no
+`sparkle:channel` is on the default channel, and per `SPUUpdaterDelegate`,
+"the default channel is always included in the allowed set." No delegate
+return value keeps stable releases away from a subscriber.
+
+Alpha is only selectable on the macOS the rewrite targets. The threshold is
+`MacOSCompatibilityWarning.firstUnsupportedMajorVersion`, shared with the
+startup warning whose alert tells the user that support for that macOS arrives
+through this channel — so the release that raises the warning is the release
+that reveals the channel. On earlier systems alpha is absent from the picker,
+and a stored alpha selection is not honored, which keeps a user who moves back
+to a supported macOS from sitting on a feed that will never offer them
+anything.
+
+Alpha carries the rewritten app built against the next macOS: a different
+product line, not a riskier build of this one. It still shares the feed,
+because Sparkle offers the newest item a subscriber is allowed to see, and a
+3.x alpha item outranks anything the 2.x line can publish. An alpha subscriber
+does see the stable items; they simply never win. This holds only while stable
+stays behind alpha in version order, which is why no further 2.x stable
+release can be numbered above the alpha line.
+
+Alpha items are tagged `sparkle:channel` = `alpha`, so beta subscribers never
+see them: beta allows `beta` and the default, not `alpha`. The two tracks run
+in parallel rather than one containing the other.
+
+Cross-version safety does not rely on any of that. `generate_appcast` derives
+`sparkle:minimumSystemVersion` from each build's deployment target, so the 3.x
+items carry `27.0` and Sparkle skips them on macOS 26 — including later, when
+3.0 goes final and drops its channel tag to become the default.
+
+Promotion between stable and beta stays cheap, because they share a feed: to
+move a build from beta to stable, drop its `sparkle:channel` rather than
+publishing a second item for the same version. Beta subscribers already have
+that build and are offered nothing; stable subscribers pick it up. Two items
+sharing a version and differing only by channel is the case to avoid — it also
+reaches the mirrored legacy appcast.
+
+Switching *away* from alpha does not roll a user back. The alpha app's version
+line is ahead of the shipping app's, so the stable feed offers nothing newer
+and Sparkle stays put. Returning to the shipping app is a reinstall, which is
+worth saying wherever alpha is advertised.
 
 ## Legacy installs
 


### PR DESCRIPTION
# Summary

Fixes for the parked-offscreen-divider failure family and the Layout editor's persistence bug:

1. **#978**: the hidden divider parks past every menu bar item and never recovers. Each apply logs `moveHiddenDivider=false` until quit/relaunch. Three gates starved the recovery; this PR fixes all three, hardens the AH_ctrl placement against an offscreen anchor, and withholds an unverified profile write.
2. **#923**: the Layout editor drags an item into a collapsed section by handing a parked-offscreen control divider straight to `move()`. The synthetic drag yanks the on-screen item offscreen, macOS snaps it back, eight attempts fail, and the user sees a generic "operation could not be completed" alert. #923 was closed as completed but the reporter never stopped hitting it, and a second user confirmed it.
3. **#981**: the Layout editor shows generic "bubble" placeholders when no captured image is cached. One narrow cause is that `LayoutBarItemView` bakes its placeholder icon in at init and never re-resolves, so an owning app that was mid-launch at init leaves the generic symbol permanently for that view instance.
4. **#983**: a Layout-editor drag from Hidden to Visible works for the session but never reaches `savedSectionOrder`, so the next launch reverts it. The save-gate cooldown exemption for user moves never armed in time.
5. **#980** (hardening): the AH_ctrl placement that drove the reporter's mass hidden-to-alwaysHidden re-sectioning now refuses an offscreen anchor, and `persistProfileStateOnSuccess` withholds when the apply left planned moves unenacted.

**Scope:** five bug fixes plus a cosmetic one, with tests, no logged-string format changes, so the log-replay harness stays valid.

## Linked issue (required)

Closes: #978
Closes: #923
Closes: #981
Closes: #983
Closes: #980

## PR Type

- [x] Bug fix

## Area

- [x] menubar
- [x] layout

## Does this PR introduce a breaking change?

- [x] No

## What is the new behavior?

### #978: reach a stranded divider from any state

Three gates made the recovery unreachable in exactly the state it repairs, plus a fourth let the rebuild reinstate the fault. All fixed:

1. The recovery ran only under `hiddenBoundaryMismatch > 0`, but a divider can strand while the visible/hidden boundary is consistent. #978's failing cycle logs `hiddenBoundaryMismatch=0` alongside `parked offscreen`. The recovery now takes a trigger rather than the raw count, and an apply refused upstream counts as evidence the bar needed the divider.
2. The zero-width guards in `applySavedLayout` and `applyProfileLayout` returned before Phase 1 computed the mismatch at all, so a strand deadlocked: stranded, section reads zero width, apply refused, mismatch never computed, streak never advances. Both guards still refuse (nothing plans against an untrustworthy reading, #868), but a stranded divider now counts the refusal.
3. The parked test now requires both edges of the divider off every display (`LayoutSolver.isFullyOffScreen`). The old leading-edge check cannot tell a stranded divider from a healthy collapsed bar, because hiding a section expands H_ctrl into a 10000-wide spacer whose frame reaches far offscreen while its trailing edge stays beside the visible section.
4. Recovery is no longer limited to `.savedOrder` applies. Profile-sourced applies never advanced the streak. The rebuild is withheld while `isDraggingMenuBarItem` is set.

`shouldMoveHiddenDivider` is untouched. With both sections populated, per-item moves remain the correct plan; the fix routes through the rebuild instead of flipping that predicate back into the full-bar drags #958 removed.

### #980 / #978: refuse an offscreen AH_ctrl anchor and withhold an unverified profile write

The AH_ctrl placement had no parked-anchor guard. `MoveDestination.leftOfItem` derives its drop point from the target's minX, so an anchor whose leading edge is off the display gives a drop point that is too. The placement now declines and lets the per-item fallback place the items: more moves, nothing stranded. `persistProfileStateOnSuccess` is separately hardened: it is the one write to `savedSectionOrder` that never consulted `shouldPersistSavedOrder`, and "success" there means the apply reached an uncancelled exit, not that the moves landed, so an apply that logged `planned move(s) left unenacted` still committed its section order. The pinning sets still commit; they are the profile's own declaration, not a reading of the bar.

### #923: refuse editor drags onto a parked-offscreen divider

The editor drag path was the one caller still handing a parked control divider straight to `move()`. `LayoutBarPaddingView` now checks the destination up front: if the target is one of Thaw's own control items and its leading edge is offscreen (the same `isOnScreen` condition the apply path uses for #899/#978), it refuses the drag, logs the reason, and shows an actionable alert naming the collapsed section. It does not burn the eight-attempt budget or surface a generic error.

### #981: re-resolve an item's app icon for the placeholder bubble

`LayoutBarItemView` bakes its placeholder image in once, at init. The view is reused across cache refreshes whenever the item's identity is stable, so when the lookup returned nil at init because the owning app was mid-launch, the generic symbol stayed for the life of that view. `drawPlaceholder` now re-resolves lazily: when the placeholder did not come from a resolved app icon, it tries the app icon again before drawing, once. This is the narrow, no-behavioral-risk piece of #981; the broader bubble causes (SCK capture failing during display-topology churn, and the rate-limited SkyLight offscreen refresh) need a dock/undock soak and are out of scope.

### #983: persist cross-section editor drags across restarts

`recordExternalMoveOperation()` was called only after `stabilizePlacement()` returned, so the first cache pass inside stabilize hit the 5s move cooldown with no user-move exemption, the save was skipped, and by the time the exemption armed the mid-transition cache gate had re-armed. The drag never saved. The user move is now recorded right after `move()` returns (no throw), before stabilize, so the save-gate exemption is armed when stabilize's cache pass reaches it. The rescue-and-retry retry path is reordered the same way. The `.suppress` branch of the failure classifier already recorded unconditionally and is unchanged.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -only-testing:ThawTests/StrandedHiddenDividerTests` (7/7 passed)
- Same invocation with `-only-testing` over `ParkedDividerTests`, `ParkedAnchorTests`, `ControlItemRecoveryTests`, `CollapsedHiddenSectionRecoveryTests`, `RebuiltDividerSeedPositionTests`, `SectionGeometryGateTests` (49/49) and `ProfileLayoutLogReplayTests` (12/12)
- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS'` (BUILD SUCCEEDED)

Note on the unticked first box: verification so far is test-based and a clean build. The #983 fix in particular needs one editor-drag session (Hidden to Visible, then quit and relaunch) to confirm the save survives restart, and #978's recovery needs a notched-display soak. Neither has been reproduced against a live build yet.

## Known limitations / follow-ups

- The broader #981 bubble causes are out of scope: SCK capture failing during display-topology churn, and the rate-limited SkyLight offscreen refresh. Both touch the #759 rate-limit discipline and need a dock/undock soak before landing.
- The #923 guard refuses the drag rather than expanding the collapsed section to let it land. Expanding the section mid-drag was considered and dropped as riskier (rehide timers, UI state). The actionable alert tells the user to open the section and retry.
- #983's reorder records a user move whenever `move()` returns without throwing, even if `stabilizePlacement` later finds the item didn't stick and runs rescue-and-retry. In the reporter's log every drag landed on attempt 1, so the common path is unaffected; the risk is a partial-failure edge where a partially-settled drag could be persisted. The rescue-and-retry catch block still owns the failure alert.

## Other information

The new tests live in `ThawTests/MenuBar/Layout/StrandedHiddenDividerTests.swift`. One pins `shouldMoveHiddenDivider == false` for #978's exact counts (40 concealed / 1 visible) so a future fix cannot "simplify" this by reintroducing the full-bar drag. Another pins that an AH_ctrl at minX=-9189 with the 10000-wide concealment spacer reads offscreen to the leading-edge check the editor guard uses (#923's log geometry).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Stable, Beta, and Alpha update channels with macOS compatibility checks and channel-specific update filtering.
  * Added localized update-channel options in About settings.
  * Added compatibility guidance for preview updates, including access to preview builds or release notes.
* **Bug Fixes**
  * Improved recovery for hidden, offscreen, or incorrectly positioned menu-bar dividers.
  * Prevented inaccessible divider drags and displayed actionable guidance.
  * Improved placeholder icons by retrying app-icon resolution when initially unavailable.
* **Documentation**
  * Expanded update-channel documentation and release notes.
* **Tests**
  * Added coverage for divider recovery, placement safeguards, offscreen detection, and update channels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->