### PR TITLE
fix(menubar): reconcile hosted item identities safely

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem+Enumeration.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem+Enumeration.swift
@@ -109,6 +109,19 @@ nonisolated extension MenuBarItem {
         static let activeSpace = ListOption(rawValue: 1 << 1)
     }
 
+    /// One enumeration together with the source-PID values that came from
+    /// persisted seeds instead of the live Accessibility resolver.
+    struct EnumerationSnapshot {
+        let items: [MenuBarItem]
+        let appliedSourcePIDSeeds: [CGWindowID: SourcePIDSeed]
+        let windowsByID: [CGWindowID: WindowInfo]
+        let controlCenterGeneration: ProcessGeneration?
+
+        var seededSourcePIDWindowIDs: Set<CGWindowID> {
+            Set(appliedSourcePIDSeeds.keys)
+        }
+    }
+
     private static let diagLog = DiagLog(category: "MenuBarItem")
 
     /// Creates and returns a list of menu bar items windows for the given display.
@@ -189,7 +202,7 @@ nonisolated extension MenuBarItem {
     @MainActor
     private static func makeItemsWithoutResolvingSourcePID(
         from windows: [WindowInfo]
-    ) -> [MenuBarItem] {
+    ) -> EnumerationSnapshot {
         var items = windows.map { window in
             if let title = window.title, title.hasPrefix("Thaw.ControlItem.") {
                 let ccBundleID = "com.apple.controlcenter"
@@ -211,7 +224,15 @@ nonisolated extension MenuBarItem {
         diagLog.debug(
             "getMenuBarItemsExperimental: created \(items.count) items without sourcePID resolution, \(nilPIDCount) unresolved"
         )
-        return items
+        return EnumerationSnapshot(
+            items: items,
+            appliedSourcePIDSeeds: [:],
+            windowsByID: Dictionary(
+                windows.map { ($0.windowID, $0) },
+                uniquingKeysWith: { first, _ in first }
+            ),
+            controlCenterGeneration: nil
+        )
     }
 
     @available(macOS 26.0, *)
@@ -220,7 +241,7 @@ nonisolated extension MenuBarItem {
         on display: CGDirectDisplayID?,
         option: ListOption,
         resolveSourcePID: Bool
-    ) async -> [MenuBarItem] {
+    ) async -> EnumerationSnapshot {
         let windows = getMenuBarItemWindows(on: display, option: option)
         diagLog.debug("getMenuBarItems: processing \(windows.count) windows for source PID resolution")
 
@@ -265,6 +286,28 @@ nonisolated extension MenuBarItem {
             )
         }
 
+        // A status-item window can survive this app relaunching. Preserve its
+        // last confirmed owner while the Accessibility resolver starts cold,
+        // but never replace a fresh result from the service.
+        let controlCenterGeneration = SourcePIDSeedStore.currentControlCenterGeneration()
+        let appliedSeeds: [CGWindowID: SourcePIDSeed] = if let controlCenterGeneration {
+            SourcePIDSeedStore.apply(
+                seeds: SourcePIDSeedStore.load(from: Defaults.store),
+                to: &pids,
+                windows: windows,
+                currentControlCenterGeneration: controlCenterGeneration,
+                liveIdentity: SourcePIDSeedStore.liveIdentity(of:)
+            )
+        } else {
+            [:]
+        }
+        let seededWindowIDs = Set(appliedSeeds.keys)
+        if !appliedSeeds.isEmpty {
+            diagLog.info(
+                "getMenuBarItems: restored source PIDs for \(appliedSeeds.count) surviving window(s): \(seededWindowIDs.sorted())"
+            )
+        }
+
         var items = windows.enumerated().map { index, window in
             let pid: pid_t? = controlItemIndices.contains(index) ? ownPID : pids[index]
             return MenuBarItem(uncheckedItemWindow: window, sourcePID: pid)
@@ -290,7 +333,7 @@ nonisolated extension MenuBarItem {
         if !unresolvedIndices.isEmpty {
             // Count how many items each PID has been resolved to.
             var resolvedCountByPID = [pid_t: Int]()
-            for item in items where item.sourcePID != nil {
+            for item in items where item.sourcePID != nil && !seededWindowIDs.contains(item.windowID) {
                 if let pid = item.sourcePID {
                     resolvedCountByPID[pid, default: 0] += 1
                 }
@@ -301,7 +344,7 @@ nonisolated extension MenuBarItem {
             // .ambiguous means multiple different PIDs share the title
             // (e.g. two apps both using "Item-0") and propagation is unsafe.
             var titleToPID = [String: ResolvedPID]()
-            for item in items where item.sourcePID != nil {
+            for item in items where item.sourcePID != nil && !seededWindowIDs.contains(item.windowID) {
                 if let title = item.title, let pid = item.sourcePID {
                     if let existing = titleToPID[title] {
                         // Mark as ambiguous if different PIDs share this title.
@@ -343,7 +386,35 @@ nonisolated extension MenuBarItem {
         } else {
             diagLog.debug("getMenuBarItems: created \(items.count) items, all with resolved sourcePID")
         }
-        return items
+        return EnumerationSnapshot(
+            items: items,
+            appliedSourcePIDSeeds: appliedSeeds,
+            windowsByID: Dictionary(
+                windows.map { ($0.windowID, $0) },
+                uniquingKeysWith: { first, _ in first }
+            ),
+            controlCenterGeneration: controlCenterGeneration
+        )
+    }
+
+    /// Creates a menu-bar enumeration while preserving whether each restored
+    /// source PID was confirmed live or supplied by the persisted seed store.
+    @MainActor
+    static func getMenuBarItemsSnapshot(
+        on display: CGDirectDisplayID? = nil,
+        option: ListOption,
+        resolveSourcePID: Bool = true
+    ) async -> EnumerationSnapshot {
+        diagLog.debug(
+            "getMenuBarItems: starting (resolveSourcePID=\(resolveSourcePID))"
+        )
+        let snapshot = await getMenuBarItemsExperimental(
+            on: display,
+            option: option,
+            resolveSourcePID: resolveSourcePID
+        )
+        diagLog.debug("getMenuBarItems: returned \(snapshot.items.count) items")
+        return snapshot
     }
 
     /// Creates and returns a list of menu bar items for the given display.
@@ -359,16 +430,12 @@ nonisolated extension MenuBarItem {
         option: ListOption,
         resolveSourcePID: Bool = true
     ) async -> [MenuBarItem] {
-        diagLog.debug(
-            "getMenuBarItems: starting (resolveSourcePID=\(resolveSourcePID))"
-        )
-        let items = await getMenuBarItemsExperimental(
+        let snapshot = await getMenuBarItemsSnapshot(
             on: display,
             option: option,
             resolveSourcePID: resolveSourcePID
         )
-        diagLog.debug("getMenuBarItems: returned \(items.count) items")
-        return items
+        return snapshot.items
     }
 }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -22,10 +22,10 @@ extension MenuBarItemManager {
         /// of the previous cache.
         private(set) var cachedItemWindowIDs = [CGWindowID]()
 
-        /// A mapping from window identifiers to their resolved source process
-        /// identifiers from the previous cache cycle. Used to detect and correct
-        /// transient sourcePID resolution errors (e.g. stale AX data after moves).
-        private(set) var cachedItemPIDs = [CGWindowID: pid_t]()
+        /// Confirmed window/source incarnations from the previous cache cycle.
+        /// These detect and correct transient source-PID resolution errors
+        /// without trusting a recycled window ID or PID by itself.
+        private(set) var cachedSourcePIDBaselines = [CGWindowID: SourcePIDSeed]()
 
         /// Window identifiers of the system clone windows seen in the most
         /// recent cache cycle. cacheItemsIfNeeded filters these out of its
@@ -40,6 +40,9 @@ extension MenuBarItemManager {
         /// stable — so applySavedLayout's windowID-change gate ignores their
         /// disappearance instead of dispatching a full bulk apply (#736).
         private(set) var cachedControlCenterGenericWindowIDs = Set<CGWindowID>()
+
+        /// Source-PID seeds already written during this app session.
+        private(set) var persistedSourcePIDSeeds: [SourcePIDSeed]?
 
         /// Updates the list of cached menu bar item window identifiers.
         func updateCachedItemWindowIDs(_ itemWindowIDs: [CGWindowID]) {
@@ -56,15 +59,36 @@ extension MenuBarItemManager {
             cachedControlCenterGenericWindowIDs = ids
         }
 
-        /// Updates the mapping from window identifiers to source process identifiers.
-        func updateCachedItemPIDs(_ pids: [CGWindowID: pid_t]) {
-            cachedItemPIDs = pids
+        /// Updates the confirmed window/source incarnations.
+        func updateCachedSourcePIDBaselines(_ baselines: [CGWindowID: SourcePIDSeed]) {
+            cachedSourcePIDBaselines = baselines
+        }
+
+        /// Records a seed snapshot and reports whether it needs persistence.
+        func updatePersistedSourcePIDSeeds(_ seeds: [SourcePIDSeed]) -> Bool {
+            guard seeds != persistedSourcePIDSeeds else { return false }
+            persistedSourcePIDSeeds = seeds
+            return true
+        }
+
+        /// Returns the last persisted snapshot, loading it once per process.
+        /// Priming this cache avoids one redundant defaults write on the first
+        /// successful enumeration after launch.
+        func persistedSourcePIDSeeds(from defaults: UserDefaults) -> [SourcePIDSeed] {
+            if let persistedSourcePIDSeeds {
+                return persistedSourcePIDSeeds
+            }
+            let loaded = SourcePIDSeedStore.load(from: defaults).values.sorted {
+                $0.windowID < $1.windowID
+            }
+            persistedSourcePIDSeeds = loaded
+            return loaded
         }
 
         /// Clears the list of cached menu bar item window identifiers.
         func clearCachedItemWindowIDs() {
             cachedItemWindowIDs.removeAll()
-            cachedItemPIDs.removeAll()
+            cachedSourcePIDBaselines.removeAll()
             // Clear clone IDs alongside the main set so the two don't drift.
             // Leaving stale clone IDs here would let cacheItemsIfNeeded filter
             // a recycled windowID out of its comparison before the recache
@@ -162,7 +186,7 @@ extension MenuBarItemManager {
     /// A pair of control items, taken from a list of menu bar items
     /// during a menu bar item cache operation.
     struct ControlItemPair {
-        nonisolated enum Resolution: Equatable, Sendable {
+        nonisolated enum Resolution: Equatable {
             case identity
             case axFrameCorrelation
         }
@@ -264,6 +288,34 @@ extension MenuBarItemManager {
                 return
             }
 
+            // Duplicate same-title divider windows cannot be disambiguated by
+            // tag or source PID: on Tahoe, Control Center hosts both the stale
+            // and current windows, and enumeration stamps both as this process.
+            // AppKit may expose a synthetic windowNumber that does not fit in a
+            // CGWindowID, so the authoritative-ID paths above are unavailable.
+            // Only current-process AX frames can break the tie; otherwise keep
+            // the last-known-good cache instead of adopting an arbitrary (often
+            // older, lower-numbered) divider.
+            let ambiguousTitles = Self.ambiguousControlItemTitles(in: items)
+            if !ambiguousTitles.isEmpty {
+                if let pair = Self.matchViaAXFrame(items: &items),
+                   !ambiguousTitles.contains(ControlItem.Identifier.alwaysHidden.rawValue) ||
+                   pair.alwaysHidden != nil
+                {
+                    self.hidden = pair.hidden
+                    self.alwaysHidden = pair.alwaysHidden
+                    self.resolution = .axFrameCorrelation
+                    MenuBarItemManager.diagLog.info(
+                        "ControlItemPair: resolved duplicate control-item titles via unambiguous current-process AX frames"
+                    )
+                    return
+                }
+                MenuBarItemManager.diagLog.warning(
+                    "ControlItemPair: refusing ambiguous same-title control windows without an authoritative CG window ID: \(ambiguousTitles.sorted())"
+                )
+                return nil
+            }
+
             // Fallback 1: match by tag (namespace + title).
             if let hidden = items.removeFirst(matching: .hiddenControlItem) {
                 self.hidden = hidden
@@ -310,6 +362,24 @@ extension MenuBarItemManager {
                 "ControlItemPair: unresolved; no strategy identified the hidden control item among \(items.count) item(s)"
             )
             return nil
+        }
+
+        /// Control-item titles that occur more than once in one enumeration.
+        /// A title is the stable channel available when AppKit's window number
+        /// is synthetic, but it cannot distinguish current and stale windows.
+        static nonisolated func ambiguousControlItemTitles(
+            in items: [MenuBarItem]
+        ) -> Set<String> {
+            let relevantTitles = Set([
+                ControlItem.Identifier.hidden.rawValue,
+                ControlItem.Identifier.alwaysHidden.rawValue,
+            ])
+            var counts = [String: Int]()
+            for item in items {
+                guard let title = item.title, relevantTitles.contains(title) else { continue }
+                counts[title, default: 0] += 1
+            }
+            return Set(counts.compactMap { title, count in count > 1 ? title : nil })
         }
 
         /// Whether to rebuild one of Thaw's own control items directly from
@@ -531,14 +601,17 @@ extension MenuBarItemManager {
             var matchedIndices = [Int]()
             for frame in axFrames {
                 let identity = [AXIdentityCatalog.AXItemIdentity(identifier: nil, title: nil, help: nil, frame: frame)]
-                guard
-                    let candidate = candidates.first(where: { candidate in
-                        !matchedIndices.contains(candidate.index)
-                            && candidate.isOwnProcess
-                            && !candidate.isVisibleControlItem
-                            && AXIdentityCatalog.identity(for: candidate.bounds, in: identity) != nil
-                    })
-                else { continue }
+                let matches = candidates.filter { candidate in
+                    !matchedIndices.contains(candidate.index)
+                        && candidate.isOwnProcess
+                        && !candidate.isVisibleControlItem
+                        && AXIdentityCatalog.identity(for: candidate.bounds, in: identity) != nil
+                }
+                // More than one candidate for a current-process frame is not
+                // corroboration. Refuse the whole correlation rather than let
+                // array/window-number order decide which divider is current.
+                guard matches.count <= 1 else { return nil }
+                guard let candidate = matches.first else { continue }
                 matchedIndices.append(candidate.index)
                 if matchedIndices.count == 2 {
                     break
@@ -564,6 +637,16 @@ extension MenuBarItemManager {
             }
         }
         return ghostIDs
+    }
+
+    /// Converts AppKit's status-item window number only when it is an exact
+    /// WindowServer identifier. Tahoe can surface a larger synthetic number;
+    /// treating it as sortable identity would let a stale divider win.
+    static nonisolated func authoritativeControlItemWindowID(
+        windowNumber: Int
+    ) -> CGWindowID? {
+        guard windowNumber > 0 else { return nil }
+        return CGWindowID(exactly: windowNumber)
     }
 
     /// Returns windows that claim this instance's own namespace without
@@ -619,8 +702,9 @@ extension MenuBarItemManager {
         return MenuBarSection.Name.allCases.reduce(into: [:]) { result, name in
             guard let controlItem = menuBarManager.controlItem(withName: name),
                   let window = controlItem.window,
-                  window.windowNumber > 0,
-                  let windowID = CGWindowID(exactly: window.windowNumber)
+                  let windowID = Self.authoritativeControlItemWindowID(
+                      windowNumber: window.windowNumber
+                  )
             else { return }
             result[controlItem.identifier.rawValue] = windowID
         }
@@ -649,12 +733,61 @@ extension MenuBarItemManager {
             in: items,
             ownWindowIDsByTitle: ownControlItemWindowIDsByTitle()
         )
-        guard !ghostIDs.isEmpty else { return [] }
-        MenuBarItemManager.diagLog.warning(
-            "cacheItemsRegardless: dropping \(ghostIDs.count) duplicate control item window(s)"
-        )
-        items.removeAll { ghostIDs.contains($0.windowID) }
+        if !ghostIDs.isEmpty {
+            MenuBarItemManager.diagLog.warning(
+                "cacheItemsRegardless: dropping \(ghostIDs.count) duplicate control item window(s)"
+            )
+            items.removeAll { ghostIDs.contains($0.windowID) }
+        }
         return ghostIDs
+    }
+
+    /// A brief period in which missing dividers mean Control Center is still
+    /// re-hosting status items, not that Thaw should recreate them.
+    static nonisolated let controlCenterRelaunchGrace: Duration = .seconds(20)
+
+    static nonisolated func shouldCountControlItemLookupFailure(
+        hostUptime: Duration?,
+        grace: Duration = controlCenterRelaunchGrace
+    ) -> Bool {
+        guard let hostUptime else { return true }
+        return hostUptime >= grace
+    }
+
+    /// Selects the exact newest host when launch handoff briefly exposes more
+    /// than one Control Center process. `runningApplications` has no ordering
+    /// contract, so using its first entry can select the process being retired.
+    static nonisolated func newestControlCenterGeneration(
+        in generations: [ProcessGeneration]
+    ) -> ProcessGeneration? {
+        SourcePIDSeedStore.newestGeneration(in: generations)
+    }
+
+    private static func controlCenterGeneration() -> ProcessGeneration? {
+        SourcePIDSeedStore.currentControlCenterGeneration()
+    }
+
+    static nonisolated func controlCenterUptime(
+        generation: ProcessGeneration?,
+        now: Date = .now
+    ) -> Duration? {
+        generation.map { .seconds(max(0, now.timeIntervalSince($0.launchDate))) }
+    }
+
+    /// Re-arms divider recovery when Control Center changes process generation.
+    /// The old process's spent rebuild latch cannot govern a new host whose
+    /// status-item windows are being created from scratch.
+    @discardableResult
+    static nonisolated func resetControlItemLookupEpisodeIfHostChanged(
+        previous: ProcessGeneration?,
+        current: ProcessGeneration?,
+        failureStreak: inout Int,
+        alreadyRebuilt: inout Bool
+    ) -> Bool {
+        guard let current, current != previous else { return false }
+        failureStreak = 0
+        alreadyRebuilt = false
+        return true
     }
 
     /// Context maintained during a menu bar item cache operation.
@@ -1414,20 +1547,22 @@ extension MenuBarItemManager {
         let displayID = Bridging.getActiveMenuBarDisplayID()
         MenuBarItemManager.diagLog.debug("cacheItemsRegardless: displayID=\(displayID.map { "\($0)" } ?? "nil"), previousWindowIDs count=\(previousWindowIDs.count)")
 
-        var items = await MenuBarItem.getMenuBarItems(
+        var enumeration = await MenuBarItem.getMenuBarItemsSnapshot(
             option: .activeSpace,
             resolveSourcePID: resolveSourcePID
         )
+        var items = enumeration.items
 
         if items.isEmpty {
             // Retry once after a small delay if we got zero items. This can happen
             // due to transient WindowServer glitches or during display reconfigurations.
             MenuBarItemManager.diagLog.warning("cacheItemsRegardless: getMenuBarItems returned ZERO items, retrying in 250ms...")
             try? await Task.sleep(for: .milliseconds(250))
-            items = await MenuBarItem.getMenuBarItems(
+            enumeration = await MenuBarItem.getMenuBarItemsSnapshot(
                 option: .activeSpace,
                 resolveSourcePID: resolveSourcePID
             )
+            items = enumeration.items
 
             // Still nothing, but the cache holds items. The menu bar does not
             // empty itself, so this is the `.activeSpace` filter resolving a
@@ -1501,57 +1636,69 @@ extension MenuBarItemManager {
         // matching between CG windows and AX extras menu bar children, which
         // can produce wrong matches when AX positions lag behind CG updates.
         // A cached PID from a previous stable cycle is more trustworthy.
+        var provisionalSourcePIDSeeds = enumeration.appliedSourcePIDSeeds
         if resolveSourcePID {
-            let previousPIDs = cacheActor.cachedItemPIDs
+            let previousBaselines = cacheActor.cachedSourcePIDBaselines
+            var attemptedPIDs = Set<pid_t>()
+            var identities = [pid_t: SourceProcessIdentity]()
+
+            func cachedLiveIdentity(for pid: pid_t) -> SourceProcessIdentity? {
+                if let cached = identities[pid] {
+                    return cached
+                }
+                guard attemptedPIDs.insert(pid).inserted,
+                      let resolved = SourcePIDSeedStore.liveIdentity(of: pid)
+                else { return nil }
+                identities[pid] = resolved
+                return resolved
+            }
+
             for i in items.indices {
                 let item = items[i]
-                guard !item.isControlItem else { continue }
-                if let prevPID = previousPIDs[item.windowID],
-                   let currentPID = item.sourcePID,
-                   currentPID != prevPID
-                {
-                    // Only a live previous PID is more trustworthy than a
-                    // fresh resolution. When the app behind it has exited —
-                    // an item's owner relaunching, or Control Center itself
-                    // respawning and recreating every status item, both seen
-                    // in the #854 logs — reverting pins the item to a dead
-                    // process, and every event addressed to it goes nowhere.
-                    // Take the new PID in that case; there is nothing left to
-                    // protect.
-                    guard Self.previousPIDIsLive(prevPID) else {
-                        MenuBarItemManager.diagLog.info(
-                            "SourcePID changed for windowID \(item.windowID): \(prevPID) -> \(currentPID); previous PID is dead, accepting the new one"
-                        )
-                        continue
-                    }
+                guard
+                    !item.isControlItem,
+                    let previous = previousBaselines[item.windowID],
+                    item.sourcePID != previous.pid,
+                    let window = enumeration.windowsByID[item.windowID],
+                    let controlCenterGeneration = enumeration.controlCenterGeneration,
+                    SourcePIDSeedStore.reconciledSourcePID(
+                        currentPID: item.sourcePID,
+                        previous: previous,
+                        for: window,
+                        currentControlCenterGeneration: controlCenterGeneration,
+                        liveIdentity: cachedLiveIdentity(for:)
+                    ) == previous.pid
+                else { continue }
+
+                if let currentPID = item.sourcePID {
                     MenuBarItemManager.diagLog.warning(
-                        "SourcePID changed for windowID \(item.windowID): \(prevPID) -> \(currentPID), reverting to previous PID"
+                        "SourcePID changed for windowID \(item.windowID): \(previous.pid) -> \(currentPID), reverting to the generation-validated baseline"
                     )
-                    // Rebuild the namespace from the previous PID. If the bundle
-                    // ID is not available (app no longer running), keep the
-                    // original tag namespace as a safe fallback.
-                    let prevBundleID = NSRunningApplication(processIdentifier: prevPID)?.bundleIdentifier
-                    let correctedNamespace: MenuBarItemTag.Namespace = if let prevBundleID {
-                        .string(prevBundleID)
-                    } else {
-                        item.tag.namespace
-                    }
-                    let correctedTag = MenuBarItemTag(
-                        namespace: correctedNamespace,
-                        title: item.tag.title,
-                        windowID: item.windowID,
-                        instanceIndex: item.tag.instanceIndex
+                } else {
+                    MenuBarItemManager.diagLog.info(
+                        "SourcePID unresolved for windowID \(item.windowID); restoring the generation-validated in-session baseline \(previous.pid)"
                     )
-                    items[i] = MenuBarItem(
-                        tag: correctedTag,
-                        windowID: item.windowID,
-                        ownerPID: item.ownerPID,
-                        sourcePID: prevPID,
-                        bounds: item.bounds,
-                        title: item.title,
-                        isOnScreen: item.isOnScreen
-                    )
+                    provisionalSourcePIDSeeds[item.windowID] = previous
                 }
+
+                let correctedNamespace = MenuBarItemTag.Namespace.optional(
+                    previous.bundleIdentifier ?? previous.processName
+                )
+                let correctedTag = MenuBarItemTag(
+                    namespace: correctedNamespace,
+                    title: item.tag.title,
+                    windowID: item.windowID,
+                    instanceIndex: item.tag.instanceIndex
+                )
+                items[i] = MenuBarItem(
+                    tag: correctedTag,
+                    windowID: item.windowID,
+                    ownerPID: item.ownerPID,
+                    sourcePID: previous.pid,
+                    bounds: item.bounds,
+                    title: item.title,
+                    isOnScreen: item.isOnScreen
+                )
             }
         }
 
@@ -1609,8 +1756,13 @@ extension MenuBarItemManager {
             .controlItem(withName: .hidden)?.window?.windowNumber
         let alwaysHiddenControlItemWindowNumber = appState?.menuBarManager
             .controlItem(withName: .alwaysHidden)?.window?.windowNumber
-        let hiddenControlItemWID = hiddenControlItemWindowNumber.flatMap { CGWindowID(exactly: $0) }
-        let alwaysHiddenControlItemWID = alwaysHiddenControlItemWindowNumber.flatMap { CGWindowID(exactly: $0) }
+        let hiddenControlItemWID = hiddenControlItemWindowNumber.flatMap {
+            Self.authoritativeControlItemWindowID(windowNumber: $0)
+        }
+        let alwaysHiddenControlItemWID = alwaysHiddenControlItemWindowNumber.flatMap {
+            Self.authoritativeControlItemWindowID(windowNumber: $0)
+        }
+        let observedControlCenterGeneration = Self.controlCenterGeneration()
 
         guard let controlItems = ControlItemPair(
             items: &items,
@@ -1633,6 +1785,27 @@ extension MenuBarItemManager {
             // gone (e.g. their windowNumber no longer matches any
             // enumerated CG window ID), not that this one cycle raced a
             // transient WindowServer update.
+            if Self.resetControlItemLookupEpisodeIfHostChanged(
+                previous: lastObservedControlCenterGeneration,
+                current: observedControlCenterGeneration,
+                failureStreak: &controlItemLookupFailureStreak,
+                alreadyRebuilt: &didRebuildControlItemsForCurrentFailureEpisode
+            ) {
+                lastControlItemLookupFailureAt = nil
+                lastObservedControlCenterGeneration = observedControlCenterGeneration
+            }
+            let hostUptime = Self.controlCenterUptime(
+                generation: observedControlCenterGeneration
+            )
+            guard Self.shouldCountControlItemLookupFailure(hostUptime: hostUptime) else {
+                MenuBarItemManager.diagLog.info(
+                    "cacheItemsRegardless: divider lookup failed \(hostUptime.map { "\(Int($0.milliseconds / 1000)) s" } ?? "?") after Control Center launched; waiting for re-hosting to finish"
+                )
+                await MainActor.run {
+                    self.areControlItemsMissing = true
+                }
+                return
+            }
             controlItemLookupFailureStreak += 1
             lastControlItemLookupFailureAt = .now
             let failureStreak = controlItemLookupFailureStreak
@@ -1669,6 +1842,9 @@ extension MenuBarItemManager {
             controlItemLookupFailureStreak = 0
             didRebuildControlItemsForCurrentFailureEpisode = false
             lastControlItemLookupFailureAt = nil
+            if let observedControlCenterGeneration {
+                lastObservedControlCenterGeneration = observedControlCenterGeneration
+            }
             cacheActor.updateCachedItemWindowIDs(itemWindowIDs)
             cacheActor.updateCachedCloneWindowIDs(cloneWindowIDs.union(ghostWindowIDs))
             cacheActor.updateCachedControlCenterGenericWindowIDs(
@@ -1979,16 +2155,79 @@ extension MenuBarItemManager {
         // Only update when sourcePIDs were actually resolved; the settle-end
         // fast restore (resolveSourcePID=false) must not overwrite the baseline.
         if resolveSourcePID {
-            // Keyed by first occurrence: macOS can briefly report the same
-            // window twice around a move, and trapping on the duplicate
-            // would take the whole cache cycle down with it.
-            let newPIDs = Dictionary(
-                items.compactMap { item in
-                    item.sourcePID.map { (item.windowID, $0) }
-                },
-                uniquingKeysWith: { first, _ in first }
+            let currentWindowIDs = Set(items.map(\.windowID))
+            let currentControlCenterGeneration = SourcePIDSeedStore.currentControlCenterGeneration()
+            let validatedProvisionalSeeds: [CGWindowID: SourcePIDSeed]
+            let freshSeeds: [SourcePIDSeed]
+
+            if let currentControlCenterGeneration {
+                var attemptedPIDs = Set<pid_t>()
+                var identities = [pid_t: SourceProcessIdentity]()
+
+                func cachedLiveIdentity(for pid: pid_t) -> SourceProcessIdentity? {
+                    if let cached = identities[pid] {
+                        return cached
+                    }
+                    guard attemptedPIDs.insert(pid).inserted,
+                          let resolved = SourcePIDSeedStore.liveIdentity(of: pid)
+                    else { return nil }
+                    identities[pid] = resolved
+                    return resolved
+                }
+
+                validatedProvisionalSeeds = provisionalSourcePIDSeeds.filter { windowID, seed in
+                    guard
+                        currentWindowIDs.contains(windowID),
+                        let window = enumeration.windowsByID[windowID]
+                    else { return false }
+                    return SourcePIDSeedStore.isTrustworthy(
+                        seed,
+                        for: window,
+                        currentControlCenterGeneration: currentControlCenterGeneration,
+                        liveIdentity: cachedLiveIdentity(for:)
+                    )
+                }
+                freshSeeds = SourcePIDSeedStore.seeds(
+                    from: items,
+                    excluding: Set(validatedProvisionalSeeds.keys),
+                    windowsByID: enumeration.windowsByID,
+                    currentControlCenterGeneration: currentControlCenterGeneration,
+                    identity: SourcePIDSeedStore.liveIdentity(of:)
+                )
+            } else {
+                validatedProvisionalSeeds = [:]
+                freshSeeds = []
+            }
+
+            let baselines = SourcePIDSeedStore.mergedConfirmedBaselines(
+                previous: cacheActor.cachedSourcePIDBaselines,
+                fresh: freshSeeds,
+                provisional: validatedProvisionalSeeds
             )
-            cacheActor.updateCachedItemPIDs(newPIDs)
+            cacheActor.updateCachedSourcePIDBaselines(baselines)
+
+            let previousPersistedSeeds = cacheActor.persistedSourcePIDSeeds(
+                from: Defaults.store
+            )
+            let persistedSeeds = SourcePIDSeedStore.coalescingCaptureTimes(
+                proposed: SourcePIDSeedStore.mergedPersistedSeeds(
+                    fresh: freshSeeds,
+                    provisional: validatedProvisionalSeeds
+                ),
+                previous: Dictionary(
+                    previousPersistedSeeds.map { ($0.windowID, $0) },
+                    uniquingKeysWith: { _, last in last }
+                )
+            )
+            if cacheActor.updatePersistedSourcePIDSeeds(persistedSeeds) {
+                SourcePIDSeedStore.save(persistedSeeds, to: Defaults.store)
+            }
+
+            if !validatedProvisionalSeeds.isEmpty {
+                MenuBarItemManager.diagLog.debug(
+                    "cacheItemsRegardless: retained \(validatedProvisionalSeeds.count) restored source PID(s) provisionally while persisting \(freshSeeds.count) fresh confirmation(s)"
+                )
+            }
         }
 
         // Detect late-arriving items that belong to the active profile.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -54,6 +54,11 @@ final class MenuBarItemManager {
     /// the first successful lookup.
     var lastControlItemLookupFailureAt: ContinuousClock.Instant?
 
+    /// Exact Control Center launch observed by the latest cache cycle.
+    /// A new host process starts a new divider-recovery episode even if the
+    /// preceding process never produced a successful lookup before exiting.
+    var lastObservedControlCenterGeneration: ProcessGeneration?
+
     /// Consecutive authoritative cache readings in which the hidden section
     /// has no geometric span despite a populated saved hidden section.
     var hiddenSectionCollapseStreak = 0
@@ -239,7 +244,7 @@ final class MenuBarItemManager {
     private var groupOrderObservationTask: Task<Void, Never>?
 
     /// A candidate menu window matched by the open-menu probe.
-    nonisolated struct MenuWindowCandidate: Sendable {
+    nonisolated struct MenuWindowCandidate {
         let windowID: CGWindowID
         let bounds: CGRect
     }

--- a/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
+++ b/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import CoreGraphics
+import Foundation
 import Testing
 @testable import Thaw
 
@@ -587,5 +588,82 @@ struct MissingAlwaysHiddenDividerRecoveryTests {
             consecutiveMissingReadings: 2,
             threshold: 2
         ))
+    }
+}
+
+@Suite("Control Center relaunch grace")
+struct ControlCenterRelaunchGraceTests {
+    private func generation(pid: pid_t, launchedAt seconds: TimeInterval) -> ProcessGeneration {
+        ProcessGeneration(
+            pid: pid,
+            launchDate: Date(timeIntervalSince1970: seconds)
+        )
+    }
+
+    @Test("Re-hosting failures do not advance divider recovery")
+    func failuresInsideGraceAreIgnored() {
+        #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(hostUptime: .zero))
+        #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: MenuBarItemManager.controlCenterRelaunchGrace - .milliseconds(1)
+        ))
+    }
+
+    @Test("Failures after the grace period still recover missing dividers")
+    func failuresAfterGraceAreCounted() {
+        #expect(MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: MenuBarItemManager.controlCenterRelaunchGrace
+        ))
+        #expect(MenuBarItemManager.shouldCountControlItemLookupFailure(hostUptime: nil))
+    }
+
+    @Test("A custom grace period is respected")
+    func customGraceIsRespected() {
+        #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: .seconds(4),
+            grace: .seconds(5)
+        ))
+        #expect(MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: .seconds(5),
+            grace: .seconds(5)
+        ))
+    }
+
+    @Test("The newest host generation wins regardless of application ordering")
+    func newestHostGenerationWins() {
+        let retiring = generation(pid: 100, launchedAt: 1000)
+        let current = generation(pid: 200, launchedAt: 2000)
+
+        #expect(MenuBarItemManager.newestControlCenterGeneration(
+            in: [current, retiring]
+        ) == current)
+        #expect(MenuBarItemManager.newestControlCenterGeneration(
+            in: [retiring, current]
+        ) == current)
+    }
+
+    @Test("A new host generation re-arms a spent recovery episode")
+    func newHostRearmsSpentEpisode() {
+        let previous = generation(pid: 100, launchedAt: 1000)
+        let current = generation(pid: 200, launchedAt: 2000)
+        var failureStreak = MenuBarItemManager.controlItemRebuildThreshold + 4
+        var alreadyRebuilt = true
+
+        #expect(MenuBarItemManager.resetControlItemLookupEpisodeIfHostChanged(
+            previous: previous,
+            current: current,
+            failureStreak: &failureStreak,
+            alreadyRebuilt: &alreadyRebuilt
+        ))
+        #expect(failureStreak == 0)
+        #expect(!alreadyRebuilt)
+
+        failureStreak = 2
+        #expect(!MenuBarItemManager.resetControlItemLookupEpisodeIfHostChanged(
+            previous: current,
+            current: current,
+            failureStreak: &failureStreak,
+            alreadyRebuilt: &alreadyRebuilt
+        ))
+        #expect(failureStreak == 2)
     }
 }

--- a/ThawTests/MenuBar/Items/AXIdentityCatalogTests.swift
+++ b/ThawTests/MenuBar/Items/AXIdentityCatalogTests.swift
@@ -258,6 +258,22 @@ struct AXIdentityCatalogTests {
         #expect(result == nil)
     }
 
+    @Test("AX frame selection refuses duplicate current-process candidates")
+    func selectViaAXFrameRejectsAmbiguousDuplicateDividers() {
+        let frame = CGRect(x: 100, y: 0, width: 20, height: 20)
+        let candidates = [
+            CandidateFrame(index: 0, bounds: frame, isOwnProcess: true),
+            CandidateFrame(index: 1, bounds: frame, isOwnProcess: true),
+        ]
+
+        let result = MenuBarItemManager.ControlItemPair.selectViaAXFrame(
+            candidates: candidates,
+            axFrames: [frame]
+        )
+
+        #expect(result == nil)
+    }
+
     // MARK: - MenuBarItemManager.previousPIDIsLive
 
     /// The reconciliation guard prefers a cached PID over a fresh

--- a/ThawTests/MenuBar/Items/GhostControlItemWindowTests.swift
+++ b/ThawTests/MenuBar/Items/GhostControlItemWindowTests.swift
@@ -16,6 +16,7 @@ import Testing
 struct GhostControlItemWindowTests {
     private let hiddenTitle = "Thaw.ControlItem.Hidden"
     private let alwaysHiddenTitle = "Thaw.ControlItem.AlwaysHidden"
+    private let visibleTitle = "Thaw.ControlItem.Visible"
 
     private func item(tag: MenuBarItemTag, windowID: CGWindowID, title: String) -> MenuBarItem {
         MenuBarItem.fixture(tag: tag, windowID: windowID, title: title)
@@ -114,6 +115,53 @@ struct GhostControlItemWindowTests {
         )
 
         #expect(ghosts.isEmpty)
+    }
+
+    @Test("Authoritative current-process IDs win even when older numerically")
+    func authoritativeDividerGenerationSurvivesReversedIDs() {
+        let items = [
+            item(tag: .hiddenControlItem, windowID: 42, title: hiddenTitle),
+            item(tag: .alwaysHiddenControlItem, windowID: 43, title: alwaysHiddenTitle),
+            item(tag: .visibleControlItem, windowID: 39, title: visibleTitle),
+            item(tag: .hiddenControlItem, windowID: 900, title: hiddenTitle),
+            item(tag: .alwaysHiddenControlItem, windowID: 901, title: alwaysHiddenTitle),
+            item(tag: .visibleControlItem, windowID: 902, title: visibleTitle),
+        ]
+
+        let ghosts = MenuBarItemManager.ghostControlItemWindowIDs(
+            in: items,
+            ownWindowIDsByTitle: [
+                hiddenTitle: 42,
+                alwaysHiddenTitle: 43,
+                visibleTitle: 39,
+            ]
+        )
+        #expect(ghosts == [900, 901, 902])
+    }
+
+    @Test("A synthetic AppKit window number leaves duplicate dividers ambiguous")
+    func syntheticWindowNumberDoesNotSelectADuplicateDivider() {
+        let syntheticWindowNumber = Int(CGWindowID.max) + 1
+        #expect(MenuBarItemManager.authoritativeControlItemWindowID(
+            windowNumber: syntheticWindowNumber
+        ) == nil)
+        #expect(MenuBarItemManager.authoritativeControlItemWindowID(windowNumber: 42) == 42)
+
+        let items = [
+            item(tag: .hiddenControlItem, windowID: 364, title: hiddenTitle),
+            item(
+                tag: .appItem(
+                    bundleID: "com.stonerl.Thaw",
+                    title: hiddenTitle,
+                    instanceIndex: 1
+                ),
+                windowID: 21542,
+                title: hiddenTitle
+            ),
+        ]
+        #expect(MenuBarItemManager.ControlItemPair.ambiguousControlItemTitles(
+            in: items
+        ) == [hiddenTitle])
     }
 
     // MARK: - Orphans under our own namespace (#1032)
@@ -231,5 +279,6 @@ struct GhostControlItemWindowTests {
         let kept = items.filter { !orphans.contains($0.windowID) }
 
         #expect(!LayoutSolver.liveIdentitiesAreDegraded(identities(kept)))
+
     }
 }


### PR DESCRIPTION
# Summary

Wires bounded source-identity evidence through both menu-bar enumeration paths and cache retries, then reconciles it without promoting provisional observations into confirmed state. A validated in-session baseline survives a transient resolver miss or stale alternate result; invalid, expired, recycled, or vanished incarnations are pruned independently, while unrelated fresh confirmations are still persisted.

Control Center handoffs now require the newest live process generation throughout enumeration and cache reconciliation. Thaw's own section dividers prefer an authoritative WindowServer ID. If AppKit exposes only a synthetic window number and multiple current same-title dividers exist, the cache accepts only one unambiguous current-process Accessibility-frame correlation; otherwise it refuses the ambiguous refresh and retains the last-known-good cache instead of guessing by numeric window order.

**Scope:** This PR changes 6 files with 547 insertions and 94 deletions. It integrates #995's seed policy into enumeration and cache reconciliation, removes the numeric divider heuristic, makes duplicate-divider matching fail closed, re-arms bounded recovery for each new Control Center generation, and adds focused Swift Testing regressions. It does not change move transport, retry policy, Layout Bar UI transitions, or diagnostic export. This may be suitable for 2.2.

Dependency: #995 must be merged first or used as this PR's base. This integration directly uses its generation, fingerprint, seed-provenance, reconciliation, and persistence APIs and is not independently buildable on `development` without them.

## Linked issue (required)

Closes: N/A

Related: #754, #923

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Enumeration snapshots carry the selected Control Center generation, live windows, and exactly which source-PID seeds were applied, including through the bounded retry path.
- Both initial enumeration and retry replace those values as one snapshot, preventing seed provenance or owner geometry from being paired with a different observation cycle.
- Only the newest live Control Center generation can validate hosted windows; a retiring generation exposed during process handoff is rejected.
- Seed-restored items remain explicitly provisional. They are excluded from sibling propagation and fresh-seed extraction until live resolution confirms them.
- A still-valid confirmed baseline wins over a transient nil or stale alternate resolver result for the same hosted-window incarnation.
- Freshly confirmed items persist even when other entries remain provisional. Each provisional entry is retained only while its own live host, source, fingerprint, and age checks still pass; vanished and invalid entries are pruned independently.
- The cache coalesces unchanged seed timestamps, avoiding a defaults write on every pass while periodically renewing continuously confirmed identities.
- Thaw divider lookup uses an exact, representable WindowServer ID when AppKit provides one; synthetic or out-of-range window numbers are not treated as an ordering signal.
- When duplicate current-process dividers share a title and no authoritative ID is available, only one unambiguous Accessibility-frame match is accepted. Multiple matches, missing frames, or conflicting candidates fail closed, preserving the last-known-good cache instead of adopting a possibly stale divider.
- A new Control Center generation begins a new bounded recovery episode, while a persistent failure within one generation still rebuilds at most once until an authoritative success re-arms it.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -project Thaw.xcodeproj -scheme Thaw -destination 'generic/platform=macOS' -derivedDataPath /tmp/ThawIdentityBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawIdentityBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/SourcePIDSeedStoreTests -only-testing:ThawTests/GhostControlItemWindowTests -only-testing:ThawTests/AXIdentityCatalogTests -only-testing:ThawTests/ControlItemRecoveryTests`

The standalone macOS build succeeded. The final identity-stack run passed all 62 selected tests across 5 suites, including the confirmed → seeded miss → stale alternate sequence, two simultaneous Control Center generations, same-host window-ID reuse, mixed provisional/fresh persistence, synthetic divider window numbers, duplicate AX candidates, and recovery re-arming. SwiftFormat lint passed for all 8 changed Swift files; strict SwiftLint reported 0 violations across 189 files; the generated SwiftLint input-list comparison and `git diff --check` were clean.

## Known limitations / follow-ups

- When neither an authoritative WindowServer ID nor one unambiguous current Accessibility-frame match is available, the cache intentionally keeps its last-known-good state or refuses the new divider candidate. That may delay an update, but it avoids moving against a stale or foreign divider.
- Deterministic tests exercise synthetic WindowServer snapshots, process generations, resolver sequences, and Accessibility candidate sets. They cannot reproduce real service timing or every frame transition during Control Center/app relaunches, so field validation of live churn remains necessary.
- This integration inherits #995's bounded fingerprint tradeoff: an otherwise identical same-generation window recycled inside the five-minute bridge cannot be distinguished perfectly, while mismatched or older evidence fails closed.
- Move-event transport, retry outcomes, LayoutApply coordination, trigger ownership, diagnostic export, and Layout Bar animation cleanup remain separate PRs in this series.
- This stacked PR should remain based on #995 until that dependency merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or interactive menu-bar run was performed for this PR; verification was through the focused automated tests, standalone build, formatting, lint, generated-file comparison, and diff checks above.

The commit includes a `Signed-off-by` trailer for the project's DCO requirement. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 4 of 12  
**Git base:** #995  
**Functional dependencies:** #995.
