### PR TITLE
feat(diagnostics): redact sensitive diagnostic report values

### DIFF
--- a/Thaw/Utilities/DiagnosticRedactor.swift
+++ b/Thaw/Utilities/DiagnosticRedactor.swift
@@ -1,0 +1,122 @@
+//
+//  DiagnosticRedactor.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+
+/// Removes potentially sensitive information from diagnostic text before it
+/// leaves the Mac.
+///
+/// Reports keep app and menu bar identifiers plus display geometry because
+/// those values are needed to investigate move failures. Exact terms supplied
+/// by the caller remove account, network, device, and trigger values; general
+/// patterns provide a second layer for paths, addresses, and location pairs.
+/// Automated redaction is best effort, so callers must still ask the user to
+/// review a report before sharing it.
+nonisolated struct DiagnosticRedactor {
+    /// An exact string to replace wherever it appears.
+    struct Term: Hashable {
+        /// The text to remove.
+        let value: String
+
+        /// What to put in its place.
+        let placeholder: String
+
+        init(_ value: String, placeholder: String) {
+            self.value = value
+            self.placeholder = placeholder
+        }
+    }
+
+    /// Terms shorter than this are matched only at identifier boundaries.
+    /// A short account name such as "Li" still needs redaction, but must not
+    /// turn an unrelated value such as "client" into "c<user>ent".
+    static let minimumTermLength = 3
+
+    /// The exact terms, longest first, so containing values are replaced
+    /// before their substrings.
+    let terms: [Term]
+
+    init(terms: [Term]) {
+        let usable = Set(terms.filter {
+            !$0.value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        })
+        self.terms = usable.sorted { lhs, rhs in
+            if lhs.value.count != rhs.value.count {
+                return lhs.value.count > rhs.value.count
+            }
+            return lhs.value < rhs.value
+        }
+    }
+
+    /// Terms for the current macOS account: the home directory, login name,
+    /// full name, and each component of the full name.
+    static func accountTerms(
+        userName: String = NSUserName(),
+        fullName: String = NSFullUserName(),
+        homeDirectory: String = NSHomeDirectory()
+    ) -> [Term] {
+        var terms = [
+            Term(homeDirectory, placeholder: "~"),
+            Term(userName, placeholder: "<user>"),
+        ]
+        let trimmedFullName = fullName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedFullName.isEmpty {
+            terms.append(Term(trimmedFullName, placeholder: "<user>"))
+        }
+        for part in fullName.split(whereSeparator: \.isWhitespace) {
+            terms.append(Term(String(part), placeholder: "<user>"))
+        }
+        return terms
+    }
+
+    /// Returns `text` with every exact term and recognized pattern replaced.
+    func redact(_ text: String) -> String {
+        var result = text
+        for term in terms {
+            if term.value.count < Self.minimumTermLength {
+                let escaped = NSRegularExpression.escapedPattern(for: term.value)
+                let pattern = #"(?i)(?<![\p{L}\p{M}\p{N}_])"# + escaped + #"(?![\p{L}\p{M}\p{N}_])"#
+                result = result.replacingOccurrences(
+                    of: pattern,
+                    with: term.placeholder,
+                    options: .regularExpression
+                )
+            } else {
+                result = result.replacingOccurrences(
+                    of: term.value,
+                    with: term.placeholder,
+                    options: [.caseInsensitive]
+                )
+            }
+        }
+        // Any home directory, not only the current account's.
+        result = result.replacing(#//Users/[^/\s"'`)\]]+/#, with: "/Users/<user>")
+        result = result.replacing(#/[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}/#, with: "<email>")
+        result = result.replacing(#/\b(?:\d{1,3}\.){3}\d{1,3}\b/#, with: "<ip-address>")
+        result = result.replacingOccurrences(
+            of: #"(?<![0-9A-Fa-f:])(?:(?:[0-9A-Fa-f]{1,4}:){7}[0-9A-Fa-f]{1,4}|(?:[0-9A-Fa-f]{1,4}:){1,7}:(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4}){0,5})?|::(?:[0-9A-Fa-f]{1,4}(?::[0-9A-Fa-f]{1,4}){0,6})?)(?![0-9A-Fa-f:])"#,
+            with: "<ip-address>",
+            options: .regularExpression
+        )
+        // IPv6 must run first: a full eight-group address can contain a
+        // six-group substring that also satisfies the MAC-address pattern.
+        result = result.replacing(#/\b(?:[0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}\b/#, with: "<mac-address>")
+        // Values written after privacy-sensitive labels. This catches
+        // trigger-like values that can appear in a log without requiring the
+        // report code to depend on a particular automation implementation.
+        result = result.replacingOccurrences(
+            of: #"(?i)\b(?:ssid|wifi(?:ssid|network)?|networkname|devicename|bluetoothdevice|audiodevice|focusmode|trigger(?:name|value)?|condition(?:name|value)?|script(?:path|output)|location(?:name|label)?)\s*[=:]\s*(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^,;\r\n]+)"#,
+            with: "<sensitive-value>",
+            options: .regularExpression
+        )
+        // A high-precision latitude/longitude pair. Menu bar geometry uses
+        // one decimal and is intentionally retained for debugging.
+        result = result.replacing(#/-?\d{1,3}\.\d{3,}\s*,\s*-?\d{1,3}\.\d{3,}/#, with: "<coordinates>")
+        return result
+    }
+}

--- a/ThawTests/Utilities/DiagnosticRedactorTests.swift
+++ b/ThawTests/Utilities/DiagnosticRedactorTests.swift
@@ -1,0 +1,98 @@
+//
+//  DiagnosticRedactorTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// The redactor must strip what identifies a person while leaving the
+/// identifiers and geometry a maintainer reads a move report for.
+@Suite("Diagnostic redactor")
+struct DiagnosticRedactorTests {
+    @Test("Exact terms are replaced case-insensitively, longest first")
+    func exactTerms() {
+        let redactor = DiagnosticRedactor(terms: [
+            .init("Alvie", placeholder: "<user>"),
+            .init("Alvie Stoddard", placeholder: "<user>"),
+            .init("HomeNet-5G", placeholder: "<wifi-network>"),
+        ])
+
+        let text = "Trigger for alvie stoddard on HomeNet-5G; owner=com.alvie.Helper"
+
+        #expect(redactor.redact(text) == "Trigger for <user> on <wifi-network>; owner=com.<user>.Helper")
+    }
+
+    @Test("Short terms redact standalone account names without mangling identifiers")
+    func shortTerms() {
+        let redactor = DiagnosticRedactor(terms: [.init("li", placeholder: "<user>")])
+
+        #expect(redactor.redact("login=Li; alias li") == "login=<user>; alias <user>")
+        #expect(redactor.redact("plist client com.little.Helper") == "plist client com.little.Helper")
+    }
+
+    @Test("Patterns catch paths, addresses and coordinates the caller did not know about")
+    func patterns() {
+        let redactor = DiagnosticRedactor(terms: [])
+
+        #expect(redactor.redact("path=/Users/someone/Library/Logs/Thaw") == "path=/Users/<user>/Library/Logs/Thaw")
+        #expect(redactor.redact("mail someone@example.com now") == "mail <email> now")
+        #expect(redactor.redact("router 192.168.1.20 up") == "router <ip-address> up")
+        #expect(redactor.redact("router fe80::a4b2:31ff:fe7a:9c10 up") == "router <ip-address> up")
+        #expect(redactor.redact("router 12:34:56:78:9a:bc:de:f0 up") == "router <ip-address> up")
+        #expect(redactor.redact("bt AA:BB:CC:DD:EE:FF paired") == "bt <mac-address> paired")
+        #expect(redactor.redact("near 37.774929, -122.419418 (home)") == "near <coordinates> (home)")
+    }
+
+    @Test("Labeled network, device, and trigger-like values are removed")
+    func labeledSensitiveValues() {
+        let redactor = DiagnosticRedactor(terms: [])
+        let text = "wifiSSID=\"Home Network\"; deviceName=Alvie AirPods; triggerName=At Work; conditionValue=private"
+        let redacted = redactor.redact(text)
+
+        #expect(!redacted.contains("Home Network"))
+        #expect(!redacted.contains("Alvie AirPods"))
+        #expect(!redacted.contains("At Work"))
+        #expect(!redacted.contains("private"))
+    }
+
+    @Test("Menu bar geometry and identifiers survive redaction")
+    func geometry() {
+        let redactor = DiagnosticRedactor(
+            terms: DiagnosticRedactor.accountTerms(userName: "someone", fullName: "Some Person", homeDirectory: "/Users/someone")
+        )
+
+        let line = "Move event geometry: item=<com.example.App:Item-0 (windowID: 1223)> itemBounds=(1425.0, 0.0, 38.0, 33.0) "
+            + "pressPoint=(-3733.0, 16.5) minX=-8791.0 elapsed=0.029878973960876465s"
+
+        #expect(redactor.redact(line) == line)
+    }
+
+    @Test("Account terms cover the home directory, the login name and the full name")
+    func accountTerms() {
+        let terms = DiagnosticRedactor.accountTerms(userName: "someone", fullName: "Some Person", homeDirectory: "/Users/someone")
+
+        #expect(terms.contains(.init("/Users/someone", placeholder: "~")))
+        #expect(terms.contains(.init("someone", placeholder: "<user>")))
+        #expect(terms.contains(.init("Some Person", placeholder: "<user>")))
+        #expect(terms.contains(.init("Some", placeholder: "<user>")))
+        #expect(terms.contains(.init("Person", placeholder: "<user>")))
+
+        let redactor = DiagnosticRedactor(terms: terms)
+
+        #expect(redactor.redact("/Users/someone/Desktop, by Some Person") == "~/Desktop, by <user>")
+    }
+
+    @Test("Short full-name parts use identifier boundaries")
+    func shortAccountNameParts() {
+        let terms = DiagnosticRedactor.accountTerms(userName: "li", fullName: "Li Bo", homeDirectory: "/Users/li")
+        let redactor = DiagnosticRedactor(terms: terms)
+
+        #expect(terms.contains(.init("Li Bo", placeholder: "<user>")))
+        #expect(redactor.redact("Owner Li Bo; logins li and bo") == "Owner <user>; logins <user> and <user>")
+        #expect(redactor.redact("plist client boiling com.little.Helper") == "plist client boiling com.little.Helper")
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -209,6 +209,7 @@ $(SRCROOT)/Thaw/Utilities/Constants.swift
 $(SRCROOT)/Thaw/Utilities/Defaults.swift
 $(SRCROOT)/Thaw/Utilities/EnergyMode.swift
 $(SRCROOT)/Thaw/Utilities/EnergyModeMonitor.swift
+$(SRCROOT)/Thaw/Utilities/DiagnosticRedactor.swift
 $(SRCROOT)/Thaw/Utilities/Extensions.swift
 $(SRCROOT)/Thaw/Utilities/Helpers.swift
 $(SRCROOT)/Thaw/Utilities/HookProcess.swift

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -207,9 +207,9 @@ $(SRCROOT)/Thaw/Utilities/ConcurrencyHelpers.swift
 $(SRCROOT)/Thaw/Utilities/ConflictingAppDetector.swift
 $(SRCROOT)/Thaw/Utilities/Constants.swift
 $(SRCROOT)/Thaw/Utilities/Defaults.swift
+$(SRCROOT)/Thaw/Utilities/DiagnosticRedactor.swift
 $(SRCROOT)/Thaw/Utilities/EnergyMode.swift
 $(SRCROOT)/Thaw/Utilities/EnergyModeMonitor.swift
-$(SRCROOT)/Thaw/Utilities/DiagnosticRedactor.swift
 $(SRCROOT)/Thaw/Utilities/Extensions.swift
 $(SRCROOT)/Thaw/Utilities/Helpers.swift
 $(SRCROOT)/Thaw/Utilities/HookProcess.swift


### PR DESCRIPTION
# Summary

Adds a reusable, best-effort diagnostic redactor for text that a user may attach to a bug report. It removes caller-provided sensitive terms and then applies focused patterns for account paths, email and network addresses, sensitive labeled values, and precise location-coordinate pairs.

Account terms now include the complete macOS full name as well as its components. Short usernames and name parts are matched only at identifier boundaries, so a name such as `Li` is removed without corrupting unrelated identifiers such as `client` or `com.little.Helper`. IPv6 redaction runs before MAC-address redaction so a full eight-group IPv6 address cannot be partially mistaken for a MAC address.

**Scope:** This PR adds only the privacy foundation, focused Swift Testing coverage, and the generated SwiftLint input entry. It changes 3 files with 221 insertions. The next related PR uses the redactor for move-failure reports; this PR does not add an export UI by itself. This targets `development` and may be suitable for 2.2.

## Linked issue (required)

Closes: N/A

Related: #905, #923

## PR Type

- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [x] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Callers can redact exact sensitive terms case-insensitively before diagnostic text is written. Longer terms are processed first so a full name is removed before one of its components.
- Account terms cover the home directory, login name, complete full name, and each full-name component.
- One- and two-character terms are redactable, but only at Unicode-aware identifier boundaries; they do not replace matching letters inside unrelated words or identifiers.
- A second pass recognizes `/Users/<name>` paths, email addresses, IPv4 and common IPv6 forms, MAC addresses, privacy-sensitive labeled values, and high-precision coordinate pairs.
- IPv6 is processed before MAC addresses, preventing an eight-group IPv6 value from being only partially redacted.
- Menu-bar identifiers and low-precision display geometry are intentionally left available for later diagnostic reporting.
- The API documents that redaction is best effort and that callers must still ask users to review exported text before sharing it.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/DiagnosticRedactorTests -only-testing:ThawTests/DiagnosticLoggerFileTests -only-testing:ThawTests/MoveFailureDiagnosticReportTests`

The final-stack run passed all three selected suites (32 tests total), including all 7 `DiagnosticRedactorTests`. A separate macOS `xcodebuild build` also passed. SwiftFormat was run against every changed Swift file; strict SwiftLint reported 0 violations; the generated SwiftLint input list and `git diff --check` matched cleanly.

## Known limitations / follow-ups

- Automated redaction cannot guarantee that every sensitive value is removed; exported reports must tell users to review the result before sharing it.
- App and menu-item identities plus display/menu-bar geometry are intentionally retained when required for diagnosis and may themselves be sensitive.
- This foundation becomes user-facing only when the dependent move-diagnostic-report PR is included.

## Other information

No manual app launch or interactive UI run was performed for this PR; verification was through the focused automated tests, build, formatting, lint, and diff checks above.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 1 of 12  
**Git base:** `development`  
**Functional dependencies:** None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic redaction of sensitive information in diagnostic text, including account details, file paths, email addresses, network addresses, coordinates, and labeled values.
  * Added support for redacting caller-provided terms with case-insensitive, boundary-aware matching while preserving unrelated identifiers and geometry data.
  * Redacted content is replaced with category-specific placeholders for clearer, safer diagnostics.

* **Tests**
  * Added coverage for matching behavior, overlapping terms, account-term generation, sensitive data detection, and preservation of non-sensitive values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->