### PR TITLE
feat(layout): add redacted move diagnostic reports

### DIFF
--- a/Shared/Utilities/DiagnosticLogger.swift
+++ b/Shared/Utilities/DiagnosticLogger.swift
@@ -92,6 +92,15 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         currentLogFileLock.withLock { $0 }
     }
 
+    /// A bounded text view of the newest bytes in one diagnostic log file.
+    struct TailSnapshot: Equatable {
+        /// The log file that was read.
+        let fileURL: URL
+
+        /// UTF-8 decoded text from the bounded tail window.
+        let text: String
+    }
+
     /// The file handle for writing.
     private let fileHandleLock = OSAllocatedUnfairLock<FileHandle?>(initialState: nil)
 
@@ -567,6 +576,59 @@ final nonisolated class DiagnosticLogger: @unchecked Sendable {
         } catch {
             osLog.warning("Failed to clean up old log files: \(error)")
         }
+    }
+
+    // MARK: - Snapshots
+
+    /// Returns a bounded tail of the active or most recent diagnostic log.
+    ///
+    /// The read is submitted to ``writeQueue`` so every write already accepted
+    /// by ``log(level:category:message:)`` is complete before the snapshot is
+    /// taken. File lookup and I/O also stay off the caller's executor.
+    func tailSnapshot(maxBytes: Int) async -> TailSnapshot? {
+        guard maxBytes > 0 else { return nil }
+        return await withCheckedContinuation { continuation in
+            writeQueue.async { [weak self] in
+                guard
+                    let self,
+                    let fileURL = self.currentLogFile ?? self.latestLogFile,
+                    let text = try? Self.readTail(from: fileURL, maxBytes: maxBytes)
+                else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: TailSnapshot(fileURL: fileURL, text: text))
+            }
+        }
+    }
+
+    /// Reads no more than `maxBytes` from the end of `fileURL`.
+    ///
+    /// When the window begins inside a line, that incomplete line is dropped.
+    /// `String(decoding:as:)` deliberately tolerates a trailing partial UTF-8
+    /// scalar, which another process can expose while appending to the shared
+    /// log file.
+    static func readTail(from fileURL: URL, maxBytes: Int) throws -> String {
+        guard maxBytes > 0 else { return "" }
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        let fileSize = try handle.seekToEnd()
+        let byteLimit = UInt64(maxBytes)
+        let startOffset = fileSize > byteLimit ? fileSize - byteLimit : 0
+        try handle.seek(toOffset: startOffset)
+        let data = try handle.read(upToCount: maxBytes) ?? Data()
+
+        let completeData: Data
+        if startOffset > 0 {
+            guard let newline = data.firstIndex(of: 0x0A) else { return "" }
+            completeData = Data(data.suffix(from: data.index(after: newline)))
+        } else {
+            completeData = data
+        }
+        // Replacement characters keep partial cross-process writes readable.
+        // swiftlint:disable:next optional_data_string_conversion
+        return String(decoding: completeData, as: UTF8.self)
     }
 
     // MARK: - Logging

