### PR TITLE
fix(menubar): bound persisted item identity seeds

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/SourcePIDSeedStore.swift
+++ b/Thaw/MenuBar/MenuBarItems/SourcePIDSeedStore.swift
@@ -1,0 +1,377 @@
+//
+//  SourcePIDSeedStore.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Cocoa
+
+/// One exact launch of a process.
+///
+/// A PID alone is not an identity: macOS reuses it after a process exits and
+/// across boots. Pairing it with `NSRunningApplication.launchDate` lets a
+/// persisted menu-bar attribution distinguish the process that originally
+/// owned the item from a later process that received the same numeric PID.
+nonisolated struct ProcessGeneration: Codable, Equatable, Hashable {
+    let pid: pid_t
+    let launchDate: Date
+}
+
+/// The current identity and exact generation of a running process.
+nonisolated struct SourceProcessIdentity: Equatable {
+    let generation: ProcessGeneration
+    let bundleIdentifier: String?
+    let processName: String?
+}
+
+/// Stable-enough evidence that a numeric window ID still describes the same
+/// hosted status-item window.
+///
+/// Window IDs are recycled. Process generations prevent reuse across a Control
+/// Center restart, while this fingerprint rejects reuse within one host launch.
+/// Horizontal position is deliberately excluded because Thaw moves items and
+/// recreating its dividers can shift the whole bar. The menu-bar lane, size,
+/// title, owner name, and layer are expected to survive a Thaw-only relaunch.
+nonisolated struct SourcePIDWindowFingerprint: Codable, Equatable {
+    private static let pointsPerUnit: CGFloat = 8
+
+    let title: String?
+    let ownerName: String?
+    let layer: Int
+    let minYUnits: Int
+    let widthUnits: Int
+    let heightUnits: Int
+
+    init(window: WindowInfo) {
+        self.title = window.title
+        self.ownerName = window.ownerName
+        self.layer = window.layer
+        self.minYUnits = Self.units(window.bounds.minY)
+        self.widthUnits = Self.units(window.bounds.width)
+        self.heightUnits = Self.units(window.bounds.height)
+    }
+
+    private static func units(_ value: CGFloat) -> Int {
+        Int((value * pointsPerUnit).rounded())
+    }
+}
+
+/// A source-process attribution remembered for a menu bar window.
+///
+/// On macOS 26, Control Center owns hosted item windows and Thaw resolves the
+/// process behind each one through Accessibility. An item window can outlive a
+/// Thaw process, so a confirmed attribution can bridge the next launch while
+/// that resolver warms up. A seed is accepted only while the host, window
+/// fingerprint, source process, and bounded observation period still match,
+/// and it never replaces a fresh resolution.
+nonisolated struct SourcePIDSeed: Codable, Equatable {
+    let windowID: CGWindowID
+    let windowOwnerGeneration: ProcessGeneration
+    let windowFingerprint: SourcePIDWindowFingerprint
+    let sourceGeneration: ProcessGeneration
+    let bundleIdentifier: String?
+    let processName: String?
+    let capturedAt: Date
+
+    var pid: pid_t {
+        sourceGeneration.pid
+    }
+
+    /// Whether two records identify the same observed source/window lifetime.
+    /// Capture time is freshness metadata, not part of the incarnation.
+    func describesSameIncarnation(as other: SourcePIDSeed) -> Bool {
+        windowID == other.windowID &&
+            windowOwnerGeneration == other.windowOwnerGeneration &&
+            windowFingerprint == other.windowFingerprint &&
+            sourceGeneration == other.sourceGeneration &&
+            bundleIdentifier == other.bundleIdentifier &&
+            processName == other.processName
+    }
+}
+
+nonisolated enum SourcePIDSeedStore {
+    static let defaultsKey = "MenuBarItemManager.sourcePIDSeeds"
+
+    /// A seed is only a short cold-start bridge. Keeping it bounded prevents a
+    /// long-lived source process and Control Center from making a recycled,
+    /// same-shaped window ID look current indefinitely.
+    static let maximumSeedAge: TimeInterval = 5 * 60
+
+    /// Avoid rewriting defaults on every cache pass while still refreshing a
+    /// continuously confirmed incarnation before its cold-start bridge ages
+    /// out. This is intentionally well below ``maximumSeedAge``.
+    static let seedRefreshInterval: TimeInterval = 60
+
+    /// Selects the exact newest host when launch handoff briefly exposes more
+    /// than one Control Center process. `runningApplications` has no ordering
+    /// contract, so using its first entry can select the process being retired.
+    static func newestGeneration(in generations: [ProcessGeneration]) -> ProcessGeneration? {
+        generations.max { lhs, rhs in
+            if lhs.launchDate == rhs.launchDate {
+                return lhs.pid < rhs.pid
+            }
+            return lhs.launchDate < rhs.launchDate
+        }
+    }
+
+    static func currentControlCenterGeneration() -> ProcessGeneration? {
+        let applications = NSRunningApplication.runningApplications(
+            withBundleIdentifier: MenuBarItemTag.Namespace.controlCenter.description
+        )
+        return newestGeneration(in: applications.compactMap { application in
+            guard !application.isTerminated, let launchDate = application.launchDate else { return nil }
+            return ProcessGeneration(
+                pid: application.processIdentifier,
+                launchDate: launchDate
+            )
+        })
+    }
+
+    /// Whether the current source process is the exact launch named by a seed.
+    private static func sourceIsTrustworthy(
+        _ seed: SourcePIDSeed,
+        liveIdentity: SourceProcessIdentity?
+    ) -> Bool {
+        guard
+            let liveIdentity,
+            liveIdentity.generation == seed.sourceGeneration
+        else { return false }
+        if let bundleIdentifier = seed.bundleIdentifier {
+            return liveIdentity.bundleIdentifier == bundleIdentifier
+        }
+        guard let processName = seed.processName, !processName.isEmpty else { return false }
+        return liveIdentity.bundleIdentifier == nil && liveIdentity.processName == processName
+    }
+
+    /// Whether a seed still names this exact, recent hosted window and source
+    /// process under the currently selected Control Center generation.
+    static func isTrustworthy(
+        _ seed: SourcePIDSeed,
+        for window: WindowInfo,
+        currentControlCenterGeneration: ProcessGeneration,
+        now: Date = .now,
+        maximumAge: TimeInterval = maximumSeedAge,
+        liveIdentity: (pid_t) -> SourceProcessIdentity?
+    ) -> Bool {
+        let age = now.timeIntervalSince(seed.capturedAt)
+        guard age >= 0, age <= maximumAge else { return false }
+
+        let ownerIdentity = liveIdentity(window.ownerPID)
+        guard
+            seed.windowID == window.windowID,
+            seed.windowOwnerGeneration == currentControlCenterGeneration,
+            seed.windowOwnerGeneration.pid == window.ownerPID,
+            ownerIdentity?.generation == seed.windowOwnerGeneration,
+            ownerIdentity?.bundleIdentifier == MenuBarItemTag.Namespace.controlCenter.description,
+            seed.windowFingerprint == SourcePIDWindowFingerprint(window: window)
+        else { return false }
+        return sourceIsTrustworthy(seed, liveIdentity: liveIdentity(seed.pid))
+    }
+
+    /// Creates one useful seed per freshly resolved, non-control item window.
+    static func seeds(
+        from items: [MenuBarItem],
+        excluding excludedWindowIDs: Set<CGWindowID> = [],
+        windowsByID: [CGWindowID: WindowInfo],
+        currentControlCenterGeneration: ProcessGeneration,
+        capturedAt: Date = .now,
+        identity: (pid_t) -> SourceProcessIdentity?
+    ) -> [SourcePIDSeed] {
+        var seen = Set<CGWindowID>()
+        var attemptedPIDs = Set<pid_t>()
+        var identities = [pid_t: SourceProcessIdentity]()
+
+        func cachedIdentity(for pid: pid_t) -> SourceProcessIdentity? {
+            if let cached = identities[pid] {
+                return cached
+            }
+            guard attemptedPIDs.insert(pid).inserted, let resolved = identity(pid) else {
+                return nil
+            }
+            identities[pid] = resolved
+            return resolved
+        }
+
+        return items.compactMap { item in
+            guard
+                !item.isControlItem,
+                !excludedWindowIDs.contains(item.windowID),
+                let window = windowsByID[item.windowID],
+                let pid = item.sourcePID,
+                seen.insert(item.windowID).inserted,
+                let sourceIdentity = cachedIdentity(for: pid),
+                let ownerIdentity = cachedIdentity(for: item.ownerPID),
+                ownerIdentity.generation == currentControlCenterGeneration,
+                ownerIdentity.bundleIdentifier == MenuBarItemTag.Namespace.controlCenter.description,
+                sourceIdentity.bundleIdentifier != nil || sourceIdentity.processName?.isEmpty == false
+            else { return nil }
+
+            return SourcePIDSeed(
+                windowID: item.windowID,
+                windowOwnerGeneration: ownerIdentity.generation,
+                windowFingerprint: SourcePIDWindowFingerprint(window: window),
+                sourceGeneration: sourceIdentity.generation,
+                bundleIdentifier: sourceIdentity.bundleIdentifier,
+                processName: sourceIdentity.processName,
+                capturedAt: capturedAt
+            )
+        }
+        .sorted { $0.windowID < $1.windowID }
+    }
+
+    /// Restores only unresolved entries whose current host, window
+    /// fingerprint, and source process match a recent seed exactly.
+    ///
+    /// - Returns: The seed used for each restored window.
+    static func apply(
+        seeds: [CGWindowID: SourcePIDSeed],
+        to pids: inout [pid_t?],
+        windows: [WindowInfo],
+        currentControlCenterGeneration: ProcessGeneration,
+        now: Date = .now,
+        maximumAge: TimeInterval = maximumSeedAge,
+        liveIdentity: (pid_t) -> SourceProcessIdentity?
+    ) -> [CGWindowID: SourcePIDSeed] {
+        var applied = [CGWindowID: SourcePIDSeed]()
+        var attemptedPIDs = Set<pid_t>()
+        var identities = [pid_t: SourceProcessIdentity]()
+
+        func cachedIdentity(for pid: pid_t) -> SourceProcessIdentity? {
+            if let cached = identities[pid] {
+                return cached
+            }
+            guard attemptedPIDs.insert(pid).inserted, let resolved = liveIdentity(pid) else {
+                return nil
+            }
+            identities[pid] = resolved
+            return resolved
+        }
+
+        for (index, window) in windows.enumerated() where index < pids.count && pids[index] == nil {
+            guard
+                let seed = seeds[window.windowID],
+                isTrustworthy(
+                    seed,
+                    for: window,
+                    currentControlCenterGeneration: currentControlCenterGeneration,
+                    now: now,
+                    maximumAge: maximumAge,
+                    liveIdentity: cachedIdentity(for:)
+                )
+            else { continue }
+            pids[index] = seed.pid
+            applied[window.windowID] = seed
+        }
+        return applied
+    }
+
+    /// Chooses the current resolver result unless a generation-, window-, and
+    /// age-validated in-session baseline proves that result is a transient
+    /// miss or stale alternate match.
+    static func reconciledSourcePID(
+        currentPID: pid_t?,
+        previous: SourcePIDSeed?,
+        for window: WindowInfo,
+        currentControlCenterGeneration: ProcessGeneration,
+        now: Date = .now,
+        liveIdentity: (pid_t) -> SourceProcessIdentity?
+    ) -> pid_t? {
+        guard
+            let previous,
+            currentPID != previous.pid,
+            isTrustworthy(
+                previous,
+                for: window,
+                currentControlCenterGeneration: currentControlCenterGeneration,
+                now: now,
+                liveIdentity: liveIdentity
+            )
+        else { return currentPID }
+        return previous.pid
+    }
+
+    /// Carries a confirmed in-session baseline across a provisional resolver
+    /// miss without promoting the persisted seed into a new baseline.
+    /// Vanished, invalid, or different incarnations are omitted.
+    static func mergedConfirmedBaselines(
+        previous: [CGWindowID: SourcePIDSeed],
+        fresh: [SourcePIDSeed],
+        provisional: [CGWindowID: SourcePIDSeed]
+    ) -> [CGWindowID: SourcePIDSeed] {
+        var merged = Dictionary(
+            uniqueKeysWithValues: fresh.map { ($0.windowID, $0) }
+        )
+        for (windowID, provisionalSeed) in provisional where merged[windowID] == nil {
+            guard
+                let previousSeed = previous[windowID],
+                previousSeed.describesSameIncarnation(as: provisionalSeed)
+            else { continue }
+            merged[windowID] = previousSeed
+        }
+        return merged
+    }
+
+    /// Persists fresh confirmations alongside only the provisional entries
+    /// independently validated in this enumeration. Fresh evidence wins.
+    static func mergedPersistedSeeds(
+        fresh: [SourcePIDSeed],
+        provisional: [CGWindowID: SourcePIDSeed]
+    ) -> [SourcePIDSeed] {
+        var merged = provisional
+        for seed in fresh {
+            merged[seed.windowID] = seed
+        }
+        return merged.values.sorted { $0.windowID < $1.windowID }
+    }
+
+    /// Reuses a recent capture timestamp for an unchanged incarnation so the
+    /// cache does not write identical seed evidence to defaults every pass.
+    /// The timestamp is refreshed periodically, preserving a bounded but
+    /// continuously renewable bridge while live resolution keeps confirming
+    /// the same item.
+    static func coalescingCaptureTimes(
+        proposed: [SourcePIDSeed],
+        previous: [CGWindowID: SourcePIDSeed],
+        now: Date = .now,
+        refreshInterval: TimeInterval = seedRefreshInterval
+    ) -> [SourcePIDSeed] {
+        proposed.map { seed in
+            guard
+                let oldSeed = previous[seed.windowID],
+                seed.describesSameIncarnation(as: oldSeed)
+            else { return seed }
+
+            let age = now.timeIntervalSince(oldSeed.capturedAt)
+            return age >= 0 && age < refreshInterval ? oldSeed : seed
+        }
+        .sorted { $0.windowID < $1.windowID }
+    }
+
+    static func liveIdentity(of pid: pid_t) -> SourceProcessIdentity? {
+        guard
+            let app = NSRunningApplication(processIdentifier: pid),
+            !app.isTerminated,
+            let launchDate = app.launchDate
+        else { return nil }
+        return SourceProcessIdentity(
+            generation: ProcessGeneration(pid: pid, launchDate: launchDate),
+            bundleIdentifier: app.bundleIdentifier,
+            processName: app.localizedName
+        )
+    }
+
+    static func load(from defaults: UserDefaults) -> [CGWindowID: SourcePIDSeed] {
+        guard
+            let data = defaults.data(forKey: defaultsKey),
+            let seeds = try? JSONDecoder().decode([SourcePIDSeed].self, from: data)
+        else { return [:] }
+        return Dictionary(seeds.map { ($0.windowID, $0) }, uniquingKeysWith: { _, last in last })
+    }
+
+    static func save(_ seeds: [SourcePIDSeed], to defaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(seeds) else { return }
+        defaults.set(data, forKey: defaultsKey)
+    }
+}

