### PR TITLE
feat(layout): activate items from the layout editor

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -33,6 +33,12 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
     private var cancellables = Set<AnyCancellable>()
 
+    /// Whether the current mouse gesture has crossed into the existing drag
+    /// path. AppKit normally consumes mouse-up when a dragging session starts,
+    /// but retaining this bit makes the click action safe even if a source app
+    /// or future drag implementation lets that mouse-up reach the view.
+    private var didBeginDraggingForCurrentClick = false
+
     /// Observes `appState.imageCache.images` (wave 3: `MenuBarItemImageCache`
     /// is @Observable rather than a Combine `ObservableObject`, so its old
     /// `$images` projection is gone). This is an AppKit view (not a SwiftUI
@@ -197,6 +203,48 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     override func mouseExited(with event: NSEvent) {
         super.mouseExited(with: event)
         tooltipController.cancel()
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        didBeginDraggingForCurrentClick = false
+        super.mouseDown(with: event)
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        super.mouseUp(with: event)
+
+        let location = convert(event.locationInWindow, from: nil)
+        let shouldActivate = Self.shouldActivateRepresentedItem(
+            buttonNumber: event.buttonNumber,
+            didBeginDragging: didBeginDraggingForCurrentClick,
+            mouseUpInsideBounds: bounds.contains(location)
+        )
+        didBeginDraggingForCurrentClick = false
+
+        guard shouldActivate else { return }
+        activateRepresentedItem()
+    }
+
+    /// Pure click-versus-drag gate used by the AppKit event handlers.
+    static nonisolated func shouldActivateRepresentedItem(
+        buttonNumber: Int,
+        didBeginDragging: Bool,
+        mouseUpInsideBounds: Bool
+    ) -> Bool {
+        buttonNumber == 0 && !didBeginDragging && mouseUpInsideBounds
+    }
+
+    /// Performs the status item's native left-click action. For an on-screen
+    /// item this clicks it in place; for a hidden item the shared activation
+    /// path temporarily reveals it, opens its menu/popover (or launches its
+    /// app when that is the item's normal behavior), and schedules a rehide.
+    private func activateRepresentedItem() {
+        let representedItem = effectiveItem
+        guard let itemManager = appState?.itemManager else { return }
+        let displayID = NSScreen.screenWithActiveMenuBar?.displayID
+        Task {
+            await itemManager.activate(item: representedItem, on: displayID)
+        }
     }
 
     private func configureCancellables() {
@@ -421,6 +469,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
 
     override func mouseDragged(with event: NSEvent) {
         super.mouseDragged(with: event)
+        didBeginDraggingForCurrentClick = true
         tooltipController.cancel()
 
         // #905 fallback: before refusing an `unresolvedControlCenterPlaceholder`

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -12280,6 +12280,9 @@
         }
       }
     },
+    "Click an item to open it. Hidden items are temporarily revealed." : {
+      "comment" : "Explains that clicking a layout item opens it and that hidden items are only revealed temporarily."
+    },
     "Click Item" : {
       "comment" : "A button label that appears when the item is currently being displayed.",
       "localizations" : {

--- a/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
+++ b/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
@@ -47,10 +47,10 @@ struct LayoutBarsSection: View {
             layoutBars
         } footer: {
             // Native grouped Section footer beneath the bars. Interpolated so
-            // the three translated strings flow as one wrapping paragraph
-            // instead of three fixed lines (Text + is deprecated on macOS 26;
+            // the four localized strings flow as one wrapping paragraph
+            // instead of four fixed lines (Text + is deprecated on macOS 26;
             // each inner Text keeps its own localization key).
-            Text("\(Text("Drag to arrange your menu bar items into different sections.")) \(Text("Move the New Items badge to choose where newly detected items will appear.")) \(Text("Items can also be arranged by ⌘ Command + dragging them in the menu bar."))")
+            Text("\(Text("Drag to arrange your menu bar items into different sections.")) \(Text("Move the New Items badge to choose where newly detected items will appear.")) \(Text("Items can also be arranged by ⌘ Command + dragging them in the menu bar.")) \(Text("Click an item to open it. Hidden items are temporarily revealed."))")
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
         .onReceive(

--- a/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
+++ b/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
@@ -62,3 +62,38 @@ struct LayoutBarContainerTests {
         #expect(insertionIndex == 0)
     }
 }
+
+@Suite("Layout item activation")
+struct LayoutBarItemActivationTests {
+    @Test("A left click released inside the icon activates its menu bar item")
+    func leftClickActivates() {
+        #expect(LayoutBarItemView.shouldActivateRepresentedItem(
+            buttonNumber: 0,
+            didBeginDragging: false,
+            mouseUpInsideBounds: true
+        ))
+    }
+
+    @Test("A drag never activates the app on mouse-up")
+    func dragDoesNotActivate() {
+        #expect(!LayoutBarItemView.shouldActivateRepresentedItem(
+            buttonNumber: 0,
+            didBeginDragging: true,
+            mouseUpInsideBounds: true
+        ))
+    }
+
+    @Test("Clicks released outside the icon and non-left clicks do not activate")
+    func unrelatedClicksDoNotActivate() {
+        #expect(!LayoutBarItemView.shouldActivateRepresentedItem(
+            buttonNumber: 0,
+            didBeginDragging: false,
+            mouseUpInsideBounds: false
+        ))
+        #expect(!LayoutBarItemView.shouldActivateRepresentedItem(
+            buttonNumber: 1,
+            didBeginDragging: false,
+            mouseUpInsideBounds: true
+        ))
+    }
+}


### PR DESCRIPTION
# Summary

Some menu bar apps do not correctly reopen their window or settings when they are already running and launched again through Finder or Spotlight. For those apps, activating the menu bar item may be the only reliable way to access their interface.

The layout editor already displays these items, including hidden ones, but previously supported dragging only. This PR allows users to click an item in the layout editor to perform its normal menu bar action.

Visible items are activated in place. Hidden items use Thaw's existing activation path, which temporarily reveals the item, activates it, and schedules it to be hidden again.

Clicking and dragging remain separate interactions: activation occurs only when a left click is released inside the item without starting a drag. The layout footer now explains the new behavior.

**Scope:** This PR adds one focused interaction using the existing item-activation infrastructure, together with user-facing guidance and tests.

This PR targets `release/v2.1.0` as a focused follow-up to #977.

## Linked issue (required)

Closes: N/A

Related: #977

## PR Type

- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [x] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Left-clicking an item in the layout editor performs its normal menu bar action.
- Visible items are activated in place.
- Hidden items are temporarily revealed, activated, and scheduled to hide again.
- Starting a drag does not activate the item when the mouse is released.
- Secondary-click behavior is unchanged.
- The layout footer explains that items can be clicked and hidden items are temporarily revealed.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run SwiftFormat against the changed files to keep code style consistent.
- [x] I've run the smallest relevant test command listed below.
- [x] I've added tests for the new click-versus-drag behavior.
- [x] I've documented the non-obvious click-versus-drag helper.
- [x] I've updated the layout footer and localization catalog.
- [x] This PR targets the requested `release/v2.1.0` testing branch.
- [x] This PR does not change dependencies or lockfiles.

Test command run:

`xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/LayoutBarItemActivationTests`

Result: 3 tests passed.

## Known limitations / follow-ups

- Activation invokes the item's normal left-click behavior; Thaw cannot force a specific window or settings screen if the target app handles that action differently.
- Secondary-click behavior remains unchanged.

## Other information

This reuses `MenuBarItemManager`'s existing activation and temporary-reveal behavior. The interaction has been manually tested in the running app.
