### PR TITLE
fix(layout): stop the cross-section fallback from reversing concealed sections

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
+++ b/Thaw/MenuBar/MenuBarItems/LayoutSolver.swift
@@ -959,6 +959,62 @@ nonisolated enum LayoutSolver {
             ?? desiredVisible.last(where: liveMovableUIDs.contains)
     }
 
+    // MARK: - Cross-section fallback
+
+    /// Which slot a cross-boundary fallback move lands its item in.
+    ///
+    /// The fallback drags every item onto the same anchor, the
+    /// always-hidden divider, so the landing slot is fixed and each move
+    /// pushes whatever is already there one place further away from it.
+    enum FallbackLandingSlot {
+        /// Dragged to the right of the divider, into the leftmost slot of
+        /// the hidden section.
+        case leftmostOfHidden
+        /// Dragged to the left of the divider, into the rightmost slot of
+        /// the always-hidden section.
+        case rightmostOfAlwaysHidden
+    }
+
+    /// The order in which items crossing the hidden to always-hidden
+    /// boundary must be dragged so they come to rest in profile order.
+    ///
+    /// Because every move lands in the same slot and displaces its
+    /// predecessors, the item that must end up furthest from the divider
+    /// moves first, and the one that ends up adjacent to it moves last.
+    ///
+    /// Getting that backwards strands nothing in the wrong section, so no
+    /// gate downstream reports it: membership is correct and only the
+    /// order inside the section comes out reversed. With
+    /// enforceConcealedSectionOrder off, relaxConcealedSectionOrder then
+    /// rewrites the desired sequence to match that reversal, the LCS finds
+    /// nothing to plan, and the apply logs a layout already in its correct
+    /// positions over a bar the user can see is backwards.
+    ///
+    /// The saved order is stored left-to-right, index 0 leftmost. Landing
+    /// at the leftmost slot of hidden therefore means index 0 moves last;
+    /// landing at the rightmost slot of always-hidden means index 0 moves
+    /// first.
+    ///
+    /// Identifiers the profile does not carry have no position to honour.
+    /// They are appended, which lands them together against the divider on
+    /// whichever side they were headed, and sorted so a set's arbitrary
+    /// iteration order cannot make the sequence differ between applies.
+    ///
+    /// Pure over its inputs.
+    static nonisolated func crossSectionFallbackMoveOrder(
+        profileOrder: [String],
+        crossing: Set<String>,
+        landingSlot: FallbackLandingSlot
+    ) -> [String] {
+        let positioned = switch landingSlot {
+        case .leftmostOfHidden:
+            profileOrder.reversed().filter(crossing.contains)
+        case .rightmostOfAlwaysHidden:
+            profileOrder.filter(crossing.contains)
+        }
+        return positioned + crossing.subtracting(profileOrder).sorted()
+    }
+
     // MARK: - LCS reorder
 
     /// Plans the LCS-anchored move sequence for items that need to move

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1938,8 +1938,10 @@ extension MenuBarItemManager {
             // tells us which items still need to cross the boundary,
             // and dragging them explicitly to .leftOfItem(AH_ctrl)
             // or .rightOfItem(AH_ctrl) puts them on the correct
-            // side. The LCS within-section reorder pass below
-            // handles intra-section ordering.
+            // side. The order these moves are issued in is the order
+            // the items come to rest in, so it has to be right here:
+            // the LCS pass below only re-sorts concealed sections when
+            // enforceConcealedSectionOrder is on, and it defaults off.
             let freshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
             var freshItemsCopy = freshItems
             if let freshControl = ControlItemPair(
@@ -1992,15 +1994,18 @@ extension MenuBarItemManager {
                     )
 
                     // Move items destined for AH (currently in hidden)
-                    // to the LEFT of AH_ctrl. Iterate in reverse
-                    // profile order so the first item in
-                    // itemOrder["alwaysHidden"] (rightmost in AH per
-                    // profile convention, index 0) is moved last and
-                    // therefore lands closest to AH_ctrl, matching
-                    // the order LCS will leave it in.
+                    // to the LEFT of AH_ctrl. Every move lands in the
+                    // slot immediately left of the divider, the
+                    // rightmost slot of always-hidden, and pushes the
+                    // items already there further left, so index 0 of
+                    // the saved order moves first and ends up furthest
+                    // left. See crossSectionFallbackMoveOrder.
                     let ahProfileOrder = itemOrder["alwaysHidden"] ?? []
-                    let orderedCrossToAH = ahProfileOrder.reversed().filter { crossToAH.contains($0) }
-                        + crossToAH.subtracting(ahProfileOrder).sorted()
+                    let orderedCrossToAH = LayoutSolver.crossSectionFallbackMoveOrder(
+                        profileOrder: ahProfileOrder,
+                        crossing: crossToAH,
+                        landingSlot: .rightmostOfAlwaysHidden
+                    )
                     for uid in orderedCrossToAH {
                         guard !Task.isCancelled else { break }
                         guard
@@ -2019,14 +2024,18 @@ extension MenuBarItemManager {
                     }
 
                     // Move items destined for hidden (currently in AH)
-                    // to the RIGHT of AH_ctrl. Iterate in profile
-                    // order so itemOrder["hidden"] index 0 (rightmost
-                    // in hidden = furthest from AH_ctrl) is moved
-                    // first and gets pushed furthest right by
-                    // subsequent moves.
+                    // to the RIGHT of AH_ctrl. Every move lands in the
+                    // slot immediately right of the divider, the
+                    // leftmost slot of hidden, and pushes the items
+                    // already there further right, so index 0 of the
+                    // saved order moves last and ends up closest to
+                    // AH_ctrl. See crossSectionFallbackMoveOrder.
                     let hiddenProfileOrder = itemOrder["hidden"] ?? []
-                    let orderedCrossToHidden = hiddenProfileOrder.filter { crossToHidden.contains($0) }
-                        + crossToHidden.subtracting(hiddenProfileOrder).sorted()
+                    let orderedCrossToHidden = LayoutSolver.crossSectionFallbackMoveOrder(
+                        profileOrder: hiddenProfileOrder,
+                        crossing: crossToHidden,
+                        landingSlot: .leftmostOfHidden
+                    )
                     for uid in orderedCrossToHidden {
                         guard !Task.isCancelled else { break }
                         guard

--- a/ThawTests/MenuBar/Layout/CrossSectionFallbackMoveOrderTests.swift
+++ b/ThawTests/MenuBar/Layout/CrossSectionFallbackMoveOrderTests.swift
@@ -1,0 +1,154 @@
+//
+//  CrossSectionFallbackMoveOrderTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// Tests for LayoutSolver.crossSectionFallbackMoveOrder.
+///
+/// The per-item fallback in applyProfileLayout drags every item that still
+/// needs to cross the hidden to always-hidden boundary onto one anchor, the
+/// always-hidden divider. The landing slot is therefore the same for every
+/// move in the run, and each move displaces its predecessors one place
+/// further from the divider. The order the moves are issued in is the order
+/// the items come to rest in, reversed.
+///
+/// The failure this locks down is quiet. A reversed run leaves every item in
+/// the section the profile asked for, so the cross-section tallies, the
+/// divider gates and the saved order all read as correct; only the order the
+/// user sees when the section is revealed is backwards. With
+/// enforceConcealedSectionOrder off, relaxConcealedSectionOrder then rewrites
+/// the desired sequence to match, so the LCS plans nothing and the apply
+/// reports success over a visibly backwards bar.
+@Suite("Cross-section fallback move order")
+struct CrossSectionFallbackMoveOrderTests {
+    /// Landing at the leftmost slot of hidden means the saved order has to
+    /// be issued back-to-front: the last entry moves first and is pushed
+    /// furthest right, index 0 moves last and comes to rest adjacent to the
+    /// divider, which is where left-to-right index 0 belongs.
+    @Test("Items bound for hidden move in reverse saved order")
+    func hiddenBoundItemsMoveInReverseSavedOrder() {
+        let order = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: ["a", "b", "c", "d"],
+            crossing: ["a", "b", "c", "d"],
+            landingSlot: .leftmostOfHidden
+        )
+
+        #expect(order == ["d", "c", "b", "a"])
+    }
+
+    /// Landing at the rightmost slot of always-hidden is the mirror image:
+    /// index 0 moves first and is pushed furthest left, which is where
+    /// left-to-right index 0 belongs.
+    @Test("Items bound for always-hidden move in saved order")
+    func alwaysHiddenBoundItemsMoveInSavedOrder() {
+        let order = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: ["a", "b", "c", "d"],
+            crossing: ["a", "b", "c", "d"],
+            landingSlot: .rightmostOfAlwaysHidden
+        )
+
+        #expect(order == ["a", "b", "c", "d"])
+    }
+
+    /// Only the items actually crossing are issued. Entries the profile
+    /// carries that are already on the correct side keep their influence on
+    /// the relative order of the ones that are not.
+    @Test("Entries not crossing are skipped without disturbing the rest")
+    func nonCrossingEntriesSkipped() {
+        let order = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: ["a", "b", "c", "d", "e"],
+            crossing: ["b", "d"],
+            landingSlot: .leftmostOfHidden
+        )
+
+        #expect(order == ["d", "b"])
+    }
+
+    /// An identifier the profile has no position for is appended, so it
+    /// lands against the divider rather than displacing an item the profile
+    /// does place. Sorted, so a Set's arbitrary iteration order cannot make
+    /// two applies of the same profile disagree.
+    @Test("Unknown identifiers are appended in sorted order")
+    func unknownIdentifiersAppendedSorted() {
+        let order = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: ["a", "b"],
+            crossing: ["a", "b", "z", "y"],
+            landingSlot: .leftmostOfHidden
+        )
+
+        #expect(order == ["b", "a", "y", "z"])
+    }
+
+    /// Nothing crossing plans nothing: the fast path where the AH_ctrl
+    /// placement already produced the correct split must stay free.
+    @Test("An empty crossing set issues no moves")
+    func emptyCrossingSetIssuesNoMoves() {
+        let order = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: ["a", "b", "c"],
+            crossing: [],
+            landingSlot: .rightmostOfAlwaysHidden
+        )
+
+        #expect(order.isEmpty)
+    }
+
+    /// Regression, reproduced from a field log (thaw_2026-08-27_09-14-14).
+    ///
+    /// Applying an all-in-always-hidden profile and then switching back left
+    /// four items needing to cross into hidden. The fallback issued them in
+    /// saved order (Maccy, Hookshot, BetterDisplay, DisplayLink), each to the
+    /// right of AH_ctrl, and the bar came to rest exactly reversed:
+    ///
+    ///     saved:  Numi, Maccy, Flameshot, Hookshot, BetterDisplay, DisplayLink
+    ///     result: DisplayLink, BetterDisplay, Hookshot, Maccy, Numi
+    ///
+    /// Flameshot was not running and never crossed. Numi did not cross
+    /// either: the preceding AH_ctrl move landed left of it, which made it
+    /// hidden's leftmost item, and the four then inserted to its left. Where
+    /// a non-crossing item ends up relative to the run is decided by that
+    /// divider placement, not here, so this asserts only what the fallback
+    /// controls: the relative order of the items it issues.
+    @Test("Field regression: four items crossing into hidden are not reversed")
+    func fieldRegressionItemsCrossingIntoHiddenAreNotReversed() {
+        let savedHiddenOrder = [
+            "com.dmitrynikolaev.numi:Item-0",
+            "org.p0deje.Maccy:Item-0",
+            "org.flameshot.Flameshot:Item-0",
+            "com.knollsoft.Hookshot:Item-0",
+            "pro.betterdisplay.BetterDisplay:Item-0",
+            "com.displaylink.DisplayLinkUserAgent:Item-0",
+        ]
+        let crossing: Set = [
+            "org.p0deje.Maccy:Item-0",
+            "com.knollsoft.Hookshot:Item-0",
+            "pro.betterdisplay.BetterDisplay:Item-0",
+            "com.displaylink.DisplayLinkUserAgent:Item-0",
+        ]
+
+        let moveOrder = LayoutSolver.crossSectionFallbackMoveOrder(
+            profileOrder: savedHiddenOrder,
+            crossing: crossing,
+            landingSlot: .leftmostOfHidden
+        )
+
+        // The order the moves are issued in.
+        #expect(moveOrder == [
+            "com.displaylink.DisplayLinkUserAgent:Item-0",
+            "pro.betterdisplay.BetterDisplay:Item-0",
+            "com.knollsoft.Hookshot:Item-0",
+            "org.p0deje.Maccy:Item-0",
+        ])
+
+        // The order they come to rest in. Each move takes the slot next to
+        // the divider, the leftmost slot of hidden, and pushes its
+        // predecessors right, so the run reads as the moves reversed. That
+        // is the saved order, which is what the field log did not show.
+        #expect(Array(moveOrder.reversed()) == savedHiddenOrder.filter(crossing.contains))
+    }
+}