--- a/Thaw/MenuBar/LayoutBar/MoveFailureDiagnosticReport.swift
+++ b/Thaw/MenuBar/LayoutBar/MoveFailureDiagnosticReport.swift
@@ -1,0 +1,519 @@
+//
+//  MoveFailureDiagnosticReport.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Cocoa
+import UniformTypeIdentifiers
+
+/// A self-contained, redacted description of a failed menu bar item move,
+/// offered from the failure alert for attaching to a bug report.
+///
+/// A pasted log excerpt on its own cannot answer the questions that decide
+/// a move investigation: what the display looks like, what the rest of the
+/// bar looked like at the time, which settings the move engine ran under,
+/// and whether the same mechanics had just worked for another item. This
+/// gathers all of that into one text file and applies
+/// ``DiagnosticRedactor`` before the user reviews and shares it.
+nonisolated struct MoveFailureDiagnosticReport {
+    /// The move that failed.
+    struct Failure {
+        /// The item that did not move.
+        let item: MenuBarItem
+
+        /// Where it was supposed to go.
+        let destination: MenuBarItemManager.MoveDestination
+
+        /// The section the destination lies in.
+        let expectedSection: MenuBarSection.Name
+
+        /// The error the move ended with.
+        let error: any Error
+
+        /// What the caller already tried, if anything.
+        let note: String?
+
+        init(
+            item: MenuBarItem,
+            destination: MenuBarItemManager.MoveDestination,
+            expectedSection: MenuBarSection.Name,
+            error: any Error,
+            note: String? = nil
+        ) {
+            self.item = item
+            self.destination = destination
+            self.expectedSection = expectedSection
+            self.error = error
+            self.note = note
+        }
+    }
+
+    /// Log categories the excerpt keeps: everything about enumerating and
+    /// moving items, nothing that quotes a network, device, or script. The
+    /// window-list chatter in `Bridging` is left out as noise; the move
+    /// engine's own lines already summarize what each enumeration returned.
+    static let logCategories: Set<String> = [
+        "AppState",
+        "ControlItem",
+        "DisplaySettingsManager",
+        "EventTap",
+        "LayoutBarContainer",
+        "LayoutBarItemView",
+        "LayoutBarPaddingView",
+        "Listener",
+        "MenuBarItem",
+        "MenuBarItemManager",
+        "MenuBarItemService.Connection",
+        "MenuBarItemSpacingManager",
+        "MenuBarManager",
+        "MouseHelpers",
+        "NSScreen",
+        "SourcePIDCache",
+        "StaleIdentifierLedger",
+        "WindowInfo",
+    ]
+
+    /// How many matching log lines the excerpt keeps, newest last.
+    static let logLineLimit = 800
+
+    /// Maximum on-disk log window read while building a report.
+    static let logTailByteLimit = 2 * 1024 * 1024
+
+    /// The redacted report text.
+    let text: String
+
+    /// A file name for the save panel.
+    let suggestedFileName: String
+
+    // MARK: Generation
+
+    /// Builds the report for a failed move against the app's current state.
+    @MainActor
+    static func generate(for failure: Failure, appState: AppState) async -> MoveFailureDiagnosticReport {
+        // Not `.onScreen`: items parked in a collapsed section are the ones
+        // a failed hidden-section move is usually about.
+        let liveItems = await MenuBarItem.getMenuBarItems(on: nil, option: .activeSpace, resolveSourcePID: false)
+        let logger = DiagnosticLogger.shared
+        let diagnosticLoggingWasEnabled = logger.isEnabled
+        let logSnapshot = await logger.tailSnapshot(maxBytes: logTailByteLimit)
+
+        var writer = Writer()
+        writeHeader(to: &writer)
+        writeFailure(failure, appState: appState, to: &writer)
+        writeDisplays(to: &writer)
+        writeSettings(appState: appState, to: &writer)
+        writeCachedMenuBar(appState: appState, liveItems: liveItems, to: &writer)
+        writeLiveMenuBar(liveItems, to: &writer)
+        writeSavedLayout(appState: appState, to: &writer)
+        writeLogExcerpt(
+            logSnapshot,
+            diagnosticLoggingWasEnabled: diagnosticLoggingWasEnabled,
+            to: &writer
+        )
+
+        let redactor = DiagnosticRedactor(terms: DiagnosticRedactor.accountTerms())
+        return MoveFailureDiagnosticReport(
+            text: redactor.redact(writer.text),
+            suggestedFileName: suggestedFileName(for: Date())
+        )
+    }
+
+    // MARK: Presentation
+
+    /// Presents `alert` with an added "Save Diagnostic Report…" button and
+    /// saves this report when it is chosen.
+    ///
+    /// Shown as a sheet on `window` when there is one. An app-modal alert
+    /// holds the main actor for as long as it is up, and the move engine
+    /// runs on the main actor: in the field another move sat behind a
+    /// modal failure alert for fifteen seconds with its synthetic press
+    /// still down, and Control Center completed that orphaned drag by
+    /// removing the item from the bar. A sheet returns immediately.
+    @MainActor
+    func run(_ alert: NSAlert, in window: NSWindow? = nil) {
+        let notice = String(
+            localized: "The report retains installed-app identities, menu-item titles and status text, and display/menu-bar geometry for debugging. It attempts to redact other potentially sensitive information, but redaction cannot be guaranteed. Review the report before sharing it."
+        )
+        alert.informativeText = alert.informativeText.isEmpty ? notice : alert.informativeText + "\n\n" + notice
+        let saveResponse = Self.configureButtons(on: alert)
+        guard let window else {
+            if alert.runModal() == saveResponse {
+                save()
+            }
+            return
+        }
+        alert.beginSheetModal(for: window) { response in
+            if response == saveResponse {
+                save(in: window)
+            }
+        }
+    }
+
+    /// Reuses the primary button supplied by `NSAlert`, adds one save
+    /// button, and returns the response value for that button.
+    @MainActor
+    static func configureButtons(on alert: NSAlert) -> NSApplication.ModalResponse {
+        // `NSAlert` supplies its default OK button lazily in some contexts.
+        // Loading the window makes `buttons` accurately reflect that button
+        // before we add another one.
+        _ = alert.window
+        if let primaryButton = alert.buttons.first {
+            primaryButton.title = String(localized: "OK")
+        } else {
+            alert.addButton(withTitle: String(localized: "OK"))
+        }
+        let saveTitle = String(localized: "Save Diagnostic Report…")
+        alert.addButton(withTitle: saveTitle)
+        if alert.buttons.count == 1 {
+            // On older AppKit, adding a button can replace the lazily supplied
+            // default instead of appending to it. Add the second explicit
+            // button, then restore the primary title and order.
+            alert.addButton(withTitle: saveTitle)
+            alert.buttons[0].title = String(localized: "OK")
+        }
+        let saveButtonIndex = alert.buttons.lastIndex { $0.title == saveTitle } ?? (alert.buttons.count - 1)
+        return NSApplication.ModalResponse(
+            rawValue: NSApplication.ModalResponse.alertFirstButtonReturn.rawValue + saveButtonIndex
+        )
+    }
+
+    /// Writes the report to `url`.
+    func write(to url: URL) throws {
+        try text.write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    /// Asks where to save the report, writes it, and reveals it in Finder.
+    @MainActor
+    func save(in window: NSWindow? = nil) {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.plainText]
+        panel.nameFieldStringValue = suggestedFileName
+        panel.canCreateDirectories = true
+        panel.title = String(localized: "Save Diagnostic Report")
+
+        let handleResponse: (NSApplication.ModalResponse) -> Void = { response in
+            guard response == .OK, let url = panel.url else { return }
+            do {
+                try write(to: url)
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            } catch {
+                let alert = NSAlert(error: error)
+                if let window {
+                    alert.beginSheetModal(for: window)
+                } else {
+                    alert.runModal()
+                }
+            }
+        }
+        if let window {
+            panel.beginSheetModal(for: window, completionHandler: handleResponse)
+        } else {
+            handleResponse(panel.runModal())
+        }
+    }
+
+    // MARK: Log excerpt
+
+    /// Keeps the lines whose category is in ``logCategories``, newest
+    /// `limit` of them. A line that does not parse as a log line (the file
+    /// header, a continuation) is dropped.
+    static func filterLogLines(_ lines: [String], limit: Int = logLineLimit) -> [String] {
+        guard limit > 0 else { return [] }
+        var kept: [String] = []
+        kept.reserveCapacity(min(lines.count, limit))
+        for line in lines.reversed() {
+            guard let category = logCategory(of: line), logCategories.contains(category) else {
+                continue
+            }
+            kept.append(line)
+            if kept.count == limit {
+                break
+            }
+        }
+        return Array(kept.reversed())
+    }
+
+    /// The `[Category]` field of a log line, which follows the timestamp
+    /// and the level: `2026-08-28 22:16:43.817 [DEBUG] [MenuBarItemManager] …`.
+    static func logCategory(of line: String) -> String? {
+        guard let match = line.firstMatch(of: #/^\S+ \S+ \[[A-Z]+\] \[([^\]]+)\]/#) else {
+            return nil
+        }
+        return String(match.1)
+    }
+
+    /// The file name offered by the save panel.
+    static func suggestedFileName(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return "\(Constants.displayName)-move-diagnostic-\(formatter.string(from: date)).txt"
+    }
+}
+
+// MARK: - Sections
+
+private extension MoveFailureDiagnosticReport {
+    /// Accumulates the report's lines.
+    struct Writer {
+        private(set) var lines: [String] = []
+
+        var text: String {
+            lines.joined(separator: "\n") + "\n"
+        }
+
+        mutating func heading(_ title: String) {
+            lines.append("")
+            lines.append("## \(title)")
+        }
+
+        mutating func line(_ text: String = "") {
+            lines.append(text)
+        }
+    }
+
+    static func writeHeader(to writer: inout Writer) {
+        let commit = Bundle.main.infoDictionary?["GitCommitSHA"] as? String ?? "unknown"
+        writer.line("\(Constants.displayName) move diagnostic report")
+        writer.line("Generated: \(ISO8601DateFormatter().string(from: Date()))")
+        writer.line()
+        writer.line(
+            """
+            This report intentionally retains installed-app identities, menu-item titles \
+            and status text, and display/menu-bar geometry because they are needed to \
+            investigate the failure. Those values may themselves be sensitive. The report \
+            attempts to redact usernames and full names, home-directory paths, network and \
+            connected-device names, e-mail, IP and MAC addresses, trigger names and \
+            condition values, and precise location coordinates. Automated redaction cannot \
+            be guaranteed to catch everything. Review the report before sharing it.
+            """
+        )
+        writer.heading("Environment")
+        writer.line("\(Constants.displayName): \(Constants.versionString) (\(Constants.buildString)) commit \(commit)")
+        writer.line("macOS: \(ProcessInfo.processInfo.operatingSystemVersionString)")
+        writer.line("Hardware: \(hardwareModel())")
+        writer.line("Diagnostic logging: \(DiagnosticLogger.shared.isEnabled ? "enabled" : "disabled")")
+    }
+
+    @MainActor
+    static func writeFailure(_ failure: Failure, appState: AppState, to writer: inout Writer) {
+        let manager = appState.itemManager
+        let cache = manager.itemCache
+
+        writer.heading("Failure")
+        writer.line("Error: \(describe(failure.error))")
+        if let note = failure.note {
+            writer.line("Note: \(note)")
+        }
+        writer.line("Expected section: \(failure.expectedSection.logString)")
+        writer.line("Item: \(failure.item.logString)")
+        for line in itemLines(failure.item, cache: cache, manager: manager) {
+            writer.line(line)
+        }
+        let target = failure.destination.targetItem
+        writer.line("Destination: \(failure.destination.logString)")
+        for line in itemLines(target, cache: cache, manager: manager) {
+            writer.line(line)
+        }
+        if let liveTargetBounds = Bridging.getWindowBounds(for: target.windowID) {
+            writer.line("  liveBounds=\(format(liveTargetBounds))")
+        }
+
+        let lastMove = manager.lastMoveOperationTimestamp.map { instant in
+            String(format: "%.1f s ago", (ContinuousClock.now - instant).milliseconds / 1000)
+        } ?? "none this session"
+        writer.line(
+            "Manager state: bulkApply=\(manager.isBulkApplyInProgress) profileApply=\(manager.isApplyingProfileLayout) "
+                + "resettingLayout=\(manager.isResettingLayout) restoringOrder=\(manager.isRestoringItemOrder) "
+                + "startupSettling=\(manager.isInStartupSettling) controlItemsMissing=\(manager.areControlItemsMissing) "
+                + "lastMove=\(lastMove)"
+        )
+    }
+
+    @MainActor
+    static func itemLines(
+        _ item: MenuBarItem,
+        cache: MenuBarItemManager.ItemCache,
+        manager: MenuBarItemManager
+    ) -> [String] {
+        let section = cache.address(for: item.tag)?.section.logString ?? "not in cache"
+        let owner = processDescription(item.ownerPID, application: item.owningApplication)
+        let source = item.sourcePID.map { processDescription($0, application: item.sourceApplication) } ?? "unresolved"
+        let movability = item.immovabilityReason?.logDescription ?? "movable"
+        let timeout = manager.moveOperationTimeouts[item.tag].map { "\(Int($0.milliseconds)) ms" } ?? "default"
+        return [
+            "  identifier=\(item.tag.tagIdentifier) windowID=\(item.windowID)",
+            "  bounds=\(format(item.bounds)) onScreen=\(item.isOnScreen) cachedSection=\(section)",
+            "  owner=\(owner) source=\(source)",
+            "  movability=\(movability) provisionalIdentity=\(item.hasProvisionalIdentity) "
+                + "systemClone=\(item.isSystemClone) canBeHidden=\(item.canBeHidden) controlItem=\(item.isControlItem)",
+            "  ownerUnresponsive=\(Bridging.isProcessUnresponsive(item.ownerPID)) "
+                + "sourceUnresponsive=\(item.sourcePID.map { String(Bridging.isProcessUnresponsive($0)) } ?? "n/a") "
+                + "ledgerUnresponsive=\(manager.failureLedger.isUnresponsive(item)) "
+                + "ledgerBackoff=\(manager.failureLedger.isUnderBackoff(for: item)) moveTimeout=\(timeout)",
+        ]
+    }
+
+    @MainActor
+    static func writeDisplays(to writer: inout Writer) {
+        let activeDisplayID = Bridging.getActiveMenuBarDisplayID()
+        writer.heading("Displays")
+        for (index, screen) in NSScreen.screens.enumerated() {
+            let notch = screen.frameOfNotch.map(format) ?? "none"
+            writer.line(
+                "[\(index)] displayID=\(screen.displayID) frame=\(format(screen.frame)) "
+                    + "visibleFrame=\(format(screen.visibleFrame)) scale=\(screen.backingScaleFactor) "
+                    + "notch=\(notch) safeAreaTop=\(screen.safeAreaInsets.top) "
+                    + "main=\(screen == NSScreen.main) activeMenuBar=\(screen.displayID == activeDisplayID)"
+            )
+        }
+    }
+
+    @MainActor
+    static func writeSettings(appState: AppState, to writer: inout Writer) {
+        writer.heading("Settings")
+        writer.line("postMoveEventsToWindowOwner=\(MenuBarItem.postsMoveEventsToWindowOwner)")
+        writer.line("discardStrayMoveEvents=\(defaultsValue(.discardStrayMoveEvents))")
+        writer.line("enableAlwaysHiddenSection=\(appState.settings.advanced.enableAlwaysHiddenSection)")
+        writer.line("useIceBar=\(defaultsValue(.useIceBar)) useIceBarOnlyOnNotchedDisplay=\(defaultsValue(.useIceBarOnlyOnNotchedDisplay))")
+        writer.line("showOnClick=\(defaultsValue(.showOnClick)) showOnHover=\(defaultsValue(.showOnHover))")
+    }
+
+    @MainActor
+    static func writeCachedMenuBar(appState: AppState, liveItems: [MenuBarItem], to writer: inout Writer) {
+        let manager = appState.itemManager
+        let cache = manager.itemCache
+        writer.heading("Menu bar (cached sections, left to right)")
+        writer.line("displayID=\(cache.displayID.map(String.init) ?? "nil")")
+        for section in MenuBarSection.Name.allCases {
+            let items = cache[section]
+            writer.line("\(section.logString) (\(items.count)):")
+            for item in items {
+                writer.line("  \(compactDescription(of: item))")
+            }
+        }
+        // The control item's own window reference is often nil; the divider
+        // is still enumerable as a menu bar item by its tag.
+        let dividers: [(name: MenuBarSection.Name, tag: MenuBarItemTag)] = [
+            (.hidden, .hiddenControlItem),
+            (.alwaysHidden, .alwaysHiddenControlItem),
+        ]
+        for divider in dividers {
+            let windowID = appState.menuBarManager.controlItem(withName: divider.name)?.window
+                .flatMap { CGWindowID(exactly: $0.windowNumber) }
+                ?? liveItems.first { $0.tag == divider.tag }?.windowID
+            guard let windowID else {
+                writer.line("\(divider.name.logString) divider: not found")
+                continue
+            }
+            let bounds = Bridging.getWindowBounds(for: windowID).map(format) ?? "unknown"
+            writer.line("\(divider.name.logString) divider: windowID=\(windowID) bounds=\(bounds)")
+        }
+    }
+
+    static func writeLiveMenuBar(_ items: [MenuBarItem], to writer: inout Writer) {
+        writer.heading("Menu bar (live enumeration, active space, source processes unresolved)")
+        for item in items.sorted(by: { $0.bounds.minX < $1.bounds.minX }) {
+            writer.line("  \(compactDescription(of: item))")
+        }
+    }
+
+    @MainActor
+    static func writeSavedLayout(appState: AppState, to writer: inout Writer) {
+        writer.heading("Saved layout")
+        let order = appState.itemManager.savedSectionOrder
+        for key in order.keys.sorted() {
+            writer.line("\(key): \(order[key] ?? [])")
+        }
+    }
+
+    static func writeLogExcerpt(
+        _ snapshot: DiagnosticLogger.TailSnapshot?,
+        diagnosticLoggingWasEnabled: Bool,
+        to writer: inout Writer
+    ) {
+        writer.heading(
+            "Recent log (categories: \(logCategories.sorted().joined(separator: ", ")); "
+                + "newest \(logLineLimit) matching lines from a \(logTailByteLimit / 1024 / 1024) MiB tail)"
+        )
+        if !diagnosticLoggingWasEnabled {
+            writer.line("Diagnostic logging is disabled; the most recent log file may predate this failure.")
+        }
+        guard let snapshot else {
+            writer.line("(no log file available)")
+            return
+        }
+        writer.line("File: \(snapshot.fileURL.lastPathComponent)")
+        let lines = snapshot.text.split(separator: "\n", omittingEmptySubsequences: true).map(String.init)
+        let filteredLines = filterLogLines(lines)
+        if filteredLines.isEmpty {
+            writer.line("(no matching log lines in the bounded tail)")
+        }
+        for line in filteredLines {
+            writer.line(line)
+        }
+    }
+
+    // MARK: Formatting
+
+    static func describe(_ error: any Error) -> String {
+        let description = String(describing: error)
+        if let localized = (error as? LocalizedError)?.errorDescription {
+            return "\(description) — \(localized)"
+        }
+        return description
+    }
+
+    static func compactDescription(of item: MenuBarItem) -> String {
+        let source = item.sourcePID.map(String.init) ?? "unresolved"
+        let control = item.isControlItem ? " [control item]" : ""
+        return "\(item.tag.tagIdentifier) windowID=\(item.windowID) minX=\(format(item.bounds.minX)) "
+            + "width=\(format(item.bounds.width)) onScreen=\(item.isOnScreen) source=\(source)\(control)"
+    }
+
+    /// The activation policy matters for the source app: a regular app whose
+    /// window is closed can be napped, and both revert episodes in the field
+    /// logs began right after a long idle stretch.
+    static func processDescription(_ pid: pid_t, application: NSRunningApplication?) -> String {
+        guard let application else {
+            return "pid \(pid) (not a running application)"
+        }
+        let identity = application.bundleIdentifier
+            ?? "no bundle identifier; name=\(application.localizedName ?? "unknown")"
+        let policy = switch application.activationPolicy {
+        case .regular: "regular"
+        case .accessory: "accessory"
+        case .prohibited: "prohibited"
+        @unknown default: "unknown"
+        }
+        return "pid \(pid) (\(identity)) policy=\(policy)"
+    }
+
+    static func defaultsValue(_ key: Defaults.Key) -> String {
+        Defaults.object(forKey: key).map { String(describing: $0) } ?? "default"
+    }
+
+    static func format(_ rect: CGRect) -> String {
+        "(x=\(format(rect.minX)) y=\(format(rect.minY)) w=\(format(rect.width)) h=\(format(rect.height)))"
+    }
+
+    static func format(_ value: CGFloat) -> String {
+        String(format: "%.1f", value)
+    }
+
+    static func hardwareModel() -> String {
+        var size = 0
+        guard sysctlbyname("hw.model", nil, &size, nil, 0) == 0, size > 0 else {
+            return "unknown"
+        }
+        var buffer = [CChar](repeating: 0, count: size)
+        guard sysctlbyname("hw.model", &buffer, &size, nil, 0) == 0 else {
+            return "unknown"
+        }
+        let bytes = buffer.prefix { $0 != 0 }.map { UInt8(bitPattern: $0) }
+        return String(bytes: bytes, encoding: .utf8) ?? "unknown"
+    }
+}

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -61507,6 +61507,12 @@
         }
       }
     },