--- a/ThawTests/MenuBar/Items/SourcePIDSeedStoreTests.swift
+++ b/ThawTests/MenuBar/Items/SourcePIDSeedStoreTests.swift
@@ -1,0 +1,479 @@
+//
+//  SourcePIDSeedStoreTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Thaw
+
+@MainActor
+@Suite("Source PID identity continuity")
+struct SourcePIDSeedStoreTests {
+    private struct LegacySeed: Codable {
+        let windowID: CGWindowID
+        let windowOwnerGeneration: ProcessGeneration
+        let sourceGeneration: ProcessGeneration
+        let bundleIdentifier: String?
+        let processName: String?
+    }
+
+    private let now = Date(timeIntervalSince1970: 1_700_000_400)
+    private let sourceGeneration = ProcessGeneration(
+        pid: 54484,
+        launchDate: Date(timeIntervalSince1970: 1_700_000_100)
+    )
+    private let alternateGeneration = ProcessGeneration(
+        pid: 8086,
+        launchDate: Date(timeIntervalSince1970: 1_700_000_200)
+    )
+    private let ownerGeneration = ProcessGeneration(
+        pid: 700,
+        launchDate: Date(timeIntervalSince1970: 1_700_000_000)
+    )
+
+    private func window(
+        id: CGWindowID,
+        ownerPID: pid_t = 700,
+        bounds: CGRect = CGRect(x: 100, y: 0, width: 24, height: 22),
+        title: String? = "Item-0",
+        ownerName: String? = "Control Center",
+        layer: Int = Int(CGWindowLevelForKey(.statusWindow))
+    ) -> WindowInfo {
+        WindowInfo(
+            windowID: id,
+            ownerPID: ownerPID,
+            bounds: bounds,
+            layer: layer,
+            title: title,
+            ownerName: ownerName
+        )
+    }
+
+    private func seed(
+        window itemWindow: WindowInfo,
+        sourceGeneration: ProcessGeneration? = nil,
+        bundleIdentifier: String? = "com.example.IconSwitcher",
+        processName: String? = "Icon Switcher",
+        capturedAt: Date? = nil
+    ) -> SourcePIDSeed {
+        SourcePIDSeed(
+            windowID: itemWindow.windowID,
+            windowOwnerGeneration: ownerGeneration,
+            windowFingerprint: SourcePIDWindowFingerprint(window: itemWindow),
+            sourceGeneration: sourceGeneration ?? self.sourceGeneration,
+            bundleIdentifier: bundleIdentifier,
+            processName: processName,
+            capturedAt: capturedAt ?? now.addingTimeInterval(-30)
+        )
+    }
+
+    private var bundledWindow: WindowInfo {
+        window(id: 2314)
+    }
+
+    private var bundled: SourcePIDSeed {
+        seed(window: bundledWindow)
+    }
+
+    private var bundlelessWindow: WindowInfo {
+        window(id: 5467, title: "Bundleless")
+    }
+
+    private var bundleless: SourcePIDSeed {
+        seed(
+            window: bundlelessWindow,
+            sourceGeneration: ProcessGeneration(
+                pid: 12460,
+                launchDate: Date(timeIntervalSince1970: 1_700_000_200)
+            ),
+            bundleIdentifier: nil,
+            processName: "IconSwitcher"
+        )
+    }
+
+    private func identity(
+        generation: ProcessGeneration,
+        bundleIdentifier: String?,
+        processName: String?
+    ) -> SourceProcessIdentity {
+        SourceProcessIdentity(
+            generation: generation,
+            bundleIdentifier: bundleIdentifier,
+            processName: processName
+        )
+    }
+
+    private func ownerIdentity(
+        generation: ProcessGeneration? = nil
+    ) -> SourceProcessIdentity {
+        identity(
+            generation: generation ?? ownerGeneration,
+            bundleIdentifier: "com.apple.controlcenter",
+            processName: "Control Center"
+        )
+    }
+
+    private func bundledSourceIdentity(
+        generation: ProcessGeneration? = nil,
+        bundleIdentifier: String? = "com.example.IconSwitcher"
+    ) -> SourceProcessIdentity {
+        identity(
+            generation: generation ?? sourceGeneration,
+            bundleIdentifier: bundleIdentifier,
+            processName: "Icon Switcher"
+        )
+    }
+
+    @Test("A bundled seed requires the exact source launch, bundle, host, and window")
+    func bundledSeedRequiresExactIdentity() {
+        let identities = [
+            ownerGeneration.pid: ownerIdentity(),
+            sourceGeneration.pid: bundledSourceIdentity(),
+        ]
+        #expect(SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: bundledWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        ))
+
+        let recycledSource = bundledSourceIdentity(
+            generation: ProcessGeneration(
+                pid: sourceGeneration.pid,
+                launchDate: sourceGeneration.launchDate.addingTimeInterval(30)
+            )
+        )
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: bundledWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { pid in
+                [ownerGeneration.pid: ownerIdentity(), sourceGeneration.pid: recycledSource][pid]
+            }
+        ))
+
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: bundledWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { pid in
+                [
+                    ownerGeneration.pid: ownerIdentity(),
+                    sourceGeneration.pid: bundledSourceIdentity(bundleIdentifier: "com.example.Other"),
+                ][pid]
+            }
+        ))
+    }
+
+    @Test("A bundle-less seed requires the same process name and exact launch")
+    func bundlelessSeedRequiresMatchingName() {
+        let matchingSource = identity(
+            generation: bundleless.sourceGeneration,
+            bundleIdentifier: nil,
+            processName: "IconSwitcher"
+        )
+        #expect(SourcePIDSeedStore.isTrustworthy(
+            bundleless,
+            for: bundlelessWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { pid in
+                [ownerGeneration.pid: ownerIdentity(), bundleless.pid: matchingSource][pid]
+            }
+        ))
+
+        let newlyBundledSource = identity(
+            generation: bundleless.sourceGeneration,
+            bundleIdentifier: "com.example.IconSwitcher",
+            processName: "IconSwitcher"
+        )
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            bundleless,
+            for: bundlelessWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { pid in
+                [ownerGeneration.pid: ownerIdentity(), bundleless.pid: newlyBundledSource][pid]
+            }
+        ))
+    }
+
+    @Test("The newest of two live Control Center generations is required")
+    func newestControlCenterGenerationRejectsRetiringHost() throws {
+        let newestOwner = ProcessGeneration(
+            pid: 701,
+            launchDate: ownerGeneration.launchDate.addingTimeInterval(20)
+        )
+        let selected = try #require(SourcePIDSeedStore.newestGeneration(in: [
+            newestOwner,
+            ownerGeneration,
+        ]))
+        #expect(selected == newestOwner)
+
+        let identities = [
+            ownerGeneration.pid: ownerIdentity(),
+            newestOwner.pid: ownerIdentity(generation: newestOwner),
+            sourceGeneration.pid: bundledSourceIdentity(),
+        ]
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: bundledWindow,
+            currentControlCenterGeneration: selected,
+            now: now,
+            liveIdentity: { identities[$0] }
+        ))
+    }
+
+    @Test("Seeds fill only unresolved windows with exact process generations")
+    func applyingSeedsPreservesFreshResultsAndRejectsRecycledPIDs() {
+        let recycledWindow = window(id: 71, title: "Recycled")
+        let recycledGeneration = ProcessGeneration(
+            pid: 12460,
+            launchDate: Date(timeIntervalSince1970: 1_600_000_000)
+        )
+        let recycled = seed(
+            window: recycledWindow,
+            sourceGeneration: recycledGeneration,
+            bundleIdentifier: "com.example.Old",
+            processName: "Old"
+        )
+        let liveRecycledGeneration = ProcessGeneration(
+            pid: recycledGeneration.pid,
+            launchDate: Date(timeIntervalSince1970: 1_700_000_300)
+        )
+        let identities: [pid_t: SourceProcessIdentity] = [
+            ownerGeneration.pid: ownerIdentity(),
+            sourceGeneration.pid: bundledSourceIdentity(),
+            recycledGeneration.pid: identity(
+                generation: liveRecycledGeneration,
+                bundleIdentifier: "com.example.Old",
+                processName: "Old"
+            ),
+        ]
+        var pids: [pid_t?] = [nil, 8086, nil]
+
+        let applied = SourcePIDSeedStore.apply(
+            seeds: [bundled.windowID: bundled, recycled.windowID: recycled],
+            to: &pids,
+            windows: [bundledWindow, window(id: 2556), recycledWindow],
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        )
+
+        #expect(Set(applied.keys) == [bundled.windowID])
+        #expect(pids == [sourceGeneration.pid, 8086, nil])
+    }
+
+    @Test("Confirmed, seeded miss, then stale alternate keeps the confirmed baseline")
+    func threeCycleResolverMissDoesNotLoseConfirmedBaseline() throws {
+        let identities = [
+            ownerGeneration.pid: ownerIdentity(),
+            sourceGeneration.pid: bundledSourceIdentity(),
+        ]
+
+        let cycleOne = SourcePIDSeedStore.mergedConfirmedBaselines(
+            previous: [:],
+            fresh: [bundled],
+            provisional: [:]
+        )
+        #expect(cycleOne[bundled.windowID] == bundled)
+
+        var missedPID: [pid_t?] = [nil]
+        let applied = SourcePIDSeedStore.apply(
+            seeds: cycleOne,
+            to: &missedPID,
+            windows: [bundledWindow],
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        )
+        let cycleTwo = SourcePIDSeedStore.mergedConfirmedBaselines(
+            previous: cycleOne,
+            fresh: [],
+            provisional: applied
+        )
+        #expect(cycleTwo == cycleOne)
+
+        let baseline = try #require(cycleTwo[bundled.windowID])
+        let reconciledPID = SourcePIDSeedStore.reconciledSourcePID(
+            currentPID: alternateGeneration.pid,
+            previous: baseline,
+            for: bundledWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        )
+        #expect(reconciledPID == sourceGeneration.pid)
+    }
+
+    @Test("Same-host reuse of a window ID needs bounded fingerprint continuity")
+    func sameHostWindowIDReuseIsRejected() {
+        let identities = [
+            ownerGeneration.pid: ownerIdentity(),
+            sourceGeneration.pid: bundledSourceIdentity(),
+        ]
+        let reusedWindow = window(
+            id: bundled.windowID,
+            bounds: CGRect(x: 100, y: 0, width: 36, height: 22),
+            title: "Other Item"
+        )
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: reusedWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        ))
+
+        let expired = seed(
+            window: bundledWindow,
+            capturedAt: now.addingTimeInterval(-SourcePIDSeedStore.maximumSeedAge - 1)
+        )
+        #expect(!SourcePIDSeedStore.isTrustworthy(
+            expired,
+            for: bundledWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        ))
+
+        let movedWindow = window(
+            id: bundled.windowID,
+            bounds: CGRect(x: -4000, y: 0, width: 24, height: 22)
+        )
+        #expect(SourcePIDSeedStore.isTrustworthy(
+            bundled,
+            for: movedWindow,
+            currentControlCenterGeneration: ownerGeneration,
+            now: now,
+            liveIdentity: { identities[$0] }
+        ))
+    }
+
+    @Test("Only resolved non-control windows on the selected host produce seeds")
+    func seedExtractionFiltersUnsafeEntries() {
+        let items = [
+            MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.example.IconSwitcher", title: "Item-0", windowID: 2314),
+                windowID: 2314,
+                sourcePID: sourceGeneration.pid,
+                ownerPID: ownerGeneration.pid
+            ),
+            MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.example.IconSwitcher", title: "Item-0", windowID: 2314),
+                windowID: 2314,
+                sourcePID: sourceGeneration.pid,
+                ownerPID: ownerGeneration.pid
+            ),
+            MenuBarItem.fixture(
+                tag: .hiddenControlItem,
+                windowID: 5718,
+                sourcePID: 17950,
+                ownerPID: ownerGeneration.pid
+            ),
+            MenuBarItem.fixture(
+                tag: .appItem(bundleID: "com.example.Unknown", title: "Item-0", windowID: 99),
+                windowID: 99,
+                sourcePID: 999,
+                ownerPID: ownerGeneration.pid
+            ),
+        ]
+        let identities = [
+            ownerGeneration.pid: ownerIdentity(),
+            sourceGeneration.pid: bundledSourceIdentity(),
+        ]
+
+        let seeds = SourcePIDSeedStore.seeds(
+            from: items,
+            windowsByID: [bundled.windowID: bundledWindow],
+            currentControlCenterGeneration: ownerGeneration,
+            capturedAt: bundled.capturedAt,
+            identity: { identities[$0] }
+        )
+
+        #expect(seeds == [bundled])
+    }
+
+    @Test("Fresh confirmations persist beside independently retained provisional entries")
+    func mixedProvisionalAndFreshPersistence() {
+        let freshWindow = window(id: 9001, title: "Fresh")
+        let fresh = seed(
+            window: freshWindow,
+            sourceGeneration: alternateGeneration,
+            bundleIdentifier: "com.example.Fresh",
+            processName: "Fresh"
+        )
+        let vanished = seed(window: window(id: 7777, title: "Vanished"))
+        let previous = [
+            bundled.windowID: bundled,
+            vanished.windowID: vanished,
+        ]
+
+        let confirmed = SourcePIDSeedStore.mergedConfirmedBaselines(
+            previous: previous,
+            fresh: [fresh],
+            provisional: [bundled.windowID: bundled]
+        )
+        #expect(confirmed == [bundled.windowID: bundled, fresh.windowID: fresh])
+
+        let persisted = SourcePIDSeedStore.mergedPersistedSeeds(
+            fresh: [fresh],
+            provisional: [bundled.windowID: bundled]
+        )
+        #expect(persisted == [bundled, fresh])
+    }
+
+    @Test("Unchanged seeds coalesce writes but periodically refresh freshness")
+    func captureTimeCoalescingAvoidsPerCycleWrites() {
+        let recent = seed(window: bundledWindow, capturedAt: now.addingTimeInterval(-30))
+        let proposed = seed(window: bundledWindow, capturedAt: now)
+
+        #expect(SourcePIDSeedStore.coalescingCaptureTimes(
+            proposed: [proposed],
+            previous: [recent.windowID: recent],
+            now: now
+        ) == [recent])
+
+        let old = seed(window: bundledWindow, capturedAt: now.addingTimeInterval(-61))
+        #expect(SourcePIDSeedStore.coalescingCaptureTimes(
+            proposed: [proposed],
+            previous: [old.windowID: old],
+            now: now
+        ) == [proposed])
+    }
+
+    @Test("Seeds round-trip while corrupt and pre-fingerprint defaults fail closed")
+    func persistenceRoundTripAndMigration() throws {
+        let suiteName = "com.stonerl.Thaw.tests.SourcePIDSeeds.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        SourcePIDSeedStore.save([bundled, bundleless], to: defaults)
+        #expect(SourcePIDSeedStore.load(from: defaults) == [
+            bundled.windowID: bundled,
+            bundleless.windowID: bundleless,
+        ])
+
+        let legacy = LegacySeed(
+            windowID: bundled.windowID,
+            windowOwnerGeneration: ownerGeneration,
+            sourceGeneration: sourceGeneration,
+            bundleIdentifier: bundled.bundleIdentifier,
+            processName: bundled.processName
+        )
+        try defaults.set(JSONEncoder().encode([legacy]), forKey: SourcePIDSeedStore.defaultsKey)
+        #expect(SourcePIDSeedStore.load(from: defaults).isEmpty)
+
+        defaults.set(Data("not json".utf8), forKey: SourcePIDSeedStore.defaultsKey)
+        #expect(SourcePIDSeedStore.load(from: defaults).isEmpty)
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -105,6 +105,7 @@ $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarLiveRefreshPolicy.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarSpacer.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarSpacerManager.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/PendingLedger.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/SourcePIDSeedStore.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/StaleIdentifierLedger.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarManager.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarSection.swift


