### PR TITLE
fix(menubar): make move outcomes explicit and attributable

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemFailureLedger.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemFailureLedger.swift
@@ -68,8 +68,18 @@ final class MenuBarItemFailureLedger {
     /// bulk applies for the remainder of its two-week lifetime, because
     /// nothing re-attempts it often enough to renew *or* retire the mark. The
     /// build stamp makes an update the natural clearing event.
+    /// The rule the marks are recorded by. Bumping it drops every persisted mark
+    /// once, the same way a build change does: marks recorded before the
+    /// owner and stable-identity checks existed blamed Control Center-hosted
+    /// items for Control Center's own timeouts, and one such mark — hours
+    /// old, from a previous rule — cut a user's drag to a single attempt and
+    /// an alert on the first slow press after the rule had changed.
+    private static let markRuleVersion = 2
+
+    /// The build the persisted marks belong to, qualified by ``markRuleVersion``.
     private static var currentBuildVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        let build = Bundle.main.object(forInfoDictionaryKey: "CFBundleVersion") as? String ?? "unknown"
+        return "\(build)/rule\(markRuleVersion)"
     }
 
     /// How long a failed item stays excluded from bulk-apply moves.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
@@ -39,6 +39,9 @@ extension MenuBarItemManager {
         case itemResponseTimeout(MenuBarItem)
         /// A menu bar item's bounds cannot be found.
         case missingItemBounds(MenuBarItem)
+        /// The destination anchor disappeared before the move could use it.
+        /// This is a stale plan, not a failure of the item being moved.
+        case missingDestinationBounds(MenuBarItem)
         /// A menu bar item's menu is tracking (e.g. the Wi-Fi picker or an
         /// input method panel is open) and the move was deferred.
         case menuTrackingActive(MenuBarItem)
@@ -62,6 +65,19 @@ extension MenuBarItemManager {
         /// The condition which requested this move changed while the move was
         /// waiting or retrying. The obsolete drag must stop immediately.
         case moveSuperseded(MenuBarItem)
+        /// Every release put the item straight back at its starting origin:
+        /// Control Center restored the item's autosaved slot because its
+        /// source app never registered the drop. Observed to hold for
+        /// minutes at a time for one item — every press variant reverted the
+        /// same way — and then clear by itself, so retrying only costs time.
+        case dropReverted(MenuBarItem)
+        /// Another move held the bar for the whole gate wait. Says nothing
+        /// about the item; callers treat it as a deferral.
+        case moveEngineBusy(MenuBarItem)
+        /// A press outlived its deadline and was released by the guard, or
+        /// the move as a whole ran past its deadline. Whatever reply came
+        /// back after that describes a press that was no longer down.
+        case moveTimedOut(MenuBarItem)
 
         var description: String {
             switch self {
@@ -81,6 +97,8 @@ extension MenuBarItemManager {
                 "\(Self.self).itemResponseTimeout(item: \(item.tag))"
             case let .missingItemBounds(item):
                 "\(Self.self).missingItemBounds(item: \(item.tag))"
+            case let .missingDestinationBounds(item):
+                "\(Self.self).missingDestinationBounds(item: \(item.tag))"
             case let .menuTrackingActive(item):
                 "\(Self.self).menuTrackingActive(item: \(item.tag))"
             case let .ownerUnresponsive(item):
@@ -93,6 +111,12 @@ extension MenuBarItemManager {
                 "\(Self.self).inputPauseTimedOut(item: \(item.tag))"
             case let .moveSuperseded(item):
                 "\(Self.self).moveSuperseded(item: \(item.tag))"
+            case let .dropReverted(item):
+                "\(Self.self).dropReverted(item: \(item.tag))"
+            case let .moveEngineBusy(item):
+                "\(Self.self).moveEngineBusy(item: \(item.tag))"
+            case let .moveTimedOut(item):
+                "\(Self.self).moveTimedOut(item: \(item.tag))"
             }
         }
 
@@ -114,6 +138,8 @@ extension MenuBarItemManager {
                 "\"\(item.displayName)\" took too long to respond"
             case let .missingItemBounds(item):
                 "Missing bounds rectangle for \"\(item.displayName)\""
+            case let .missingDestinationBounds(item):
+                "The destination \"\(item.displayName)\" is no longer available"
             case let .menuTrackingActive(item):
                 "A menu bar item's menu was open while moving \"\(item.displayName)\""
             case let .ownerUnresponsive(item):
@@ -126,14 +152,35 @@ extension MenuBarItemManager {
                 "Input did not pause before moving \"\(item.displayName)\""
             case let .moveSuperseded(item):
                 "The requested move for \"\(item.displayName)\" is no longer current"
+            case let .dropReverted(item):
+                "\"\(item.displayName)\" could not be kept in its new position"
+            case let .moveEngineBusy(item):
+                "Another move was still in progress when \"\(item.displayName)\" was to be moved"
+            case let .moveTimedOut(item):
+                "Moving \"\(item.displayName)\" took too long and was stopped"
             }
         }
 
         var recoverySuggestion: String? {
-            if case .itemNotMovable = self {
-                return nil
+            switch self {
+            case .itemNotMovable:
+                nil
+            case let .dropReverted(item):
+                // An app with no bundle identifier — a bare executable such
+                // as a `swift run` build — is keyed by path in Control
+                // Center, which has refused every off-screen drop of such an
+                // item in the field. Say so, or the alert reads as a Thaw
+                // bug the next time around.
+                if let app = item.sourceApplication, app.bundleIdentifier == nil {
+                    "macOS put \"\(item.displayName)\" back after every attempt. Its app has no bundle identifier (it runs as a bare executable), and macOS does not keep such items in a hidden section. Build it as an app bundle to test moving it."
+                } else {
+                    "macOS put \"\(item.displayName)\" back after every attempt. This usually clears on its own within a few minutes; clicking the item, or quitting and reopening its app, resets it sooner. If it keeps happening, please file a bug report."
+                }
+            case .moveEngineBusy:
+                "Wait a moment for the move in progress to finish, then try again."
+            default:
+                "Please try again. If the error persists, please file a bug report."
             }
-            return "Please try again. If the error persists, please file a bug report."
         }
 
         /// How the failure ledger should file this error.
@@ -153,8 +200,9 @@ extension MenuBarItemManager {
             case .ownerUnresponsive, .eventOperationTimeout, .itemResponseTimeout:
                 true
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
-                 .itemNotMovable, .missingItemBounds, .menuTrackingActive, .eventWindowMismatch,
-                 .staleDestination, .inputPauseTimedOut, .moveSuperseded:
+                 .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
+                 .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
+                 .moveEngineBusy, .moveTimedOut:
                 false
             }
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -228,6 +228,11 @@ final class MenuBarItemManager {
     /// Cached timeouts for move operations.
     var moveOperationTimeouts = [MenuBarItemTag: Duration]()
 
+    /// Items whose most recent move macOS refused — every release put the
+    /// item straight back — keyed by `uniqueIdentifier`, with when. See
+    /// `noteRefusedMove(of:)`.
+    var macOSRefusedMoves = [String: ContinuousClock.Instant]()
+
     /// Cached timeouts for click operations (adaptive per app).
     var clickOperationTimeouts = [MenuBarItemTag: Duration]()
     /// Serialization gate for cache operations.
@@ -1259,12 +1264,19 @@ final class MenuBarItemManager {
         )
         notchOverflowEjectedUIDs = ejectedStillInHidden
 
+        // An item macOS refused to move sits wherever the refusal left it,
+        // which is not where anyone put it. Treat it like a closed app so
+        // the merge below keeps its saved slot; the record clears when a
+        // move of it lands or the refusal ages out.
+        let refusedIdentifiers = refusedMoveIdentifiers()
+
         var allCurrentIdentifiers = Set<String>()
         var allCurrentBaseIdentifiers = Set<String>()
         for section in MenuBarSection.Name.allCases {
             for item in cache[section] where isPersistable(item) {
                 guard !pendingRehideTagIDs.contains(item.tag.tagIdentifier) else { continue }
                 guard !ejectedStillInHidden.contains(item.uniqueIdentifier) else { continue }
+                guard !refusedIdentifiers.contains(item.uniqueIdentifier) else { continue }
                 // Always track base identifier so stale saved entries for
                 // transient items (Live Activities) get pruned by the
                 // isStaleInstanceIndex guard below and not re-injected.
@@ -1297,7 +1309,8 @@ final class MenuBarItemManager {
                         !$0.isTransientControlCenterItem &&
                         !$0.hasProvisionalIdentity &&
                         !pendingRehideTagIDs.contains($0.tag.tagIdentifier) &&
-                        !ejectedStillInHidden.contains($0.uniqueIdentifier)
+                        !ejectedStillInHidden.contains($0.uniqueIdentifier) &&
+                        !refusedIdentifiers.contains($0.uniqueIdentifier)
                 }
                 .map(\.uniqueIdentifier)
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
@@ -310,7 +310,7 @@ extension MenuBarItemManager {
                 .overran
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
                  .itemNotMovable, .menuTrackingActive, .eventWindowMismatch, .staleDestination,
-                 .dropReverted, .moveEngineBusy:
+                 .inputPauseTimedOut, .dropReverted, .moveEngineBusy:
                 .other
             }
         }
@@ -343,7 +343,7 @@ extension MenuBarItemManager {
             return ownerIsControlCenter || hasProvisionalIdentity ? .other : .unresponsiveOwner
         case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
              .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
-             .staleDestination, .moveSuperseded, .dropReverted,
+             .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
              .moveEngineBusy, .moveTimedOut:
             return .other
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
@@ -1,0 +1,420 @@
+//
+//  MenuBarItemMovePolicy.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+
+// MARK: - Move Policy
+
+extension MenuBarItemManager {
+    /// The pure core of `move(item:to:)`.
+    ///
+    /// `move` posts events and reads the bar; everything it *decides* — retry
+    /// or stop, and what to call the result — lives here, over plain values,
+    /// so a field log's sequence of attempts can be replayed in a unit test
+    /// and the verdict the user sees can be checked without a live menu bar.
+    ///
+    /// Each attempt produces one ``Observation``. ``decide(after:state:configuration:)``
+    /// folds it into the running ``State`` and answers with a ``Decision``:
+    /// the move landed, another attempt is worth making, or it stops for a
+    /// named ``StopReason``. The reasons are deliberately specific, because
+    /// the callers report them to the user: a drop that macOS put back is not
+    /// an owner that never answered, and neither is a destination that moved.
+    nonisolated enum MovePolicy {
+        /// What one attempt observed.
+        nonisolated enum Observation: Equatable {
+            /// The item was verified beside the target once the bar settled.
+            case landed
+            /// The owner answered the press and the release, but the item is
+            /// not beside the target. `revertedToStart` records a release that
+            /// put it exactly back where it started; `targetMinX` is where the
+            /// target sits now.
+            case displaced(revertedToStart: Bool, targetMinX: CGFloat?)
+            /// The attempt threw before a landing could be judged.
+            case failed(AttemptFailure)
+        }
+
+        /// Why an attempt threw, reduced to what the policy needs.
+        nonisolated enum AttemptFailure: Equatable {
+            /// A posted event, or the item's reaction to it, timed out.
+            case ownerSilent
+            /// The owner is alive but not pumping its event loop.
+            case ownerUnresponsive
+            /// The item's window no longer reports bounds.
+            case itemGone
+            /// The destination anchor no longer reports bounds.
+            case destinationGone
+            /// The caller's condition changed; the move is obsolete.
+            case superseded
+            /// The press outlived its deadline and was released by the guard.
+            case overran
+            /// Anything else.
+            case other
+        }
+
+        /// What `move` does next.
+        nonisolated enum Decision: Equatable {
+            case succeed
+            case retry
+            case stop(StopReason)
+        }
+
+        /// Why a move stopped short of a verified landing.
+        nonisolated enum StopReason: Equatable {
+            /// Two consecutive releases put the item straight back where it
+            /// started: macOS is restoring the item's autosaved slot.
+            case refusedByMacOS
+            /// The target travelled more than a display width during the drag.
+            case targetMoved
+            /// The target retreated in one direction on every recent attempt.
+            case targetRetreating
+            /// The owner is hung; no event will be acknowledged this call.
+            case ownerUnresponsive
+            /// The owner has a standing record of ignoring events and just
+            /// did so again.
+            case ownerAlwaysSilent
+            /// Events timed out on the final attempt.
+            case ownerSilent
+            case itemGone
+            case destinationGone
+            case superseded
+            /// A press was released by the deadline guard, or the move as a
+            /// whole ran past its deadline.
+            case overran
+            /// Every attempt displaced the item without landing it.
+            case budgetExhausted
+            /// The final attempt failed for an unclassified reason.
+            case other
+
+            /// Whether the item could nevertheless be sitting at the
+            /// destination, so the verdict must be checked against the bar
+            /// before it is reported as a failure.
+            ///
+            /// Not for a refused drop, whose releases were observed putting
+            /// the item back; not for a vanished item; not for a superseded
+            /// move, whose caller no longer wants the answer; and not for a
+            /// hung owner, which never received a press.
+            var deservesFinalLandingCheck: Bool {
+                switch self {
+                case .targetMoved, .targetRetreating, .ownerAlwaysSilent, .ownerSilent, .overran, .budgetExhausted, .other:
+                    true
+                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded:
+                    false
+                }
+            }
+
+            /// Whether the failure is filed against the item's owner in the
+            /// failure ledger. Only silence is: a refused drop, a moved target,
+            /// and a deadline overrun say nothing about the owner.
+            var isFiledAgainstOwner: Bool {
+                switch self {
+                case .ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent:
+                    true
+                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other:
+                    false
+                }
+            }
+
+            var logString: String {
+                switch self {
+                case .refusedByMacOS: "refused by macOS"
+                case .targetMoved: "target moved"
+                case .targetRetreating: "target retreating"
+                case .ownerUnresponsive: "owner unresponsive"
+                case .ownerAlwaysSilent: "owner always silent"
+                case .ownerSilent: "owner silent"
+                case .itemGone: "item gone"
+                case .destinationGone: "destination gone"
+                case .superseded: "superseded"
+                case .overran: "overran deadline"
+                case .budgetExhausted: "budget exhausted"
+                case .other: "other"
+                }
+            }
+        }
+
+        /// The fixed inputs of one move.
+        nonisolated struct Configuration: Equatable {
+            /// How many attempts the move may spend.
+            var maxAttempts: Int
+            /// The width of the display the move runs on; the staleness
+            /// threshold for a target that moved.
+            var displayWidth: CGFloat
+            /// Whether the moved item is a zero-width control item, whose
+            /// position match can coincide with bounds drifting externally.
+            var itemIsControlItem: Bool
+            /// Whether the failure ledger holds a standing unresponsive mark
+            /// for the item's owner.
+            var ownerHasSilentRecord: Bool
+            /// Consecutive reverted releases that prove a refusal.
+            var revertRunLength = 2
+            /// Consecutive same-direction target moves that prove a retreat.
+            var retreatRunLength = 3
+        }
+
+        /// The running state of one move across attempts.
+        nonisolated struct State: Equatable {
+            /// Attempts observed so far.
+            var attempts = 0
+            /// Consecutive attempts whose release put the item back at its start.
+            var revertedRun = 0
+            /// Whether any attempt's events displaced the item at all.
+            var anyEventsSucceeded = false
+            /// The target's `minX` when the move was planned, then at the end
+            /// of every attempt that observed it.
+            var targetMinXHistory: [CGFloat]
+
+            init(plannedTargetMinX: CGFloat?) {
+                targetMinXHistory = plannedTargetMinX.map { [$0] } ?? []
+            }
+
+            /// Where the target sat when the move was planned.
+            var plannedTargetMinX: CGFloat? {
+                targetMinXHistory.first
+            }
+
+            /// Where the target sat after the most recent attempt.
+            var latestTargetMinX: CGFloat? {
+                targetMinXHistory.count > 1 ? targetMinXHistory.last : nil
+            }
+        }
+
+        /// Folds one attempt's observation into `state` and decides what
+        /// `move` does next.
+        ///
+        /// Order of the checks on a displaced item matters and mirrors the
+        /// evidence each one needs: a refusal is proven by the releases alone
+        /// (two in a row, so a single warm-up nudge does not count); a moved
+        /// target by one reading against the display width; a retreat by a
+        /// run of readings. Only then does the attempt budget decide.
+        static func decide(
+            after observation: Observation,
+            state: inout State,
+            configuration: Configuration
+        ) -> Decision {
+            state.attempts += 1
+            let maxAttempts = max(1, configuration.maxAttempts)
+
+            switch observation {
+            case .landed:
+                state.anyEventsSucceeded = true
+                return .succeed
+
+            case let .displaced(revertedToStart, targetMinX):
+                state.anyEventsSucceeded = true
+                if revertedToStart {
+                    state.revertedRun += 1
+                    if state.revertedRun >= max(1, configuration.revertRunLength) {
+                        return .stop(.refusedByMacOS)
+                    }
+                } else {
+                    state.revertedRun = 0
+                }
+                if let targetMinX {
+                    state.targetMinXHistory.append(targetMinX)
+                }
+                if let planned = state.plannedTargetMinX,
+                   let targetMinX,
+                   destinationIsStale(
+                       plannedTargetMinX: planned,
+                       currentTargetMinX: targetMinX,
+                       displayWidth: configuration.displayWidth
+                   )
+                {
+                    return .stop(.targetMoved)
+                }
+                if targetIsRetreating(
+                    recentTargetMinX: state.targetMinXHistory,
+                    runLength: configuration.retreatRunLength
+                ) {
+                    return .stop(.targetRetreating)
+                }
+                return state.attempts < maxAttempts ? .retry : .stop(.budgetExhausted)
+
+            case let .failed(failure):
+                switch failure {
+                case .itemGone:
+                    return .stop(.itemGone)
+                case .destinationGone:
+                    return .stop(.destinationGone)
+                case .ownerUnresponsive:
+                    return .stop(.ownerUnresponsive)
+                case .superseded:
+                    return .stop(.superseded)
+                case .overran:
+                    return .stop(.overran)
+                case .ownerSilent:
+                    // An owner with a standing record of ignoring synthetic
+                    // events gets no further attempts once it fails this way
+                    // again. Deliberately narrower than capping the budget up
+                    // front: the loop also retries when the owner *did*
+                    // respond but the item did not land, which is a different
+                    // failure and still deserves its full budget.
+                    if configuration.ownerHasSilentRecord {
+                        return .stop(.ownerAlwaysSilent)
+                    }
+                    return state.attempts < maxAttempts ? .retry : .stop(.ownerSilent)
+                case .other:
+                    return state.attempts < maxAttempts ? .retry : .stop(.other)
+                }
+            }
+        }
+
+        /// Whether a position match read *before* posting an attempt's events
+        /// can be trusted as a landing.
+        ///
+        /// On the first attempt it always can. On retries, the only case where
+        /// the match can be a coincidence is when the item being moved is
+        /// itself a zero-width control item whose bounds may have drifted onto
+        /// the target externally; those are gated on observed displacement.
+        static func trustsPositionMatch(
+            attempt: Int,
+            anyEventsSucceeded: Bool,
+            itemIsControlItem: Bool
+        ) -> Bool {
+            attempt <= 1 || anyEventsSucceeded || !itemIsControlItem
+        }
+
+        /// Whether a move that has been running for `elapsed` may start
+        /// another attempt.
+        ///
+        /// Every attempt is bounded by the press-release guard, but eight
+        /// bounded attempts still add up; the move as a whole yields the bar
+        /// before the cursor watchdog and the callers waiting on the move
+        /// gate give up on it.
+        static func mayStartAnotherAttempt(elapsed: Duration, deadline: Duration) -> Bool {
+            elapsed < deadline
+        }
+
+        /// The reason `move` reports when it stops for `failure` on an attempt
+        /// it never got to observe (before posting), keeping the mapping in
+        /// one place with ``decide(after:state:configuration:)``.
+        static func attemptFailure(for error: EventError) -> AttemptFailure {
+            switch error {
+            case .eventOperationTimeout, .itemResponseTimeout:
+                .ownerSilent
+            case .ownerUnresponsive:
+                .ownerUnresponsive
+            case .missingItemBounds:
+                .itemGone
+            case .missingDestinationBounds:
+                .destinationGone
+            case .moveSuperseded:
+                .superseded
+            case .moveTimedOut:
+                .overran
+            case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
+                 .itemNotMovable, .menuTrackingActive, .eventWindowMismatch, .staleDestination,
+                 .dropReverted, .moveEngineBusy:
+                .other
+            }
+        }
+    }
+
+    // MARK: - Failure attribution
+
+    /// How the failure ledger should file a move error against the item.
+    ///
+    /// The ledger's unresponsive-owner mark exists for an *app* that ignores
+    /// synthetic events — Little Snitch with GUI Scripting disabled is the
+    /// recurring case. It is earned by timeouts, and on macOS 26 every hosted
+    /// status item's events go to Control Center, not to the app: a timeout
+    /// there says Control Center did not relocate the window in time, which
+    /// happened for minutes at a stretch while an item's drops were being
+    /// reverted by macOS itself, and the field log shows an owner that
+    /// answered every press being marked as unresponsive for fourteen days
+    /// on the strength of two such timeouts. The mark is therefore filed
+    /// only when the owner the events reach is the item's own app.
+    ///
+    /// A provisional identity is never marked either: its key changes as
+    /// soon as the source process resolves, so the mark could not clear.
+    static nonisolated func ledgerFailureKind(
+        for error: EventError,
+        ownerIsControlCenter: Bool,
+        hasProvisionalIdentity: Bool
+    ) -> MenuBarItemFailureLedger.FailureKind {
+        switch error {
+        case .ownerUnresponsive, .eventOperationTimeout, .itemResponseTimeout:
+            return ownerIsControlCenter || hasProvisionalIdentity ? .other : .unresponsiveOwner
+        case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
+             .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
+             .staleDestination, .moveSuperseded, .dropReverted,
+             .moveEngineBusy, .moveTimedOut:
+            return .other
+        }
+    }
+
+    // MARK: - Refused moves
+
+    /// How long macOS's refusal of a move keeps the item's saved slot from
+    /// being overwritten by wherever the refusal left it.
+    ///
+    /// The refusing state observed in the field lasted about four minutes
+    /// and about one minute, and cleared by itself; a landing clears the
+    /// record sooner.
+    static nonisolated let refusedMoveLifetime: Duration = .seconds(10 * 60)
+
+    /// Whether a recorded refusal still stands.
+    static nonisolated func refusedMoveIsCurrent(
+        recordedAt: ContinuousClock.Instant,
+        now: ContinuousClock.Instant,
+        lifetime: Duration = refusedMoveLifetime
+    ) -> Bool {
+        now - recordedAt < lifetime
+    }
+
+    /// Records that macOS put `item` straight back after every release. While
+    /// the record stands, saved-order persistence keeps the intended slot
+    /// instead of adopting the position left by the refusal.
+    func noteRefusedMove(of item: MenuBarItem) {
+        macOSRefusedMoves[item.uniqueIdentifier] = .now
+    }
+
+    /// Forgets a refusal because the item just landed.
+    func clearRefusedMove(of item: MenuBarItem) {
+        macOSRefusedMoves[item.uniqueIdentifier] = nil
+    }
+
+    /// The identifiers whose most recent move macOS refused, with expired
+    /// records dropped on the way out.
+    func refusedMoveIdentifiers(now: ContinuousClock.Instant = .now) -> Set<String> {
+        macOSRefusedMoves = macOSRefusedMoves.filter { entry in
+            Self.refusedMoveIsCurrent(recordedAt: entry.value, now: now)
+        }
+        return Set(macOSRefusedMoves.keys)
+    }
+
+    /// The error a stopped move throws, so callers receive a precise outcome.
+    static nonisolated func moveError(
+        for reason: MovePolicy.StopReason,
+        item: MenuBarItem,
+        destinationItem: MenuBarItem? = nil,
+        lastError: (any Error)?
+    ) -> any Error {
+        switch reason {
+        case .refusedByMacOS:
+            EventError.dropReverted(item)
+        case .targetMoved, .targetRetreating:
+            EventError.staleDestination(item)
+        case .ownerUnresponsive:
+            EventError.ownerUnresponsive(item)
+        case .itemGone:
+            EventError.missingItemBounds(item)
+        case .destinationGone:
+            EventError.missingDestinationBounds(destinationItem ?? item)
+        case .superseded:
+            EventError.moveSuperseded(item)
+        case .overran:
+            EventError.moveTimedOut(item)
+        case .ownerAlwaysSilent, .ownerSilent, .other:
+            (lastError as? EventError) ?? EventError.cannotComplete
+        case .budgetExhausted:
+            EventError.cannotComplete
+        }
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
@@ -1,0 +1,130 @@
+//
+//  MoveFailureAttributionTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+import Testing
+@testable import Thaw
+
+/// How a move's failure is attributed once it leaves the engine: which
+/// failures the ledger may file as an owner that ignores events and how long
+/// a refusal by macOS keeps an item's saved slot.
+@MainActor
+@Suite("Move failure attribution")
+struct MoveFailureAttributionTests {
+    typealias EventError = MenuBarItemManager.EventError
+
+    private let item = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "com.example.IconSwitcher", title: "Item-0"),
+        windowID: 2314
+    )
+
+    // MARK: Ledger
+
+    /// The 13:00:51 mark: a timeout on a Control-Center-hosted item during a
+    /// reverting episode, filed for fourteen days against an owner that had
+    /// answered every press.
+    @Test("A timeout on a Control-Center-hosted item is not the owner's silence")
+    func hostedTimeoutIsNotFiledAgainstOwner() {
+        let kind = MenuBarItemManager.ledgerFailureKind(
+            for: .itemResponseTimeout(item),
+            ownerIsControlCenter: true,
+            hasProvisionalIdentity: false
+        )
+        #expect(kind == .other)
+    }
+
+    /// The case the mark exists for: an app that owns its own window and
+    /// never acknowledges the events posted to it.
+    @Test("A timeout on an app-owned item is the owner's silence")
+    func appOwnedTimeoutIsFiledAgainstOwner() {
+        let kind = MenuBarItemManager.ledgerFailureKind(
+            for: .eventOperationTimeout(item),
+            ownerIsControlCenter: false,
+            hasProvisionalIdentity: false
+        )
+        #expect(kind == .unresponsiveOwner)
+    }
+
+    @Test("A hung owner is filed only when it is not Control Center")
+    func hungOwnerAttribution() {
+        #expect(
+            MenuBarItemManager.ledgerFailureKind(
+                for: .ownerUnresponsive(item),
+                ownerIsControlCenter: false,
+                hasProvisionalIdentity: false
+            ) == .unresponsiveOwner
+        )
+        #expect(
+            MenuBarItemManager.ledgerFailureKind(
+                for: .ownerUnresponsive(item),
+                ownerIsControlCenter: true,
+                hasProvisionalIdentity: false
+            ) == .other
+        )
+    }
+
+    @Test("A provisional identity is never marked")
+    func provisionalIdentityIsNeverMarked() {
+        let kind = MenuBarItemManager.ledgerFailureKind(
+            for: .itemResponseTimeout(item),
+            ownerIsControlCenter: false,
+            hasProvisionalIdentity: true
+        )
+        #expect(kind == .other)
+    }
+
+    @Test("Failures that are not silence never earn a mark", arguments: [
+        EventError.dropReverted(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .staleDestination(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .moveTimedOut(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .moveEngineBusy(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .missingItemBounds(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .cannotComplete,
+    ])
+    func nonSilenceIsNeverMarked(error: EventError) {
+        let kind = MenuBarItemManager.ledgerFailureKind(
+            for: error,
+            ownerIsControlCenter: false,
+            hasProvisionalIdentity: false
+        )
+        #expect(kind == .other)
+    }
+
+    // MARK: Refused moves
+
+    @Test("A refusal stands for its lifetime and then lapses")
+    func refusalLifetime() {
+        let recordedAt = ContinuousClock.Instant.now
+        #expect(MenuBarItemManager.refusedMoveIsCurrent(recordedAt: recordedAt, now: recordedAt))
+        #expect(
+            MenuBarItemManager.refusedMoveIsCurrent(
+                recordedAt: recordedAt,
+                now: recordedAt.advanced(by: .seconds(9 * 60))
+            )
+        )
+        #expect(
+            !MenuBarItemManager.refusedMoveIsCurrent(
+                recordedAt: recordedAt,
+                now: recordedAt.advanced(by: MenuBarItemManager.refusedMoveLifetime)
+            )
+        )
+    }
+
+    @Test("A refusal record is kept by the manager until it lapses")
+    func refusalRecordLifecycle() {
+        let manager = MenuBarItemManager()
+        let now = ContinuousClock.Instant.now
+        manager.noteRefusedMove(of: item)
+        #expect(manager.refusedMoveIdentifiers(now: now) == [item.uniqueIdentifier])
+        #expect(manager.refusedMoveIdentifiers(now: now.advanced(by: .seconds(11 * 60))).isEmpty)
+
+        manager.noteRefusedMove(of: item)
+        manager.clearRefusedMove(of: item)
+        #expect(manager.refusedMoveIdentifiers(now: now).isEmpty)
+    }
+}

--- a/ThawTests/MenuBar/Items/MovePolicyTests.swift
+++ b/ThawTests/MenuBar/Items/MovePolicyTests.swift
@@ -1,0 +1,281 @@
+//
+//  MovePolicyTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+/// Characterizes `MenuBarItemManager.MovePolicy`, the pure decision core of
+/// `move(item:to:)`: each attempt's observation is folded into the running
+/// state and answered with retry, succeed, or a named stop reason. The
+/// sequences below are the ones the field logs contain, replayed without a
+/// menu bar.
+@Suite("Move policy")
+struct MovePolicyTests {
+    typealias Policy = MenuBarItemManager.MovePolicy
+
+    private func configuration(
+        maxAttempts: Int = 8,
+        itemIsControlItem: Bool = false,
+        ownerHasSilentRecord: Bool = false
+    ) -> Policy.Configuration {
+        Policy.Configuration(
+            maxAttempts: maxAttempts,
+            displayWidth: 1728,
+            itemIsControlItem: itemIsControlItem,
+            ownerHasSilentRecord: ownerHasSilentRecord
+        )
+    }
+
+    /// Runs `observations` through the policy and returns every decision.
+    private func decisions(
+        _ observations: [Policy.Observation],
+        plannedTargetMinX: CGFloat? = -3725,
+        configuration: Policy.Configuration? = nil
+    ) -> [Policy.Decision] {
+        var state = Policy.State(plannedTargetMinX: plannedTargetMinX)
+        let configuration = configuration ?? self.configuration()
+        return observations.map { Policy.decide(after: $0, state: &state, configuration: configuration) }
+    }
+
+    // MARK: Landing
+
+    @Test("A verified landing succeeds on the first attempt")
+    func landingSucceeds() {
+        #expect(decisions([.landed]) == [.succeed])
+    }
+
+    @Test("A warm-up nudge followed by a landing succeeds on the second attempt")
+    func warmUpThenLanding() {
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: -3725)
+        #expect(decisions([displaced, .landed]) == [.retry, .succeed])
+    }
+
+    // MARK: Refusal
+
+    /// The 13:28:55 drag: the item followed the press into the notch and the
+    /// release put it back at 1433 twice. Two reverts prove the refusal; one
+    /// is the warm-up press #881 documents.
+    @Test("Two consecutive reverted releases stop the move as refused")
+    func twoRevertsAreARefusal() {
+        let reverted = Policy.Observation.displaced(revertedToStart: true, targetMinX: -3725)
+        #expect(decisions([reverted, reverted]) == [.retry, .stop(.refusedByMacOS)])
+    }
+
+    @Test("A single reverted release is only a warm-up")
+    func singleRevertIsNotARefusal() {
+        let reverted = Policy.Observation.displaced(revertedToStart: true, targetMinX: -3725)
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: -3725)
+        #expect(decisions([reverted, displaced, reverted]) == [.retry, .retry, .retry])
+    }
+
+    // MARK: Target movement
+
+    /// The #881 numbers: the target measured at -4222 on one attempt and at
+    /// 794 on the next, on a bar far narrower than that swing.
+    @Test("A target that crossed a display width stops the move as moved")
+    func displayWidthSwingIsStale() {
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: 794)
+        #expect(decisions([displaced], plannedTargetMinX: -4222) == [.stop(.targetMoved)])
+    }
+
+    /// The #924/#927 sequence: an anchor driven from 1682 to 1650 over the
+    /// attempts while the item never landed.
+    @Test("A target retreating on every attempt stops the move as retreating")
+    func retreatingTargetIsCaught() {
+        let steps: [CGFloat] = [1677, 1664, 1653]
+        let observations = steps.map { Policy.Observation.displaced(revertedToStart: false, targetMinX: $0) }
+        #expect(decisions(observations, plannedTargetMinX: 1682) == [.retry, .retry, .stop(.targetRetreating)])
+    }
+
+    @Test("A jittering target is reflow, not a retreat")
+    func jitteringTargetKeepsRetrying() {
+        let steps: [CGFloat] = [1677, 1684, 1679, 1686]
+        let observations = steps.map { Policy.Observation.displaced(revertedToStart: false, targetMinX: $0) }
+        #expect(decisions(observations, plannedTargetMinX: 1682).allSatisfy { $0 == .retry })
+    }
+
+    // MARK: Budget
+
+    @Test("Displacing without landing spends the whole budget, then stops exhausted")
+    func budgetExhaustion() {
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: -3725)
+        let result = decisions(Array(repeating: displaced, count: 3), configuration: configuration(maxAttempts: 3))
+        #expect(result == [.retry, .retry, .stop(.budgetExhausted)])
+    }
+
+    @Test("A budget of zero still allows one attempt")
+    func zeroBudgetAllowsOneAttempt() {
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: nil)
+        #expect(decisions([displaced], configuration: configuration(maxAttempts: 0)) == [.stop(.budgetExhausted)])
+    }
+
+    // MARK: Failures
+
+    @Test("Owner silence is retried until the budget runs out")
+    func ownerSilenceRetries() {
+        let silent = Policy.Observation.failed(.ownerSilent)
+        let result = decisions(Array(repeating: silent, count: 2), configuration: configuration(maxAttempts: 2))
+        #expect(result == [.retry, .stop(.ownerSilent)])
+    }
+
+    /// The 13:15:47 drag: the owner carried a standing unresponsive mark, so
+    /// the first timeout ended the move at once.
+    @Test("An owner with a silent record is not retried after another silence")
+    func silentRecordStopsAtOnce() {
+        let silent = Policy.Observation.failed(.ownerSilent)
+        #expect(decisions([silent], configuration: configuration(ownerHasSilentRecord: true)) == [.stop(.ownerAlwaysSilent)])
+    }
+
+    @Test("A silent record does not shorten a move whose owner is answering")
+    func silentRecordLeavesDisplacementsAlone() {
+        let displaced = Policy.Observation.displaced(revertedToStart: false, targetMinX: -3725)
+        #expect(decisions([displaced, .landed], configuration: configuration(ownerHasSilentRecord: true)) == [.retry, .succeed])
+    }
+
+    @Test("Definitive failures stop on the attempt they occur", arguments: [
+        (Policy.AttemptFailure.itemGone, Policy.StopReason.itemGone),
+        (.destinationGone, .destinationGone),
+        (.ownerUnresponsive, .ownerUnresponsive),
+        (.superseded, .superseded),
+        (.overran, .overran),
+    ])
+    func definitiveFailuresStop(failure: Policy.AttemptFailure, reason: Policy.StopReason) {
+        #expect(decisions([.failed(failure)]) == [.stop(reason)])
+    }
+
+    @Test("Unclassified failures are retried, then stop as other")
+    func otherFailuresRetry() {
+        let other = Policy.Observation.failed(.other)
+        #expect(decisions([other, other], configuration: configuration(maxAttempts: 2)) == [.retry, .stop(.other)])
+    }
+
+    // MARK: State
+
+    @Test("Any displacement counts as events having succeeded")
+    func displacementMarksEventsSucceeded() {
+        var state = Policy.State(plannedTargetMinX: 100)
+        _ = Policy.decide(
+            after: .displaced(revertedToStart: false, targetMinX: 100),
+            state: &state,
+            configuration: configuration()
+        )
+        #expect(state.anyEventsSucceeded)
+        #expect(state.attempts == 1)
+        #expect(state.targetMinXHistory == [100, 100])
+    }
+
+    @Test("A failure leaves the events-succeeded flag alone")
+    func failureLeavesEventsFlag() {
+        var state = Policy.State(plannedTargetMinX: nil)
+        _ = Policy.decide(after: .failed(.other), state: &state, configuration: configuration())
+        #expect(!state.anyEventsSucceeded)
+        #expect(state.latestTargetMinX == nil)
+    }
+
+    // MARK: Pre-attempt position match
+
+    @Test("A position match is trusted on the first attempt")
+    func firstAttemptMatchIsTrusted() {
+        #expect(Policy.trustsPositionMatch(attempt: 1, anyEventsSucceeded: false, itemIsControlItem: true))
+    }
+
+    @Test("A retry's match on a control item needs observed displacement")
+    func controlItemRetryNeedsDisplacement() {
+        #expect(!Policy.trustsPositionMatch(attempt: 2, anyEventsSucceeded: false, itemIsControlItem: true))
+        #expect(Policy.trustsPositionMatch(attempt: 2, anyEventsSucceeded: true, itemIsControlItem: true))
+    }
+
+    @Test("A retry's match on an ordinary item is always trusted")
+    func ordinaryItemRetryIsTrusted() {
+        #expect(Policy.trustsPositionMatch(attempt: 5, anyEventsSucceeded: false, itemIsControlItem: false))
+    }
+
+    // MARK: Deadlines
+
+    @Test("Another attempt may start only inside the move deadline")
+    func moveDeadline() {
+        #expect(Policy.mayStartAnotherAttempt(elapsed: .seconds(7), deadline: .seconds(8)))
+        #expect(!Policy.mayStartAnotherAttempt(elapsed: .seconds(8), deadline: .seconds(8)))
+    }
+
+    // MARK: Stop reasons
+
+    @Test("Reasons that leave the item possibly landed get the final check", arguments: [
+        Policy.StopReason.targetMoved, .targetRetreating, .ownerAlwaysSilent, .ownerSilent, .overran, .budgetExhausted, .other,
+    ])
+    func finalCheckReasons(reason: Policy.StopReason) {
+        #expect(reason.deservesFinalLandingCheck)
+    }
+
+    @Test("Reasons that prove the item did not land skip the final check", arguments: [
+        Policy.StopReason.refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded,
+    ])
+    func noFinalCheckReasons(reason: Policy.StopReason) {
+        #expect(!reason.deservesFinalLandingCheck)
+    }
+
+    @Test("Only silence is filed against the owner")
+    func onlySilenceIsFiled() {
+        let filed: [Policy.StopReason] = [.ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent]
+        let notFiled: [Policy.StopReason] = [.refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other]
+        let everyFiledReasonIsFiled = filed.allSatisfy(\.isFiledAgainstOwner)
+        let noOtherReasonIsFiled = notFiled.allSatisfy { !$0.isFiledAgainstOwner }
+        #expect(everyFiledReasonIsFiled)
+        #expect(noOtherReasonIsFiled)
+    }
+
+    // MARK: Error mapping
+
+    private func makeItem() -> MenuBarItem {
+        .fixture(tag: .appItem(bundleID: "com.example.IconSwitcher", title: "Item-0"), windowID: 2314)
+    }
+
+    @Test("Attempt errors reduce to the failure the policy reasons about")
+    func attemptFailureMapping() {
+        let item = makeItem()
+        #expect(Policy.attemptFailure(for: .itemResponseTimeout(item)) == .ownerSilent)
+        #expect(Policy.attemptFailure(for: .eventOperationTimeout(item)) == .ownerSilent)
+        #expect(Policy.attemptFailure(for: .ownerUnresponsive(item)) == .ownerUnresponsive)
+        #expect(Policy.attemptFailure(for: .missingItemBounds(item)) == .itemGone)
+        #expect(Policy.attemptFailure(for: .missingDestinationBounds(item)) == .destinationGone)
+        #expect(Policy.attemptFailure(for: .moveSuperseded(item)) == .superseded)
+        #expect(Policy.attemptFailure(for: .moveTimedOut(item)) == .overran)
+        #expect(Policy.attemptFailure(for: .cannotComplete) == .other)
+    }
+
+    @Test("Stop reasons throw the error callers already handle", arguments: [
+        (Policy.StopReason.refusedByMacOS, "dropReverted"),
+        (.targetMoved, "staleDestination"),
+        (.targetRetreating, "staleDestination"),
+        (.ownerUnresponsive, "ownerUnresponsive"),
+        (.itemGone, "missingItemBounds"),
+        (.destinationGone, "missingDestinationBounds"),
+        (.superseded, "moveSuperseded"),
+        (.overran, "moveTimedOut"),
+        (.budgetExhausted, "cannotComplete"),
+        (.ownerSilent, "cannotComplete"),
+        (.other, "cannotComplete"),
+    ])
+    func stopReasonErrors(reason: Policy.StopReason, expected: String) {
+        let thrown = MenuBarItemManager.moveError(for: reason, item: makeItem(), lastError: nil)
+        let description = String(describing: thrown)
+        #expect(description.contains(expected), "\(reason.logString) threw \(description)")
+    }
+
+    /// Silence rethrows the attempt's own timeout, so the caller keeps
+    /// seeing the error it saw before.
+    @Test("Silence rethrows the attempt's own error")
+    func silenceRethrowsTheAttemptError() {
+        let item = makeItem()
+        let last = MenuBarItemManager.EventError.itemResponseTimeout(item)
+        let thrown = MenuBarItemManager.moveError(for: .ownerSilent, item: item, lastError: last)
+        let description = String(describing: thrown)
+        #expect(description.contains("itemResponseTimeout"))
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -97,6 +97,7 @@ $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Notch
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+TemporaryShow.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemNameMemory.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemServiceConnection.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemTag+TriggerIdentity.swift


### PR DESCRIPTION
# Summary

Introduces a pure decision model for menu-bar moves so each attempt produces an explicit observation and each terminal result has a named reason. The model distinguishes verified landings, displacement without landing, macOS reverting a drop, source or destination disappearance, owner silence, a hung owner, supersession, deadline overrun, stale or retreating targets, and exhausted retry budgets.

Move failures are also attributed more carefully. Timeouts from Control Center-hosted or provisionally identified items no longer create a persistent mark against the source app, successful landings clear both failure and refusal state, and the failure-ledger rule version invalidates marks created by the older attribution rule. When macOS repeatedly restores an item to its old position, saved-order persistence retains the intended slot instead of learning the refused position.

**Scope:** This PR changes 7 files with 917 insertions and 7 deletions. It adds the policy, outcome/error mapping, refusal persistence, failure-attribution migration, Swift Testing coverage, and the generated SwiftLint input entry. It deliberately does not replace the live retry loop yet; #1000 performs that integration after the transport prerequisites. LayoutApply batch coordination and Layout Bar UI transitions remain out of scope. This may be suitable for 2.2.

Stack dependency: this PR is based on #996 to preserve the series' linear review order. It has no code dependency on #996 and can be rebased directly onto `development` after that predecessor merges.

## Linked issue (required)

Closes: N/A

Related: #881, #900, #924, #927

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [x] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- `MovePolicy` folds plain-value attempt observations into `succeed`, `retry`, or a named terminal reason, making field-log sequences replayable without a live menu bar.
- Consecutive releases that restore the starting origin are classified separately from an owner that never responds.
- Source disappearance and destination-anchor disappearance produce distinct errors, so a stale destination is not blamed on the item being moved.
- Target travel, same-direction retreat, owner silence, standing silence records, supersession, deadline overrun, and budget exhaustion have explicit retry or stop behavior.
- Only genuine app-owner silence can earn an unresponsive-owner mark. Control Center-hosted items and provisional identities are filed as non-owner failures.
- A rule-version component invalidates persisted marks produced by the previous attribution logic.
- A refused-move record temporarily prevents saved-order persistence from adopting the position macOS restored; a verified success clears it.
- The policy and attribution rules are covered by Swift Testing, including parameterized error mapping and refusal-state lifecycle behavior.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build -quiet -project Thaw.xcodeproj -scheme Thaw -destination 'generic/platform=macOS' -derivedDataPath /tmp/ThawMovementFinalBuildData -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -quiet -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawMovementFinalBuildData -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/MovePolicyTests -only-testing:ThawTests/MoveFailureAttributionTests -only-testing:ThawTests/MoveEndpointIdentityTests -only-testing:ThawTests/MoveGatePreflightTests -only-testing:ThawTests/MoveGestureTests -only-testing:ThawTests/MoveLayoutSettlingTests -only-testing:ThawTests/MoveEventCoordinatesTests -only-testing:ThawTests/MoveOperationTimeoutTests -only-testing:ThawTests/MoveMenuGuardTests -only-testing:ThawTests/MoveFailureBackoffTests -only-testing:ThawTests/MenuBarItemFailureLedgerTests`

The final-stack run passed 97 selected test methods and 130 parameterized runs with no failures or skips. The suites most directly covering this PR accounted for 54 methods and 87 runs: 26 policy methods/53 runs, 7 attribution methods/13 runs, 18 failure-ledger methods, and 3 failure-backoff methods. This commit also compiled independently at its stack point. The final macOS build passed; SwiftFormat lint passed for every changed Swift file; strict SwiftLint reported 0 violations; the generated SwiftLint input list and `git diff --check` matched cleanly.

## Known limitations / follow-ups

- This PR defines the policy and persistence rules but does not yet drive the live movement loop; #1000 performs that integration after the transport prerequisites land.
- Synthetic menu-bar movement still depends on private macOS behavior and can be refused by individual owners or Control Center.
- Trigger-owned movement, automatic failure reporting, LayoutApply batch/cancellation coordination, cache transactions, and Layout Bar UI stabilization are intentionally separate follow-ups.
- This stacked PR should remain based on #996 until that predecessor merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or interactive menu-bar run was performed for this PR; verification was through the automated tests, builds, formatting, lint, generated-file comparison, and diff checks above.

The commit includes a `Signed-off-by` trailer for the project's DCO requirement. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 5 of 12  
**Git base:** #996  
**Functional dependencies:** None at runtime; #996 is the linear Git base.