### PR DESCRIPTION
# Summary

The per-item cross-section fallback in `applyProfileLayout` issued its moves in the wrong direction, so items crossing back out of always-hidden came to rest in reverse saved order and stayed there. Both loops are corrected and the ordering decision moves to a tested pure helper on `LayoutSolver`.

**Scope:** This PR changes one focused thing (bug fix or feature) plus minimal plumbing. Larger refactors need prior agreement in the issue.

## Linked issue (required)

Closes: N/A

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [x] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

The fallback drags every item that still needs to cross the hidden/always-hidden boundary onto a single anchor, the always-hidden divider. Because the anchor never changes, the landing slot is identical for every move in the run and each move displaces its predecessors one place further from the divider. The order the moves are issued in is therefore the order the items come to rest in, reversed.

Both loops iterated the wrong way. The always-hidden loop walked `itemOrder["alwaysHidden"]` backwards and the hidden loop walked `itemOrder["hidden"]` forwards, on the assumption stated in their comments that index 0 is the rightmost entry. It is not: a saved order is stored left to right with index 0 leftmost, which is what `computeSectionOrder` produces and what `planNotchOverflow` documents when it takes `prefix()` for "leftmost items overflow first".

Nothing downstream caught it, because a reversed run still leaves every item in the section the profile asked for. The cross-section tallies, the divider gates and `saveSectionOrder` all read as correct, and only the order the user sees when the section is revealed is wrong.