+    "Save Diagnostic Report" : {
+
+    },
+    "Save Diagnostic Report…" : {
+
+    },
     "Save the global template to the active profile \"%@\", or save it to every profile." : {
       "comment" : "A message that instructs the user to save the global template to a profile.",
       "localizations" : {
@@ -72074,6 +72080,9 @@
           }
         }
       }
+    },
+    "The report retains installed-app identities, menu-item titles and status text, and display/menu-bar geometry for debugging. It attempts to redact other potentially sensitive information, but redaction cannot be guaranteed. Review the report before sharing it." : {
+
     },
     "The language change applies after %@ relaunches." : {
       "localizations" : {

--- a/ThawTests/MenuBar/Items/MoveFailureDiagnosticReportTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureDiagnosticReportTests.swift
@@ -1,0 +1,85 @@
+//
+//  MoveFailureDiagnosticReportTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Cocoa
+import Testing
+@testable import Thaw
+
+/// The parts of the report that need no live menu bar: which log lines it
+/// keeps and how it names its file.
+@Suite("Move failure diagnostic report")
+struct MoveFailureDiagnosticReportTests {
+    @Test("The log excerpt keeps move-engine categories and drops the rest")
+    func logFilter() {
+        let lines = [
+            "2026-08-28 22:16:43.817 [DEBUG] [MenuBarItemManager] Move points: startX=-3733.0",
+            "2026-08-28 22:16:43.818 [INFO] [SystemStateMonitor] wifi=HomeNet",
+            "2026-08-28 22:16:43.819 [DEBUG] [Bridging] getMenuBarWindowList: 11 raw",
+            "2026-08-28 22:16:43.820 [ERROR] [LayoutBarPaddingView] Error moving menu bar item",
+            "not a log line",
+        ]
+
+        #expect(MoveFailureDiagnosticReport.filterLogLines(lines) == [lines[0], lines[3]])
+    }
+
+    @Test("The log excerpt is capped to the newest lines")
+    func logCap() {
+        let lines = (0 ..< 10).map { index in
+            "2026-08-28 22:16:43.\(String(format: "%03d", index)) [DEBUG] [MenuBarItemManager] line \(index)"
+        }
+
+        let kept = MoveFailureDiagnosticReport.filterLogLines(lines, limit: 3).map { String($0.suffix(6)) }
+
+        #expect(kept == ["line 7", "line 8", "line 9"])
+    }
+
+    @Test("The category is the second bracketed field")
+    func logCategory() {
+        #expect(MoveFailureDiagnosticReport.logCategory(of: "2026-08-28 22:16:43.817 [DEBUG] [MenuBarItem] created 10 items") == "MenuBarItem")
+        #expect(MoveFailureDiagnosticReport.logCategory(of: "Started: 2026-08-28 22:16:43") == nil)
+    }
+
+    @Test("The suggested file name carries the app name and a timestamp")
+    func fileName() {
+        let name = MoveFailureDiagnosticReport.suggestedFileName(for: Date(timeIntervalSince1970: 0))
+
+        #expect(name.hasPrefix("\(Constants.displayName)-move-diagnostic-"))
+        #expect(name.hasSuffix(".txt"))
+    }
+
+    @Test("The report reuses the default OK button and adds one working save button")
+    @MainActor
+    func alertButtons() {
+        let alerts = [
+            NSAlert(),
+            NSAlert(error: NSError(domain: "MoveFailureDiagnosticReportTests", code: 1)),
+        ]
+
+        for alert in alerts {
+            let saveResponse = MoveFailureDiagnosticReport.configureButtons(on: alert)
+
+            #expect(alert.buttons.map(\.title) == [String(localized: "OK"), String(localized: "Save Diagnostic Report…")])
+            #expect(saveResponse == .alertSecondButtonReturn)
+        }
+    }
+
+    @Test("Export writes the exact redacted report text")
+    func export() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-move-diagnostic.txt")
+        defer { try? FileManager.default.removeItem(at: url) }
+        let report = MoveFailureDiagnosticReport(
+            text: "user=<user> network=<wifi-network>\n",
+            suggestedFileName: url.lastPathComponent
+        )
+
+        try report.write(to: url)
+
+        #expect(try String(contentsOf: url, encoding: .utf8) == report.text)
+    }
+}

--- a/ThawTests/Shared/DiagnosticLoggerFileTests.swift
+++ b/ThawTests/Shared/DiagnosticLoggerFileTests.swift
@@ -166,6 +166,59 @@ struct DiagnosticLoggerFileTests {
         }
     }
 