### PR DESCRIPTION
# Summary

Adds a bounded persistence foundation for source-process identities behind Control Center-hosted menu-bar windows. A remembered attribution now records the exact Control Center and source process generations, a short-lived window fingerprint, source bundle/name corroboration, and its capture time instead of trusting reusable numeric PIDs and window IDs by themselves.

Seeds are accepted only when the current live owner, newest Control Center generation, source generation, identity metadata, fingerprint, and five-minute continuity window all agree. Corrupt data and records written by the older seed schema fail closed. The helpers also distinguish fresh confirmations from provisional restorations, retain only a validated same-incarnation baseline across a resolver miss, and coalesce unchanged defaults writes while periodically refreshing continuously confirmed evidence.

**Scope:** This PR adds the identity-seed model and policy, focused Swift Testing coverage, and the generated SwiftLint input entry. It changes 3 files with 857 insertions. It deliberately does not wire seeds into live enumeration or cache reconciliation; that integration is #996. This may be suitable for 2.2.

Stack dependency: #994 must be merged first or used as this PR's base because the branch series is linear. There is no runtime coupling to the report APIs.

## Linked issue (required)

Closes: N/A

Related: #754, #923

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- A process identity is an exact PID and launch-date generation, preventing a later process that reuses the same numeric PID from inheriting an attribution.
- The newest live Control Center generation is selected deterministically by launch date, with PID as the tie-breaker, rather than relying on application enumeration order during a launch handoff.
- A persisted source attribution is trusted only when its live Control Center owner generation, live source generation, bundle identifier or process name, window fingerprint, and bounded capture age all still match.
- The window fingerprint includes title, owner name, layer, menu-bar lane, width, and height. Horizontal position is intentionally excluded because moving an item changes that coordinate.
- Seeds never overwrite a fresh resolver result; they may fill only an unresolved hosted window.
- A validated confirmed baseline can survive a provisional resolver miss or stale alternate result without promoting the provisional observation into fresh evidence.
- Fresh confirmations are merged alongside independently validated provisional entries, while invalid or vanished provisional entries are omitted.
- Unchanged confirmations reuse their recent capture timestamp to avoid writing defaults on every cache pass, then refresh before the bounded bridge expires.
- Corrupt persisted data and the older pre-generation/pre-fingerprint schema decode to no seeds rather than being accepted with weaker checks.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawIdentityBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/SourcePIDSeedStoreTests`

The isolated foundation commit compiled successfully as part of this command, and all 10 selected `SourcePIDSeedStoreTests` passed. SwiftFormat lint passed for the changed Swift files; the completed identity stack's strict SwiftLint run reported 0 violations across 189 files; the generated SwiftLint input-list comparison and `git diff --check` were clean.

## Known limitations / follow-ups

- This PR supplies the fail-closed policy and persistence helpers but does not change live app behavior until the dependent enumeration/cache integration in #996 is included.
- The five-minute fingerprint bridge cannot mathematically distinguish a same-generation window ID recycled into an otherwise identical title/owner/layer/lane/size tuple. Exact live host and source generations, the bounded age, and the remaining fingerprint fields reduce that case; uncertainty outside those checks is rejected.
- Generation, persistence, and window-reuse behavior is covered with deterministic synthetic process/window snapshots. A unit test cannot reproduce real WindowServer and Accessibility timing during Control Center or app relaunches, so live churn still needs field validation.
- This stacked PR should remain based on #994 until that dependency merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or interactive menu-bar run was performed for this PR; verification was through the focused automated tests, compilation, formatting, lint, generated-file comparison, and diff checks above.

The commit includes a `Signed-off-by` trailer for the project's DCO requirement. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 3 of 12  
**Git base:** #994  
**Functional dependencies:** None at runtime; #994 is the linear Git base.