Both loops now issue their moves through `LayoutSolver.crossSectionFallbackMoveOrder(profileOrder:crossing:landingSlot:)`, which takes the landing slot as an argument and derives the direction from it. Items landing in the leftmost slot of hidden are issued back to front, so index 0 moves last and comes to rest adjacent to the divider. Items landing in the rightmost slot of always-hidden are issued front to back, for the mirrored reason. Both come to rest in saved order. Identifiers the profile does not carry keep their existing treatment, appended and sorted, so they land together against the divider without a `Set`'s iteration order making two applies of the same profile disagree.

### Why it surfaced now

The defect arrived with the fallback itself in `fae0736b` (#576, May) and was harmless for three months. That commit ended by noting that "the existing Phase 2 LCS pass then handles within-section ordering", and it did: the LCS re-sorted the concealed sections on every apply and undid the reversal before anyone saw it.

`8d718eb7` shipped `enforceConcealedSectionOrder` defaulting to `false`, adopting the configuration the reliability test build had carried. With the gate off, `relaxConcealedSectionOrder` rewrites the desired sequence so the concealed sections' target order becomes whatever order the items already sit in. The LCS then finds them stable and plans nothing, so the reversal became permanent and every subsequent apply logged `Profile layout: all items already in correct positions` over a bar the user could see was backwards.

### Field evidence

From a diagnostic log where an all-in-always-hidden profile was applied and then switched back:

```text
09:44:09.471 Profile layout: AH_ctrl placement left 0 item(s) needing AH
             and 4 item(s) needing hidden, running per-item fallback
09:44:09.474 Moving <org.p0deje.Maccy>       to right of <AlwaysHidden ctrl>
09:44:09.646 Moving <com.knollsoft.Hookshot> to right of <AlwaysHidden ctrl>
09:44:09.811 Moving <pro.betterdisplay.…>    to right of <AlwaysHidden ctrl>
09:44:09.982 Moving <com.displaylink.…>      to right of <AlwaysHidden ctrl>
```

Saved order for those items is Numi, Maccy, Flameshot, Hookshot, BetterDisplay, DisplayLink. The section read back at the next cache cycle, and on every cycle for the rest of the session:

```text
current hidden section: [DisplayLink, BetterDisplay, Hookshot, Maccy, Numi]
```

That log's four moves are reproduced as a regression test.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -scheme Thaw -destination 'platform=macOS' -only-testing:ThawTests/CrossSectionFallbackMoveOrderTests` (6 tests, passed)
- `xcodebuild test -scheme Thaw -destination 'platform=macOS'` (2514 tests in 319 suites, passed)

## Known limitations / follow-ups

- This does not make concealed-section order match the profile in every case. With `enforceConcealedSectionOrder` off that is surrendered by design, and an item that never crossed the boundary keeps whatever position the divider placement gave it. In the field log above, Numi did not cross (the preceding `AH_ctrl` move landed left of it) and so remains at the right-hand end of hidden even with this fix applied.
- `Profile layout: all items already in correct positions` overstates what was checked whenever the relaxation is active: it fires when the LCS planned no moves, which after the rewrite means "correct, ignoring concealed-section order". That log line is what made this bug read as a healthy apply for two weeks. Tightening it is worth a follow-up but is out of scope here.
- The per-item fallback still has no coverage of its own beyond the ordering decision extracted here; the surrounding loop needs a live `AppState` and is a candidate for the log-replay harness.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790382768&installation_model_id=431242&pr_number=982&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F982&signature=95fc10917092c4d20a59fbc9ccb40dcba29a80c26d8cc2b96c7acbd85f169375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu bar item arrangement when moving items between hidden and always-hidden sections.
  - Preserves the configured profile order during cross-section moves.
  - Provides consistent, deterministic placement for items not included in the profile.

- **Tests**
  - Added coverage for move direction, excluded items, empty selections, unknown items, and multi-item placement scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->