+    @Test("A tail snapshot waits for pending writes")
+    func tailSnapshotIncludesPendingWrites() async throws {
+        try await withTemporaryLogDirectory { tmp in
+            let file = tmp.appendingPathComponent("thaw.log")
+            let marker = "snapshot-marker-\(UUID().uuidString)"
+            DiagnosticLogger.shared.attachToFile(at: file)
+
+            DiagnosticLogger.shared.log(level: .error, category: "FileTests", message: marker)
+            let snapshot = await DiagnosticLogger.shared.tailSnapshot(maxBytes: 64 * 1024)
+
+            #expect(snapshot?.fileURL == file)
+            #expect(snapshot?.text.contains("[ERROR] [FileTests] \(marker)") == true)
+        }
+    }
+
+    @Test("A tail snapshot reads only the bounded newest window")
+    func tailSnapshotIsBounded() async throws {
+        try await withTemporaryLogDirectory { tmp in
+            let file = tmp.appendingPathComponent("thaw.log")
+            DiagnosticLogger.shared.attachToFile(at: file)
+            let oldMarker = "old-marker-\(UUID().uuidString)"
+            let newestMarker = "newest-marker-\(UUID().uuidString)"
+            DiagnosticLogger.shared.log(
+                level: .debug,
+                category: "FileTests",
+                message: oldMarker + String(repeating: "x", count: 16 * 1024)
+            )
+            DiagnosticLogger.shared.log(level: .debug, category: "FileTests", message: newestMarker)
+
+            let snapshot = await DiagnosticLogger.shared.tailSnapshot(maxBytes: 1024)
+
+            #expect(snapshot?.text.utf8.count ?? .max <= 1024)
+            #expect(snapshot?.text.contains(newestMarker) == true)
+            #expect(snapshot?.text.contains(oldMarker) == false)
+        }
+    }
+
+    @Test("Tail decoding tolerates an incomplete UTF-8 scalar")
+    func tailSnapshotToleratesPartialUTF8() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(UUID().uuidString)-partial-utf8.log")
+        defer { try? FileManager.default.removeItem(at: file) }
+        var bytes = Data("complete line\ntruncated value ".utf8)
+        bytes.append(contentsOf: [0xF0, 0x9F, 0x92])
+        try bytes.write(to: file)
+
+        let text = try DiagnosticLogger.readTail(from: file, maxBytes: bytes.count)
+
+        #expect(text.contains("complete line"))
+        #expect(text.contains("truncated value"))
+        #expect(text.contains("\u{FFFD}"))
+    }
+
     @Test("A message logged while disabled is dropped rather than buffered")
     func messagesLoggedWhileDisabledAreDropped() async throws {
         try await withTemporaryLogDirectory { tmp in

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -72,6 +72,7 @@ $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarScrollView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/MenuBarLayoutEditorPanel.swift
+$(SRCROOT)/Thaw/MenuBar/LayoutBar/MoveFailureDiagnosticReport.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/NotchIndicatorOverlay.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/AXIdentityCatalog.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/AXItemActivator.swift


### PR DESCRIPTION
# Summary

Adds a redacted move-failure report and makes it available from definitive Layout Bar failure alerts through a save action. The report captures the failed move, cached and live menu-bar layouts, display/notch geometry, relevant settings, installed-app and item identities, saved order, and a bounded excerpt of movement-related logs.

The diagnostic logger now owns an asynchronous tail-snapshot API. A snapshot is serialized behind already accepted writes, reads no more than the newest 2 MiB off the caller's executor, and safely decodes a partial UTF-8 scalar that another process may expose while appending. The report awaits that snapshot and retains no more than the newest 800 lines from an explicit movement-category allowlist.

The alert and report both disclose that installed-app identities, menu-item titles and status text, and display/menu-bar geometry are intentionally retained and may be sensitive. Other recognized sensitive values pass through the redactor before any report is written, and the user is asked to review the result before sharing it.

**Scope:** This PR adds the report model, the logger tail API, save/reveal presentation, three existing failure-alert integrations, source-localization entries, and focused tests. It changes 7 files with 764 insertions and 5 deletions. It does not change movement decisions, cache behavior, or the underlying macOS movement mechanism. This may be suitable for 2.2.

Dependency: #993 must be merged first or used as this PR's base.

## Linked issue (required)

Closes: N/A

Related: #905, #923

## PR Type

- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [x] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Definitive Layout Bar move failures offer **Save Diagnostic Report…** alongside the existing acknowledgement action.
- When a parent window is available, failure alerts, save panels, and write-error alerts use sheets instead of holding the main actor in an app-modal alert loop.
- The existing primary alert button is retained as **OK**, and exactly one save button is added with the response value derived from its actual button position.
- The report records the failure, current cached and live menu-bar layouts, display/notch geometry, relevant settings, saved order, and the installed-app and item identities needed to investigate the move.
- The logger's asynchronous snapshot waits behind pending writes on its serial file-I/O queue, so a failure line already accepted by the logger is available before the report reads the file.
- Only a bounded 2 MiB tail is read off the caller's executor. A leading partial line is discarded, and partial UTF-8 at the end is decoded safely.
- The report keeps at most the newest 800 lines from an explicit set of movement-related log categories.
- Before a file is written, recognized usernames and full names, home paths, network and connected-device names, email, IP and MAC addresses, trigger-like names and values, and precise location coordinates are redacted.
- The disclosure explicitly says that installed-app identities, menu-item titles and status text, and display/menu-bar geometry remain in the report and may be sensitive.
- A successful save reveals the report in Finder. Write failures remain attached to the parent window when one is available.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/DiagnosticRedactorTests -only-testing:ThawTests/DiagnosticLoggerFileTests -only-testing:ThawTests/MoveFailureDiagnosticReportTests`

The final-stack run passed all three selected suites (32 tests total: 7 redactor, 19 logger-file, and 6 report tests). A separate macOS `xcodebuild build` passed. SwiftFormat was run against every changed Swift file; strict SwiftLint reported 0 violations; localization JSON validation, the generated SwiftLint input-list comparison, and `git diff --check` all passed.

## Known limitations / follow-ups

- Automated redaction cannot guarantee that every sensitive value is removed; the dialog and report both tell users to review the file before sharing it.
- The 2 MiB tail deliberately omits older log data, and when diagnostic logging is disabled the most recent file may predate the failure.
- Live-window behavior still depends on the same macOS private movement mechanisms; this PR improves diagnosis and presentation but does not change the mover.
- This stacked PR should remain based on #993 until that dependency merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or interactive save-dialog run was performed for this PR; verification was through the focused automated tests, build, formatting, lint, localization, and diff checks above.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 2 of 12  
**Git base:** #993  
**Functional dependencies:** #993.
