### PR TITLE
fix(menubar): serialize and preflight menu bar moves

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -29,6 +29,18 @@ extension MenuBarItemManager {
             }
         }
 
+        /// Rebuilds the same logical side against a freshly enumerated
+        /// destination window. The plan retains its original identity while
+        /// event construction uses the newest record for that identity.
+        func replacingTarget(with item: MenuBarItem) -> Self {
+            switch self {
+            case .leftOfItem:
+                .leftOfItem(item)
+            case .rightOfItem:
+                .rightOfItem(item)
+            }
+        }
+
         /// Returns the drag point for placing an item relative to the target bounds.
         ///
         /// Targets parked beyond the display's left edge use their vertical
@@ -183,25 +195,91 @@ extension MenuBarItemManager {
         _ candidate: MenuBarItem,
         expected: MenuBarItem
     ) -> Bool {
-        guard
-            candidate.windowID == expected.windowID,
-            candidate.ownerPID == expected.ownerPID,
-            candidate.tag.matchesIgnoringWindowID(expected.tag)
-        else {
-            return false
-        }
-        if let expectedSourcePID = expected.sourcePID {
-            return candidate.sourcePID == expectedSourcePID
-        }
-        return true
+        candidate.windowID == expected.windowID
+            && candidate.ownerPID == expected.ownerPID
+            && candidate.sourcePID == expected.sourcePID
+            && candidate.tag == expected.tag
     }
 
-    static nonisolated func currentMoveEndpoint(
+    /// Fresh source and destination records from one coherent WindowServer
+    /// snapshot.
+    nonisolated struct CurrentMoveEndpoints: Equatable {
+        let source: MenuBarItem
+        let target: MenuBarItem
+        let snapshot: [MenuBarItem]
+
+        func destination(matching planned: MoveDestination) -> MoveDestination {
+            planned.replacingTarget(with: target)
+        }
+    }
+
+    nonisolated enum MoveEndpointResolutionError: Error, Equatable {
+        case missingSource
+        case missingDestination
+        case recycledSource
+        case recycledDestination
+    }
+
+    static nonisolated func currentMoveEndpoints(
         in items: [MenuBarItem],
-        expected: MenuBarItem
-    ) -> MenuBarItem? {
-        let matches = items.filter { moveEndpointIsCurrent($0, expected: expected) }
-        return matches.count == 1 ? matches[0] : nil
+        expectedSource: MenuBarItem,
+        expectedDestination: MenuBarItem
+    ) -> Result<CurrentMoveEndpoints, MoveEndpointResolutionError> {
+        func resolve(
+            _ expected: MenuBarItem,
+            missing: MoveEndpointResolutionError,
+            recycled: MoveEndpointResolutionError
+        ) -> Result<MenuBarItem, MoveEndpointResolutionError> {
+            let sameID = items.filter { $0.windowID == expected.windowID }
+            guard !sameID.isEmpty else {
+                return .failure(missing)
+            }
+            let exact = sameID.filter { moveEndpointIsCurrent($0, expected: expected) }
+            guard exact.count == 1 else {
+                return .failure(recycled)
+            }
+            return .success(exact[0])
+        }
+
+        let source: MenuBarItem
+        switch resolve(expectedSource, missing: .missingSource, recycled: .recycledSource) {
+        case let .success(item):
+            source = item
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        let target: MenuBarItem
+        switch resolve(expectedDestination, missing: .missingDestination, recycled: .recycledDestination) {
+        case let .success(item):
+            target = item
+        case let .failure(error):
+            return .failure(error)
+        }
+
+        guard source.windowID != target.windowID else {
+            return .failure(.recycledDestination)
+        }
+        return .success(CurrentMoveEndpoints(source: source, target: target, snapshot: items))
+    }
+
+    static nonisolated func endpointsHaveCorrectPosition(
+        _ endpoints: CurrentMoveEndpoints,
+        for destination: MoveDestination
+    ) -> Bool {
+        guard let indices = moveEndpointIndices(
+            in: endpoints.snapshot,
+            sourceWindowID: endpoints.source.windowID,
+            destinationWindowID: endpoints.target.windowID
+        ) else {
+            return false
+        }
+        return switch destination {
+        case .leftOfItem:
+            indices.source == indices.destination - 1
+        case .rightOfItem:
+            indices.source == indices.destination + 1
+        }
     }
 
     /// Serializes complete move transactions app-wide. Serializing only event
@@ -214,6 +292,10 @@ extension MenuBarItemManager {
 
     private static let moveGateTimeout: Duration = .seconds(15)
 
+    /// User activity can defer one move without retaining the app-wide move
+    /// permit indefinitely.
+    static nonisolated let moveInputPauseLimit: Duration = .seconds(2)
+
     /// Runs a caller's gate-owned completion hook before another move can enter.
     static func performMoveGateExitActions(
         didFinishWhileHoldingGate: (@MainActor () -> Void)?,
@@ -221,6 +303,35 @@ extension MenuBarItemManager {
     ) {
         didFinishWhileHoldingGate?()
         releaseGate()
+    }
+
+    /// Performs admission work before acquiring the app-wide move gate.
+    /// Nested recovery moves already own the gate and enter directly.
+    static func performWithMoveGate(
+        timeout: Duration = moveGateTimeout,
+        timeoutProvider: (@MainActor () throws -> Duration)? = nil,
+        waitBeforeGate: @MainActor () async throws -> Void = {},
+        didFinishWhileHoldingGate: (@MainActor () -> Void)? = nil,
+        operation: @MainActor () async throws -> Void
+    ) async throws {
+        if holdsMoveGate {
+            try await operation()
+            return
+        }
+
+        try await waitBeforeGate()
+        try await moveGate.wait(timeout: timeoutProvider?() ?? timeout)
+        defer {
+            performMoveGateExitActions(
+                didFinishWhileHoldingGate: didFinishWhileHoldingGate,
+                releaseGate: {
+                    Task.detached { await moveGate.signal() }
+                }
+            )
+        }
+        try await $holdsMoveGate.withValue(true) {
+            try await operation()
+        }
     }
 
     /// Returns the default timeout for move operations associated
@@ -389,16 +500,45 @@ extension MenuBarItemManager {
         return bounds
     }
 
+    /// Re-enumerates both planned endpoints with source ownership resolved and
+    /// returns fresh records from the same snapshot.
+    private func resolveCurrentMoveEndpoints(
+        source expectedSource: MenuBarItem,
+        destination expectedDestination: MenuBarItem,
+        on displayID: CGDirectDisplayID
+    ) async throws -> CurrentMoveEndpoints {
+        let items = await MenuBarItem.getMenuBarItems(
+            on: displayID,
+            option: .activeSpace,
+            resolveSourcePID: true
+        ).filter { !$0.isSystemClone }
+        switch Self.currentMoveEndpoints(
+            in: items,
+            expectedSource: expectedSource,
+            expectedDestination: expectedDestination
+        ) {
+        case let .success(endpoints):
+            return endpoints
+        case .failure(.missingSource):
+            throw EventError.missingItemBounds(expectedSource)
+        case .failure(.missingDestination):
+            throw EventError.missingDestinationBounds(expectedDestination)
+        case .failure(.recycledDestination):
+            throw EventError.staleDestination(expectedSource)
+        case .failure(.recycledSource):
+            throw EventError.moveSuperseded(expectedSource)
+        }
+    }
+
     /// Returns the target points for creating the events needed to
     /// move a menu bar item to the given destination.
     private nonisolated func getTargetPoints(
         forMoving item: MenuBarItem,
         to destination: MoveDestination,
+        itemBounds: CGRect,
+        targetBounds: CGRect,
         on displayID: CGDirectDisplayID
-    ) async throws -> (start: CGPoint, end: CGPoint) {
-        let itemBounds = try exactMoveBounds(for: item)
-        let targetBounds = try exactMoveBounds(for: destination.targetItem, isDestination: true)
-
+    ) -> (start: CGPoint, end: CGPoint) {
         let start = destination.targetPoint(
             in: targetBounds,
             on: CGDisplayBounds(displayID)
@@ -442,27 +582,12 @@ extension MenuBarItemManager {
         for destination: MoveDestination,
         on displayID: CGDirectDisplayID
     ) async throws -> Bool {
-        // Not `.onScreen`: an item moved into a collapsed section is parked
-        // offscreen, and that is a landing we still have to be able to confirm.
-        let items = await MenuBarItem.getMenuBarItems(
-            on: displayID,
-            option: .activeSpace,
-            resolveSourcePID: false
-        ).filter { !$0.isSystemClone }
-        guard let indices = Self.moveEndpointIndices(
-            in: items,
-            sourceWindowID: item.windowID,
-            destinationWindowID: destination.targetItem.windowID
-        ) else {
-            // One endpoint no longer enumerates on this display's active
-            // space, or equal-X geometry makes its order ambiguous.
-            return false
-        }
-
-        return switch destination {
-        case .leftOfItem: indices.source == indices.destination - 1
-        case .rightOfItem: indices.source == indices.destination + 1
-        }
+        let endpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        return Self.endpointsHaveCorrectPosition(endpoints, for: destination)
     }
 
     /// Waits for a menu bar item to respond to a series of previously
@@ -527,8 +652,7 @@ extension MenuBarItemManager {
         item: MenuBarItem,
         destination: MoveDestination,
         on displayID: CGDirectDisplayID,
-        warpCursorAfter: Bool = true,
-        releaseGuard: PressReleaseGuard? = nil
+        warpCursorAfter: Bool = true
     ) async throws -> Duration {
         var acquiredSemaphore = false
         do {
@@ -550,10 +674,26 @@ extension MenuBarItemManager {
             }
         }
 
+        // Event-transport admission can take seconds. Resolve both exact
+        // identities again before using any endpoint geometry.
+        let initialEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        let initialDestination = initialEndpoints.destination(matching: destination)
+        let initialTargetPoints = getTargetPoints(
+            forMoving: initialEndpoints.source,
+            to: initialDestination,
+            itemBounds: initialEndpoints.source.bounds,
+            targetBounds: initialEndpoints.target.bounds,
+            on: displayID
+        )
+
         // Fast-fail if the target process is dead. CGEvent.tapCreateForPid
         // silently produces an invalid Mach port for dead PIDs, causing every
         // scrombleEvent to time out and burn the full 3.5 s semaphore budget.
-        let eventPID = getEventPID(for: item)
+        let eventPID = getEventPID(for: initialEndpoints.source)
         if kill(eventPID, 0) == -1, errno == ESRCH {
             MenuBarItemManager.diagLog.error("postMoveEvents: target PID \(eventPID) for \(item.logString) is dead; skipping move")
             throw EventError.cannotComplete
@@ -574,10 +714,6 @@ extension MenuBarItemManager {
             throw EventError.ownerUnresponsive(item)
         }
 
-        let itemBounds = try exactMoveBounds(for: item)
-        var itemOrigin = itemBounds.origin
-        let targetPoints = try await getTargetPoints(forMoving: item, to: destination, on: displayID)
-
         // Press and release at the *destination* (targetPoints.start == .end
         // == the target edge) with the moved item's window ID stamped on the
         // press, relying on the owner to relocate its item to the press
@@ -586,40 +722,15 @@ extension MenuBarItemManager {
         // second teleported it. A drag-gesture geometry was trialled behind
         // a setting to remove that warm-up and did not fix it, so it was
         // withdrawn; the warm-up attempt remains an open problem.
-        let eventLocations = Self.moveEventLocations(
-            targetPoints: targetPoints,
+        let initialEventLocations = Self.moveEventLocations(
+            targetPoints: initialTargetPoints,
             faithfulDragStart: nil
         )
-        let pressPoint = eventLocations.press
 
         // Capture mouse location only when this call owns the cursor warp.
         // When called from move(), the outer move() handles the single warp
         // at the end of all attempts so the cursor doesn't oscillate per attempt.
         let mouseLocation: CGPoint? = warpCursorAfter ? try getMouseLocation() : nil
-        let source = try getEventSource()
-
-        try permitLocalEvents()
-
-        guard
-            let mouseDown = CGEvent.menuBarItemEvent(
-                item: item,
-                source: source,
-                type: .move(.mouseDown),
-                location: pressPoint
-            ),
-            let mouseUp = CGEvent.menuBarItemEvent(
-                item: destination.targetItem,
-                source: source,
-                type: .move(.mouseUp),
-                location: eventLocations.release
-            )
-        else {
-            throw EventError.eventCreationFailure(item)
-        }
-
-        var timeout = getMoveOperationTimeout(for: item)
-        MenuBarItemManager.diagLog.debug("Move operation timeout: \(timeout)")
-
         lastMoveOperationTimestamp = .now
         // Skip the warp when the target is offscreen (negative-X items in
         // hidden/always-hidden on notch displays). CGWarpMouseCursorPosition
@@ -628,7 +739,7 @@ extension MenuBarItemManager {
         // there. The 20ms eventSleep that follows the warp is only needed
         // when slow apps have to register the tracking events before the
         // mouseDown; irrelevant offscreen.
-        let warpPoint = pressPoint
+        let warpPoint = initialEventLocations.press
         let warpIsOnScreen = NSScreen.screens.contains {
             CGDisplayBounds($0.displayID).contains(warpPoint)
         }
@@ -673,48 +784,133 @@ extension MenuBarItemManager {
             lastMoveOperationTimestamp = .now
         }
 
+        // The cursor-registration wait is the final intentional await before
+        // the press. Re-resolve and construct the events from fresh records.
+        let endpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        let liveItem = endpoints.source
+        let liveDestination = endpoints.destination(matching: destination)
+        let itemBounds = liveItem.bounds
+        var itemOrigin = itemBounds.origin
+        let targetPoints = getTargetPoints(
+            forMoving: liveItem,
+            to: liveDestination,
+            itemBounds: itemBounds,
+            targetBounds: endpoints.target.bounds,
+            on: displayID
+        )
+        let eventLocations = Self.moveEventLocations(
+            targetPoints: targetPoints,
+            faithfulDragStart: nil
+        )
+        if warpIsOnScreen, eventLocations.press != warpPoint {
+            MouseHelpers.warpCursor(to: eventLocations.press)
+        }
+        let source = try getEventSource()
+        try permitLocalEvents()
+        guard
+            let mouseDown = CGEvent.menuBarItemEvent(
+                item: liveItem,
+                source: source,
+                type: .move(.mouseDown),
+                location: eventLocations.press
+            ),
+            let mouseUp = CGEvent.menuBarItemEvent(
+                item: endpoints.target,
+                source: source,
+                type: .move(.mouseUp),
+                location: eventLocations.release
+            )
+        else {
+            throw EventError.eventCreationFailure(liveItem)
+        }
+
+        var timeout = getMoveOperationTimeout(for: liveItem)
+        MenuBarItemManager.diagLog.debug("Move operation timeout: \(timeout)")
+        let releaseGuard = makePressReleaseGuard(
+            for: liveItem,
+            mouseUp: mouseUp,
+            eventPID: eventPID
+        )
+
         // From here the press may be down; a deadline guard posts a matching
         // release even if the async attempt stops making progress.
-        releaseGuard?.arm()
+        releaseGuard.arm()
         do {
             try await scrombleEvent(
                 mouseDown,
-                item: item,
+                item: liveItem,
                 timeout: timeout
             )
             itemOrigin = try await waitForMoveEventResponse(
-                from: item,
+                from: liveItem,
                 initialOrigin: itemOrigin,
                 timeout: timeout
             )
+
+            // Reflow after the opening press can move the target edge. Release
+            // against a newly resolved exact endpoint rather than stale bounds.
+            let releaseEndpoints = try await resolveCurrentMoveEndpoints(
+                source: item,
+                destination: destination.targetItem,
+                on: displayID
+            )
+            let releaseDestination = releaseEndpoints.destination(matching: destination)
+            let releasePoints = getTargetPoints(
+                forMoving: releaseEndpoints.source,
+                to: releaseDestination,
+                itemBounds: releaseEndpoints.source.bounds,
+                targetBounds: releaseEndpoints.target.bounds,
+                on: displayID
+            )
+            guard let liveMouseUp = CGEvent.menuBarItemEvent(
+                item: releaseEndpoints.target,
+                source: source,
+                type: .move(.mouseUp),
+                location: releasePoints.end
+            ) else {
+                throw EventError.eventCreationFailure(releaseEndpoints.source)
+            }
             try await scrombleEvent(
-                mouseUp,
-                item: item,
+                liveMouseUp,
+                item: releaseEndpoints.source,
                 timeout: timeout,
                 repeating: 2 // Double mouse up prevents invalid item state.
             )
+            releaseGuard.recordReleaseAttempt(delivered: true)
             itemOrigin = try await waitForMoveEventResponse(
-                from: item,
+                from: releaseEndpoints.source,
                 initialOrigin: itemOrigin,
                 timeout: timeout
             )
         } catch {
+            let attemptError = error
             do {
                 MenuBarItemManager.diagLog.warning("Move events failed, posting fallback")
                 try await scrombleEvent(
                     mouseUp,
-                    item: item,
+                    item: liveItem,
                     timeout: .milliseconds(100), // Fixed timeout for fallback.
                     repeating: 2 // Double mouse up prevents invalid item state.
                 )
-            } catch {
-                // Catch this for logging purposes only. We want to propagate
-                // the original error.
-                MenuBarItemManager.diagLog.error("Fallback failed with error: \(error)")
+                releaseGuard.recordReleaseAttempt(delivered: true)
+            } catch let fallbackError {
+                // Keep the guard armed so its independent raw post remains
+                // the final release path.
+                MenuBarItemManager.diagLog.error("Fallback failed with error: \(fallbackError)")
             }
             timeout = Self.nextMoveOperationTimeout(after: timeout, outcome: .ownerDidNotRespond)
-            updateMoveOperationTimeout(timeout, for: item)
-            throw error
+            updateMoveOperationTimeout(timeout, for: liveItem)
+            if releaseGuard.didFire {
+                throw EventError.moveTimedOut(item)
+            }
+            throw attemptError
+        }
+        guard !releaseGuard.didFire else {
+            throw EventError.moveTimedOut(item)
         }
         return timeout
     }
@@ -723,7 +919,7 @@ extension MenuBarItemManager {
     /// Items in this state are stuck and cannot be interacted with normally.
     private nonisolated func isItemBlocked(_ item: MenuBarItem) async -> Bool {
         do {
-            let bounds = try await getCurrentBounds(for: item)
+            let bounds = try exactMoveBounds(for: item)
             // x=-1 is the sentinel value macOS uses for "blocked" items
             return bounds.origin.x == -1
         } catch {
@@ -890,44 +1086,79 @@ extension MenuBarItemManager {
     /// progress. A dangling press can turn the user's next real click into the
     /// end of a drag, including a drag that removes the status item.
     final nonisolated class PressReleaseGuard: Sendable {
+        typealias Scheduler = @Sendable (
+            _ deadline: Duration,
+            _ action: @escaping @Sendable () -> Void
+        ) -> Void
+
+        enum State: Equatable {
+            case idle
+            case armed
+            case releaseConfirmed
+            case fired
+        }
+
         private nonisolated struct Status {
-            var isArmed = false
-            var didFire = false
+            var state = State.idle
         }
 
         private let status = OSAllocatedUnfairLock(initialState: Status())
         private let deadline: Duration
-        private let events: PressReleaseEvents
         private let item: MenuBarItem
+        private let scheduler: Scheduler
+        private let postSafetyRelease: @Sendable () -> Void
 
         init(deadline: Duration, events: PressReleaseEvents, item: MenuBarItem) {
             self.deadline = deadline
-            self.events = events
             self.item = item
+            scheduler = { deadline, action in
+                let milliseconds = max(1, Int(deadline.milliseconds))
+                DispatchQueue.global(qos: .userInitiated).asyncAfter(
+                    deadline: .now() + .milliseconds(milliseconds),
+                    execute: action
+                )
+            }
+            postSafetyRelease = {
+                events.mouseUp.post(to: .sessionEventTap)
+                events.mouseUp.post(to: .pid(events.pid))
+            }
+        }
+
+        /// Test seam for driving the watchdog without sleeping or posting a
+        /// real Core Graphics event.
+        init(
+            deadline: Duration,
+            item: MenuBarItem,
+            scheduler: @escaping Scheduler,
+            postSafetyRelease: @escaping @Sendable () -> Void
+        ) {
+            self.deadline = deadline
+            self.item = item
+            self.scheduler = scheduler
+            self.postSafetyRelease = postSafetyRelease
         }
 
         func arm() {
             let armed = status.withLock { status -> Bool in
-                guard !status.isArmed, !status.didFire else {
+                guard status.state == .idle else {
                     return false
                 }
-                status.isArmed = true
+                status.state = .armed
                 return true
             }
             guard armed else {
                 return
             }
             let status = status
-            let events = events
             let item = item
             let milliseconds = max(1, Int(deadline.milliseconds))
-            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(milliseconds)) {
+            let postSafetyRelease = postSafetyRelease
+            scheduler(deadline) {
                 let fires = status.withLock { status -> Bool in
-                    guard status.isArmed else {
+                    guard status.state == .armed else {
                         return false
                     }
-                    status.isArmed = false
-                    status.didFire = true
+                    status.state = .fired
                     return true
                 }
                 guard fires else {
@@ -936,44 +1167,42 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.warning(
                     "Press on \(item.logString) outlived its \(milliseconds) ms deadline; releasing it"
                 )
-                events.mouseUp.post(to: .sessionEventTap)
-                events.mouseUp.post(to: .pid(events.pid))
+                postSafetyRelease()
             }
         }
 
         var didFire: Bool {
-            status.withLock(\.didFire)
+            status.withLock { $0.state == .fired }
         }
 
-        func disarm() {
-            status.withLock { $0.isArmed = false }
+        var state: State {
+            status.withLock(\.state)
+        }
+
+        /// Cancels the independent safety post only after an acknowledged
+        /// mouse-up. A failed normal or fallback release leaves it armed.
+        func recordReleaseAttempt(delivered: Bool) {
+            guard delivered else {
+                return
+            }
+            status.withLock { status in
+                guard status.state == .armed else {
+                    return
+                }
+                status.state = .releaseConfirmed
+            }
         }
     }
 
     /// Builds the independent safety release for one attempt.
     private func makePressReleaseGuard(
         for item: MenuBarItem,
-        destination: MoveDestination,
-        on displayID: CGDirectDisplayID
-    ) async -> PressReleaseGuard? {
-        guard
-            let targetBounds = try? exactMoveBounds(for: destination.targetItem, isDestination: true),
-            let source = try? getEventSource(),
-            let mouseUp = CGEvent.menuBarItemEvent(
-                item: destination.targetItem,
-                source: source,
-                type: .move(.mouseUp),
-                location: destination.targetPoint(in: targetBounds, on: CGDisplayBounds(displayID))
-            )
-        else {
-            MenuBarItemManager.diagLog.warning(
-                "No release event could be built for \(item.logString); the press runs unguarded"
-            )
-            return nil
-        }
+        mouseUp: CGEvent,
+        eventPID: pid_t
+    ) -> PressReleaseGuard {
         return PressReleaseGuard(
             deadline: Self.pressReleaseDeadline(for: getMoveOperationTimeout(for: item)),
-            events: PressReleaseEvents(mouseUp: mouseUp, pid: getEventPID(for: item)),
+            events: PressReleaseEvents(mouseUp: mouseUp, pid: eventPID),
             item: item
         )
     }
@@ -992,44 +1221,72 @@ extension MenuBarItemManager {
         skipInputPause: Bool = false,
         options: MoveOptions = .init()
     ) async throws {
-        // Serialize the whole move, including retries and verification. A
-        // nested recovery move inherits task-local ownership and cannot wait
-        // on itself.
+        // Admission waits for a bounded input lull before taking the app-wide
+        // permit. Nested recovery moves already own the gate.
         if !Self.holdsMoveGate {
-            let waitStartedAt = ContinuousClock.now
             do {
-                try await Self.moveGate.wait(timeout: Self.moveGateTimeout)
+                try await Self.performWithMoveGate(
+                    waitBeforeGate: {
+                        guard !skipInputPause else {
+                            return
+                        }
+                        let waitTask = Task(timeout: Self.moveInputPauseLimit) {
+                            try await self.waitForUserToPauseInput(
+                                for: options.requiredInputPause,
+                                timeout: options.inputPauseTimeout,
+                                shouldContinue: options.shouldProceed
+                            )
+                        }
+                        do {
+                            switch try await waitTask.value {
+                            case .paused:
+                                break
+                            case .timedOut:
+                                throw EventError.inputPauseTimedOut(item)
+                            case .superseded:
+                                throw EventError.moveSuperseded(item)
+                            }
+                        } catch let error as EventError {
+                            throw error
+                        } catch {
+                            MenuBarItemManager.diagLog.debug(
+                                "move: input did not pause within \(Self.moveInputPauseLimit) for \(item.logString)"
+                            )
+                            throw EventError.cannotComplete
+                        }
+                    },
+                    didFinishWhileHoldingGate: options.didFinishWhileHoldingGate,
+                    operation: {
+                        // Input can resume while queued. Recheck once without
+                        // waiting while the gate is held.
+                        if !skipInputPause {
+                            let pauseMs = max(
+                                0,
+                                (Defaults.object(forKey: .inputPauseThresholdMs) as? Int)
+                                    ?? Defaults.DefaultValue.inputPauseThresholdMs
+                            )
+                            guard self.hasUserPausedInput(for: .milliseconds(pauseMs)) else {
+                                throw EventError.cannotComplete
+                            }
+                        }
+                        var nestedOptions = options
+                        nestedOptions.didFinishWhileHoldingGate = nil
+                        try await self.move(
+                            item: item,
+                            to: destination,
+                            on: displayID,
+                            skipInputPause: true,
+                            options: nestedOptions
+                        )
+                    }
+                )
             } catch is SimpleSemaphore.TimeoutError {
                 MenuBarItemManager.diagLog.error(
                     "move: another move has held the bar for \(Self.moveGateTimeout); giving up on \(item.logString)"
                 )
                 throw EventError.moveEngineBusy(item)
             }
-            defer {
-                Self.performMoveGateExitActions(
-                    didFinishWhileHoldingGate: options.didFinishWhileHoldingGate,
-                    releaseGate: {
-                        Task.detached { await Self.moveGate.signal() }
-                    }
-                )
-            }
-            let waited = ContinuousClock.now - waitStartedAt
-            if waited > .milliseconds(100) {
-                MenuBarItemManager.diagLog.debug(
-                    "move: waited \(Int(waited.milliseconds)) ms for another move to finish before moving \(item.logString)"
-                )
-            }
-            return try await Self.$holdsMoveGate.withValue(true) {
-                var nestedOptions = options
-                nestedOptions.didFinishWhileHoldingGate = nil
-                return try await move(
-                    item: item,
-                    to: destination,
-                    on: displayID,
-                    skipInputPause: skipInputPause,
-                    options: nestedOptions
-                )
-            }
+            return
         }
 
         // Evaluate once, only after the transaction owns the gate. A caller
@@ -1103,40 +1360,16 @@ extension MenuBarItemManager {
             Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
         }
 
-        // The plan may have waited behind another move. Resolve both endpoints
-        // again on the selected display and require the same window, owner,
-        // stable tag, and resolved source. A same-tag replacement needs a new
-        // plan; it is never a silent transport fallback.
-        let liveEndpoints = await MenuBarItem.getMenuBarItems(
-            on: resolvedDisplayID,
-            option: .activeSpace,
-            resolveSourcePID: true
-        ).filter { !$0.isSystemClone }
-        guard Self.currentMoveEndpoint(in: liveEndpoints, expected: item) != nil else {
-            throw EventError.missingItemBounds(item)
-        }
-        guard Self.currentMoveEndpoint(
-            in: liveEndpoints,
-            expected: destination.targetItem
-        ) != nil else {
-            throw EventError.missingDestinationBounds(destination.targetItem)
-        }
-
-        if !skipInputPause {
-            let inputPauseResult = try await waitForUserToPauseInput(
-                for: options.requiredInputPause,
-                timeout: options.inputPauseTimeout,
-                shouldContinue: options.shouldProceed
-            )
-            switch inputPauseResult {
-            case .paused:
-                break
-            case .timedOut:
-                throw EventError.inputPauseTimedOut(item)
-            case .superseded:
-                throw EventError.moveSuperseded(item)
-            }
-        }
+        // The plan may have waited behind another move (admission, gate
+        // waiting). Resolve both endpoints again on the selected display and
+        // require the same window, owner, stable tag, and resolved source.
+        // A same-tag replacement needs a new plan; it is never a silent
+        // transport fallback.
+        _ = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: resolvedDisplayID
+        )
         guard options.shouldProceed?() ?? true else {
             throw EventError.moveSuperseded(item)
         }
@@ -1226,7 +1459,6 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.debug("move: superseded before attempt \(n) for \(item.logString)")
                 throw EventError.moveSuperseded(item)
             }
-            var releaseGuard: PressReleaseGuard?
             do {
                 if try await itemHasCorrectPosition(item: item, for: destination, on: resolvedDisplayID) {
                     // On the first iteration trust the position match
@@ -1246,22 +1478,12 @@ extension MenuBarItemManager {
                     attemptMouseLocation = try getMouseLocation()
                     MouseHelpers.hideCursor(watchdogTimeout: options.watchdogTimeout ?? .seconds(2))
                 }
-                releaseGuard = await makePressReleaseGuard(
-                    for: item,
-                    destination: destination,
-                    on: resolvedDisplayID
-                )
                 let attemptTimeout = try await postMoveEvents(
                     item: item,
                     destination: destination,
                     on: resolvedDisplayID,
-                    warpCursorAfter: false, // move() owns the single warp in its defer
-                    releaseGuard: releaseGuard
+                    warpCursorAfter: false // move() owns the single warp in its defer
                 )
-                releaseGuard?.disarm()
-                guard releaseGuard?.didFire != true else {
-                    throw EventError.moveTimedOut(item)
-                }
                 // postMoveEvents only returns without throwing when both
                 // waitForMoveEventResponse calls observed origin changes,
                 // i.e. our drag actually displaced the item.
@@ -1351,13 +1573,6 @@ extension MenuBarItemManager {
                     continue
                 }
             } catch {
-                releaseGuard?.disarm()
-                if releaseGuard?.didFire == true {
-                    MenuBarItemManager.diagLog.warning(
-                        "Attempt \(n): the press on \(item.logString) outlived its deadline and was released"
-                    )
-                    throw EventError.moveTimedOut(item)
-                }
                 // missingItemBounds is definitive: getCurrentBounds already
                 // refreshed the on-screen items and re-matched by tag before
                 // throwing, so the item's window is genuinely gone (transient

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -10,6 +10,7 @@ import Cocoa
 
 // @preconcurrency: see the note in MenuBarItemManager.swift.
 @preconcurrency import CoreGraphics
+import os.lock
 
 // MARK: - Moving Items
 
@@ -107,16 +108,119 @@ extension MenuBarItemManager {
         }
     }
 
-    /// Returns a safe location for an off-screen move's initial mouse-down.
-    ///
-    /// `NSScreen` frames use AppKit coordinates, while `CGEvent` locations use
-    /// Core Graphics coordinates. Their horizontal axes align, so the notch
-    /// supplies only the x-coordinate; the target supplies the event's y-coordinate.
-    static nonisolated func notchMouseDownPoint(
-        notchFrameAppKit: CGRect,
-        targetPointCoreGraphics: CGPoint
-    ) -> CGPoint {
-        CGPoint(x: notchFrameAppKit.midX, y: targetPointCoreGraphics.y)
+    /// Final coordinates used to create the opening and closing events for a
+    /// move. A teleport has no visible intermediate press: its mouse-down is
+    /// stamped directly at the destination, including when that destination
+    /// is parked off-screen.
+    nonisolated struct MoveEventLocations: Equatable {
+        let press: CGPoint
+        let release: CGPoint
+    }
+
+    static nonisolated func moveEventLocations(
+        targetPoints: (start: CGPoint, end: CGPoint),
+        faithfulDragStart: CGPoint?
+    ) -> MoveEventLocations {
+        MoveEventLocations(
+            press: faithfulDragStart ?? targetPoints.start,
+            release: targetPoints.end
+        )
+    }
+
+    /// Exact ordinal positions from one WindowServer snapshot. Verification
+    /// never falls back to a same-tag window, because a relaunched or cloned
+    /// item is not the endpoint whose move acquired the gate.
+    nonisolated struct MoveEndpointIndices: Equatable {
+        let source: Int
+        let destination: Int
+    }
+
+    static nonisolated func moveEndpointIndices(
+        in items: [MenuBarItem],
+        sourceWindowID: CGWindowID,
+        destinationWindowID: CGWindowID
+    ) -> MoveEndpointIndices? {
+        guard sourceWindowID != destinationWindowID else {
+            return nil
+        }
+        guard
+            items.count(where: { $0.windowID == sourceWindowID }) == 1,
+            items.count(where: { $0.windowID == destinationWindowID }) == 1,
+            let sourceItem = items.first(where: { $0.windowID == sourceWindowID }),
+            let destinationItem = items.first(where: { $0.windowID == destinationWindowID })
+        else {
+            return nil
+        }
+
+        // An equal-X endpoint is mid-reflow or zero-width-overlapped. Giving
+        // it an arbitrary order by enumeration or window ID could certify the
+        // wrong side, so wait for a later settled snapshot instead.
+        guard
+            items.count(where: { $0.bounds.minX == sourceItem.bounds.minX }) == 1,
+            items.count(where: { $0.bounds.minX == destinationItem.bounds.minX }) == 1
+        else {
+            return nil
+        }
+
+        let sorted = items.sorted {
+            if $0.bounds.minX == $1.bounds.minX {
+                return $0.windowID < $1.windowID
+            }
+            return $0.bounds.minX < $1.bounds.minX
+        }
+        guard
+            let source = sorted.firstIndex(where: { $0.windowID == sourceWindowID }),
+            let destination = sorted.firstIndex(where: { $0.windowID == destinationWindowID })
+        else {
+            return nil
+        }
+        return MoveEndpointIndices(source: source, destination: destination)
+    }
+
+    /// Whether a freshly enumerated endpoint is still the exact item that was
+    /// planned before the move waited for the app-wide gate.
+    static nonisolated func moveEndpointIsCurrent(
+        _ candidate: MenuBarItem,
+        expected: MenuBarItem
+    ) -> Bool {
+        guard
+            candidate.windowID == expected.windowID,
+            candidate.ownerPID == expected.ownerPID,
+            candidate.tag.matchesIgnoringWindowID(expected.tag)
+        else {
+            return false
+        }
+        if let expectedSourcePID = expected.sourcePID {
+            return candidate.sourcePID == expectedSourcePID
+        }
+        return true
+    }
+
+    static nonisolated func currentMoveEndpoint(
+        in items: [MenuBarItem],
+        expected: MenuBarItem
+    ) -> MenuBarItem? {
+        let matches = items.filter { moveEndpointIsCurrent($0, expected: expected) }
+        return matches.count == 1 ? matches[0] : nil
+    }
+
+    /// Serializes complete move transactions app-wide. Serializing only event
+    /// posts lets two independent retry loops undo each other between attempts.
+    private static let moveGate = SimpleSemaphore(value: 1)
+
+    /// A blocked-item recovery may call `move` while its parent still owns the
+    /// gate; task-local ownership lets that nested move pass through safely.
+    @TaskLocal private static var holdsMoveGate = false
+
+    private static let moveGateTimeout: Duration = .seconds(15)
+
+    /// Runs a caller's gate-owned completion hook before another move can enter.
+    static func performMoveGateExitActions(
+        didFinishWhileHoldingGate: (@MainActor () -> Void)?,
+        releaseGate: () -> Void
+    ) {
+        didFinishWhileHoldingGate?()
+        releaseGate()
     }
 
     /// Returns the default timeout for move operations associated
@@ -269,6 +373,22 @@ extension MenuBarItemManager {
         clickOperationTimeouts = clickOperationTimeouts.filter { validTags.contains($0.key) }
     }
 
+    /// Reads geometry only from the exact WindowServer window selected by the
+    /// move plan. A same-tag replacement may belong to a relaunch or clone and
+    /// must be left for a fresh cache cycle to plan.
+    private nonisolated func exactMoveBounds(
+        for item: MenuBarItem,
+        isDestination: Bool = false
+    ) throws -> CGRect {
+        guard let bounds = Bridging.getWindowBounds(for: item.windowID) else {
+            if isDestination {
+                throw EventError.missingDestinationBounds(item)
+            }
+            throw EventError.missingItemBounds(item)
+        }
+        return bounds
+    }
+
     /// Returns the target points for creating the events needed to
     /// move a menu bar item to the given destination.
     private nonisolated func getTargetPoints(
@@ -276,8 +396,8 @@ extension MenuBarItemManager {
         to destination: MoveDestination,
         on displayID: CGDirectDisplayID
     ) async throws -> (start: CGPoint, end: CGPoint) {
-        let itemBounds = try await getCurrentBounds(for: item)
-        let targetBounds = try await getCurrentBounds(for: destination.targetItem)
+        let itemBounds = try exactMoveBounds(for: item)
+        let targetBounds = try exactMoveBounds(for: destination.targetItem, isDestination: true)
 
         let start = destination.targetPoint(
             in: targetBounds,
@@ -307,10 +427,9 @@ extension MenuBarItemManager {
     /// moved (#900).
     ///
     /// Reading one list fixes that: both operands come from the same snapshot,
-    /// so they cannot drift apart mid-check. It also sidesteps
-    /// ``getCurrentBounds(for:)`` mixing coordinate spaces — its windowID path
-    /// answers for parked offscreen windows while its tag-matching fallback
-    /// answers from the on-screen list, and which one runs depends on timing.
+    /// so they cannot drift apart mid-check. Both endpoints are matched by
+    /// exact window ID; equal-X endpoints remain unverified rather than being
+    /// assigned an arbitrary order while the bar is reflowing.
     ///
     /// - Note: source PIDs are deliberately left unresolved. Only tags, window
     ///   IDs and bounds are needed here, and this runs once per attempt.
@@ -325,30 +444,24 @@ extension MenuBarItemManager {
     ) async throws -> Bool {
         // Not `.onScreen`: an item moved into a collapsed section is parked
         // offscreen, and that is a landing we still have to be able to confirm.
-        let items = await MenuBarItem
-            .getMenuBarItems(on: displayID, option: .activeSpace, resolveSourcePID: false)
-            .sorted { $0.bounds.minX < $1.bounds.minX }
-
-        /// Prefer the exact window, falling back to the tag, matching the
-        /// preference order `getCurrentBounds(for:)` already uses.
-        func index(of needle: MenuBarItem) -> Int? {
-            items.firstIndex { $0.windowID == needle.windowID }
-                ?? items.firstIndex(matching: needle.tag)
-        }
-
-        guard
-            let itemIndex = index(of: item),
-            let targetIndex = index(of: destination.targetItem)
-        else {
-            // One of the two no longer enumerates on this display's active
-            // space, so the landing cannot be confirmed either way. Report a
-            // miss and let the caller's attempt budget decide what happens.
+        let items = await MenuBarItem.getMenuBarItems(
+            on: displayID,
+            option: .activeSpace,
+            resolveSourcePID: false
+        ).filter { !$0.isSystemClone }
+        guard let indices = Self.moveEndpointIndices(
+            in: items,
+            sourceWindowID: item.windowID,
+            destinationWindowID: destination.targetItem.windowID
+        ) else {
+            // One endpoint no longer enumerates on this display's active
+            // space, or equal-X geometry makes its order ambiguous.
             return false
         }
 
         return switch destination {
-        case .leftOfItem: itemIndex == targetIndex - 1
-        case .rightOfItem: itemIndex == targetIndex + 1
+        case .leftOfItem: indices.source == indices.destination - 1
+        case .rightOfItem: indices.source == indices.destination + 1
         }
     }
 
@@ -371,7 +484,7 @@ extension MenuBarItemManager {
         let responseTask = Task.detached {
             while true {
                 try Task.checkCancellation()
-                let origin = try await self.getCurrentBounds(for: item).origin
+                let origin = try self.exactMoveBounds(for: item).origin
                 if origin != initialOrigin {
                     return origin
                 }
@@ -414,7 +527,8 @@ extension MenuBarItemManager {
         item: MenuBarItem,
         destination: MoveDestination,
         on displayID: CGDirectDisplayID,
-        warpCursorAfter: Bool = true
+        warpCursorAfter: Bool = true,
+        releaseGuard: PressReleaseGuard? = nil
     ) async throws -> Duration {
         var acquiredSemaphore = false
         do {
@@ -460,7 +574,7 @@ extension MenuBarItemManager {
             throw EventError.ownerUnresponsive(item)
         }
 
-        let itemBounds = try await getCurrentBounds(for: item)
+        let itemBounds = try exactMoveBounds(for: item)
         var itemOrigin = itemBounds.origin
         let targetPoints = try await getTargetPoints(forMoving: item, to: destination, on: displayID)
 
@@ -472,7 +586,11 @@ extension MenuBarItemManager {
         // second teleported it. A drag-gesture geometry was trialled behind
         // a setting to remove that warm-up and did not fix it, so it was
         // withdrawn; the warm-up attempt remains an open problem.
-        let pressPoint = targetPoints.start
+        let eventLocations = Self.moveEventLocations(
+            targetPoints: targetPoints,
+            faithfulDragStart: nil
+        )
+        let pressPoint = eventLocations.press
 
         // Capture mouse location only when this call owns the cursor warp.
         // When called from move(), the outer move() handles the single warp
@@ -493,7 +611,7 @@ extension MenuBarItemManager {
                 item: destination.targetItem,
                 source: source,
                 type: .move(.mouseUp),
-                location: targetPoints.end
+                location: eventLocations.release
             )
         else {
             throw EventError.eventCreationFailure(item)
@@ -539,29 +657,9 @@ extension MenuBarItemManager {
         if warpIsOnScreen {
             await eventSleep(for: .milliseconds(20))
         }
-        // For notched displays, when the target is offscreen, redirect
-        // mouseDown's horizontal hit-test location into the notch itself. The
-        // notch is hardware with no clickable UI, so the OS hit-test there has
-        // nothing to dismiss, no menu to open, and no app window to surface a
-        // click against. Keep the Core Graphics y-coordinate inside the menu
-        // bar; frameOfNotch is in AppKit coordinates and its y-coordinate would
-        // instead point near the bottom of the display. mouseUp keeps its
-        // original location (the drop position the receiving app uses to place
-        // the item). For non-notched displays the original behaviour is
-        // preserved (no override).
-        if !warpIsOnScreen {
-            let activeScreen = NSScreen.screens.first(where: { $0.displayID == displayID })
-                ?? NSScreen.main
-            if let activeScreen,
-               activeScreen.hasNotch,
-               let notch = activeScreen.frameOfNotch
-            {
-                mouseDown.location = Self.notchMouseDownPoint(
-                    notchFrameAppKit: notch,
-                    targetPointCoreGraphics: targetPoints.start
-                )
-            }
-        }
+        // Keep an off-screen teleport's stamped press at the off-screen
+        // destination. Redirecting it to the notch midpoint made the real
+        // status-item window visibly jump to the center before the release.
         defer {
             if let mouseLocation {
                 MouseHelpers.restoreCursorPosition(to: mouseLocation)
@@ -575,6 +673,9 @@ extension MenuBarItemManager {
             lastMoveOperationTimestamp = .now
         }
 
+        // From here the press may be down; a deadline guard posts a matching
+        // release even if the async attempt stops making progress.
+        releaseGuard?.arm()
         do {
             try await scrombleEvent(
                 mouseDown,
@@ -764,6 +865,117 @@ extension MenuBarItemManager {
         var maxMoveAttempts: Int = 8
         var hideCursorAcrossAttempts: Bool = true
         var shouldProceed: (@MainActor () -> Bool)?
+        /// Evaluated once the move transaction owns the gate, before any
+        /// action is taken. Returning false supersedes a move that became
+        /// stale while it was queued behind another move.
+        var shouldBegin: (@MainActor () -> Bool)?
+        /// Runs while the gate is still held, after the move finished but
+        /// before another move may enter.
+        var didFinishWhileHoldingGate: (@MainActor () -> Void)?
+    }
+
+    /// How long a synthetic press may remain down before its guard releases it.
+    static nonisolated func pressReleaseDeadline(for timeout: Duration) -> Duration {
+        (timeout * 6).clamped(min: .milliseconds(1500), max: .seconds(3))
+    }
+
+    /// The immutable event data posted by a press-release guard. `CGEvent`
+    /// posting is thread-safe and the event is not mutated after arming.
+    nonisolated struct PressReleaseEvents: @unchecked Sendable {
+        let mouseUp: CGEvent
+        let pid: pid_t
+    }
+
+    /// Releases a synthetic press when an async move attempt stops making
+    /// progress. A dangling press can turn the user's next real click into the
+    /// end of a drag, including a drag that removes the status item.
+    final nonisolated class PressReleaseGuard: Sendable {
+        private nonisolated struct Status {
+            var isArmed = false
+            var didFire = false
+        }
+
+        private let status = OSAllocatedUnfairLock(initialState: Status())
+        private let deadline: Duration
+        private let events: PressReleaseEvents
+        private let item: MenuBarItem
+
+        init(deadline: Duration, events: PressReleaseEvents, item: MenuBarItem) {
+            self.deadline = deadline
+            self.events = events
+            self.item = item
+        }
+
+        func arm() {
+            let armed = status.withLock { status -> Bool in
+                guard !status.isArmed, !status.didFire else {
+                    return false
+                }
+                status.isArmed = true
+                return true
+            }
+            guard armed else {
+                return
+            }
+            let status = status
+            let events = events
+            let item = item
+            let milliseconds = max(1, Int(deadline.milliseconds))
+            DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + .milliseconds(milliseconds)) {
+                let fires = status.withLock { status -> Bool in
+                    guard status.isArmed else {
+                        return false
+                    }
+                    status.isArmed = false
+                    status.didFire = true
+                    return true
+                }
+                guard fires else {
+                    return
+                }
+                MenuBarItemManager.diagLog.warning(
+                    "Press on \(item.logString) outlived its \(milliseconds) ms deadline; releasing it"
+                )
+                events.mouseUp.post(to: .sessionEventTap)
+                events.mouseUp.post(to: .pid(events.pid))
+            }
+        }
+
+        var didFire: Bool {
+            status.withLock(\.didFire)
+        }
+
+        func disarm() {
+            status.withLock { $0.isArmed = false }
+        }
+    }
+
+    /// Builds the independent safety release for one attempt.
+    private func makePressReleaseGuard(
+        for item: MenuBarItem,
+        destination: MoveDestination,
+        on displayID: CGDirectDisplayID
+    ) async -> PressReleaseGuard? {
+        guard
+            let targetBounds = try? exactMoveBounds(for: destination.targetItem, isDestination: true),
+            let source = try? getEventSource(),
+            let mouseUp = CGEvent.menuBarItemEvent(
+                item: destination.targetItem,
+                source: source,
+                type: .move(.mouseUp),
+                location: destination.targetPoint(in: targetBounds, on: CGDisplayBounds(displayID))
+            )
+        else {
+            MenuBarItemManager.diagLog.warning(
+                "No release event could be built for \(item.logString); the press runs unguarded"
+            )
+            return nil
+        }
+        return PressReleaseGuard(
+            deadline: Self.pressReleaseDeadline(for: getMoveOperationTimeout(for: item)),
+            events: PressReleaseEvents(mouseUp: mouseUp, pid: getEventPID(for: item)),
+            item: item
+        )
     }
 
     /// Moves a menu bar item to the given destination.
@@ -780,6 +992,53 @@ extension MenuBarItemManager {
         skipInputPause: Bool = false,
         options: MoveOptions = .init()
     ) async throws {
+        // Serialize the whole move, including retries and verification. A
+        // nested recovery move inherits task-local ownership and cannot wait
+        // on itself.
+        if !Self.holdsMoveGate {
+            let waitStartedAt = ContinuousClock.now
+            do {
+                try await Self.moveGate.wait(timeout: Self.moveGateTimeout)
+            } catch is SimpleSemaphore.TimeoutError {
+                MenuBarItemManager.diagLog.error(
+                    "move: another move has held the bar for \(Self.moveGateTimeout); giving up on \(item.logString)"
+                )
+                throw EventError.moveEngineBusy(item)
+            }
+            defer {
+                Self.performMoveGateExitActions(
+                    didFinishWhileHoldingGate: options.didFinishWhileHoldingGate,
+                    releaseGate: {
+                        Task.detached { await Self.moveGate.signal() }
+                    }
+                )
+            }
+            let waited = ContinuousClock.now - waitStartedAt
+            if waited > .milliseconds(100) {
+                MenuBarItemManager.diagLog.debug(
+                    "move: waited \(Int(waited.milliseconds)) ms for another move to finish before moving \(item.logString)"
+                )
+            }
+            return try await Self.$holdsMoveGate.withValue(true) {
+                var nestedOptions = options
+                nestedOptions.didFinishWhileHoldingGate = nil
+                return try await move(
+                    item: item,
+                    to: destination,
+                    on: displayID,
+                    skipInputPause: skipInputPause,
+                    options: nestedOptions
+                )
+            }
+        }
+
+        // Evaluate once, only after the transaction owns the gate. A caller
+        // can reject a plan that became stale while queued without mistaking
+        // the move's own subsequent updates for supersession.
+        guard options.shouldBegin?() ?? true else {
+            throw EventError.moveSuperseded(item)
+        }
+
         // System clone windows are transient WindowServer duplicates that
         // must never be moved. Refuse here as a final safety net so no
         // planning path can drag a phantom and displace real items. The
@@ -842,6 +1101,25 @@ extension MenuBarItemManager {
             window.displayID
         } else {
             Bridging.getActiveMenuBarDisplayID() ?? CGMainDisplayID()
+        }
+
+        // The plan may have waited behind another move. Resolve both endpoints
+        // again on the selected display and require the same window, owner,
+        // stable tag, and resolved source. A same-tag replacement needs a new
+        // plan; it is never a silent transport fallback.
+        let liveEndpoints = await MenuBarItem.getMenuBarItems(
+            on: resolvedDisplayID,
+            option: .activeSpace,
+            resolveSourcePID: true
+        ).filter { !$0.isSystemClone }
+        guard Self.currentMoveEndpoint(in: liveEndpoints, expected: item) != nil else {
+            throw EventError.missingItemBounds(item)
+        }
+        guard Self.currentMoveEndpoint(
+            in: liveEndpoints,
+            expected: destination.targetItem
+        ) != nil else {
+            throw EventError.missingDestinationBounds(destination.targetItem)
         }
 
         if !skipInputPause {
@@ -924,7 +1202,7 @@ extension MenuBarItemManager {
         // was chosen against the bar as it looked when this move was planned;
         // if the target itself travels a long way while we are dragging, the
         // plan describes an arrangement that no longer exists.
-        let plannedTargetBounds = try? await getCurrentBounds(for: destination.targetItem)
+        let plannedTargetBounds = try? exactMoveBounds(for: destination.targetItem, isDestination: true)
 
         // Where the target has sat at the end of each failed attempt. A
         // single nudge is expected; a run of them in one direction is the
@@ -948,6 +1226,7 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.debug("move: superseded before attempt \(n) for \(item.logString)")
                 throw EventError.moveSuperseded(item)
             }
+            var releaseGuard: PressReleaseGuard?
             do {
                 if try await itemHasCorrectPosition(item: item, for: destination, on: resolvedDisplayID) {
                     // On the first iteration trust the position match
@@ -967,12 +1246,22 @@ extension MenuBarItemManager {
                     attemptMouseLocation = try getMouseLocation()
                     MouseHelpers.hideCursor(watchdogTimeout: options.watchdogTimeout ?? .seconds(2))
                 }
+                releaseGuard = await makePressReleaseGuard(
+                    for: item,
+                    destination: destination,
+                    on: resolvedDisplayID
+                )
                 let attemptTimeout = try await postMoveEvents(
                     item: item,
                     destination: destination,
                     on: resolvedDisplayID,
-                    warpCursorAfter: false // move() owns the single warp in its defer
+                    warpCursorAfter: false, // move() owns the single warp in its defer
+                    releaseGuard: releaseGuard
                 )
+                releaseGuard?.disarm()
+                guard releaseGuard?.didFire != true else {
+                    throw EventError.moveTimedOut(item)
+                }
                 // postMoveEvents only returns without throwing when both
                 // waitForMoveEventResponse calls observed origin changes,
                 // i.e. our drag actually displaced the item.
@@ -1014,7 +1303,10 @@ extension MenuBarItemManager {
                 // batch with a fresh partial arrangement on every pass (#900).
                 // Stop instead and let the next cache tick re-plan against a
                 // settled bar.
-                let currentTargetBounds = try? await getCurrentBounds(for: destination.targetItem)
+                let currentTargetBounds = try? exactMoveBounds(
+                    for: destination.targetItem,
+                    isDestination: true
+                )
                 if let currentTargetBounds {
                     targetMinXHistory.append(currentTargetBounds.minX)
                 }
@@ -1059,6 +1351,13 @@ extension MenuBarItemManager {
                     continue
                 }
             } catch {
+                releaseGuard?.disarm()
+                if releaseGuard?.didFire == true {
+                    MenuBarItemManager.diagLog.warning(
+                        "Attempt \(n): the press on \(item.logString) outlived its deadline and was released"
+                    )
+                    throw EventError.moveTimedOut(item)
+                }
                 // missingItemBounds is definitive: getCurrentBounds already
                 // refreshed the on-screen items and re-matched by tag before
                 // throwing, so the item's window is genuinely gone (transient
@@ -1069,6 +1368,15 @@ extension MenuBarItemManager {
                     MenuBarItemManager.diagLog.warning(
                         "Attempt \(n): \(item.logString) no longer reports bounds, aborting move"
                     )
+                    throw error
+                }
+                if case EventError.missingDestinationBounds = error {
+                    MenuBarItemManager.diagLog.warning(
+                        "Attempt \(n): \(destination.targetItem.logString) no longer reports bounds, abandoning the destination"
+                    )
+                    throw error
+                }
+                if case EventError.moveTimedOut = error {
                     throw error
                 }
                 // Also definitive for the duration of this call: a hung owner

--- a/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
@@ -1,0 +1,95 @@
+//
+//  MoveEndpointIdentityTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+@Suite("Move endpoint identity")
+struct MoveEndpointIdentityTests {
+    private func item(
+        windowID: CGWindowID,
+        x: CGFloat,
+        ownerPID: pid_t = 80,
+        sourcePID: pid_t? = 81,
+        title: String
+    ) -> MenuBarItem {
+        .fixture(
+            tag: .appItem(bundleID: "com.example.MoveEndpoint", title: title),
+            windowID: windowID,
+            bounds: CGRect(x: x, y: 0, width: 24, height: 33),
+            sourcePID: sourcePID,
+            ownerPID: ownerPID,
+            title: title
+        )
+    }
+
+    @Test("A same-tag replacement is not the planned endpoint")
+    func replacementWindowIsRejected() {
+        let expected = item(windowID: 40, x: 100, title: "Item")
+        let replacement = item(windowID: 41, x: 100, title: "Item")
+
+        #expect(!MenuBarItemManager.moveEndpointIsCurrent(replacement, expected: expected))
+        #expect(MenuBarItemManager.currentMoveEndpoint(in: [replacement], expected: expected) == nil)
+    }
+
+    @Test("A recycled window owned by another process is rejected")
+    func recycledWindowIsRejected() {
+        let expected = item(windowID: 40, x: 100, ownerPID: 80, title: "Item")
+        let recycled = item(windowID: 40, x: 100, ownerPID: 90, title: "Item")
+
+        #expect(!MenuBarItemManager.moveEndpointIsCurrent(recycled, expected: expected))
+    }
+
+    @Test("A resolved source must still match after the gate")
+    func changedSourceIsRejected() {
+        let expected = item(windowID: 40, x: 100, sourcePID: 81, title: "Item")
+        let changed = item(windowID: 40, x: 100, sourcePID: 82, title: "Item")
+
+        #expect(!MenuBarItemManager.moveEndpointIsCurrent(changed, expected: expected))
+    }
+
+    @Test("Exact endpoints produce deterministic ordinal positions")
+    func exactEndpointsProduceIndices() {
+        let source = item(windowID: 40, x: 100, title: "Source")
+        let middle = item(windowID: 41, x: 200, title: "Middle")
+        let destination = item(windowID: 42, x: 300, title: "Destination")
+
+        #expect(
+            MenuBarItemManager.moveEndpointIndices(
+                in: [destination, source, middle],
+                sourceWindowID: source.windowID,
+                destinationWindowID: destination.windowID
+            ) == .init(source: 0, destination: 2)
+        )
+    }
+
+    @Test("Equal-X endpoint geometry stays unverified")
+    func equalXIsAmbiguous() {
+        let source = item(windowID: 40, x: 100, title: "Source")
+        let destination = item(windowID: 42, x: 100, title: "Destination")
+
+        #expect(MenuBarItemManager.moveEndpointIndices(
+            in: [source, destination],
+            sourceWindowID: source.windowID,
+            destinationWindowID: destination.windowID
+        ) == nil)
+    }
+
+    @Test("An anchor absent from the selected display cannot verify")
+    func missingDisplayEndpointIsRejected() {
+        let source = item(windowID: 40, x: 100, title: "Source")
+        let destination = item(windowID: 42, x: 300, title: "Destination")
+
+        #expect(MenuBarItemManager.moveEndpointIndices(
+            in: [source],
+            sourceWindowID: source.windowID,
+            destinationWindowID: destination.windowID
+        ) == nil)
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
@@ -35,7 +35,6 @@ struct MoveEndpointIdentityTests {
         let replacement = item(windowID: 41, x: 100, title: "Item")
 
         #expect(!MenuBarItemManager.moveEndpointIsCurrent(replacement, expected: expected))
-        #expect(MenuBarItemManager.currentMoveEndpoint(in: [replacement], expected: expected) == nil)
     }
 
     @Test("A recycled window owned by another process is rejected")
@@ -52,6 +51,42 @@ struct MoveEndpointIdentityTests {
         let changed = item(windowID: 40, x: 100, sourcePID: 82, title: "Item")
 
         #expect(!MenuBarItemManager.moveEndpointIsCurrent(changed, expected: expected))
+    }
+
+    @Test("The exact resolver returns fresh endpoint geometry")
+    func exactResolverReturnsFreshRecords() throws {
+        let source = item(windowID: 40, x: 100, title: "Source")
+        let target = item(windowID: 42, x: 300, title: "Target")
+        let movedSource = item(windowID: 40, x: 180, title: "Source")
+        let movedTarget = item(windowID: 42, x: 360, title: "Target")
+
+        let endpoints = try MenuBarItemManager.currentMoveEndpoints(
+            in: [movedTarget, movedSource],
+            expectedSource: source,
+            expectedDestination: target
+        ).get()
+
+        #expect(endpoints.source.bounds.minX == 180)
+        #expect(endpoints.target.bounds.minX == 360)
+    }
+
+    @Test("A recycled source or anchor stops the transaction")
+    func recycledEndpointStopsTransaction() {
+        let source = item(windowID: 40, x: 100, title: "Source")
+        let target = item(windowID: 42, x: 300, title: "Target")
+        let recycledSource = item(windowID: 40, x: 180, ownerPID: 999, title: "Source")
+        let recycledTarget = item(windowID: 42, x: 120, sourcePID: 999, title: "Target")
+
+        #expect(MenuBarItemManager.currentMoveEndpoints(
+            in: [recycledSource, target],
+            expectedSource: source,
+            expectedDestination: target
+        ) == .failure(.recycledSource))
+        #expect(MenuBarItemManager.currentMoveEndpoints(
+            in: [source, recycledTarget],
+            expectedSource: source,
+            expectedDestination: target
+        ) == .failure(.recycledDestination))
     }
 
     @Test("Exact endpoints produce deterministic ordinal positions")

--- a/ThawTests/MenuBar/Items/MoveEventCoordinatesTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEventCoordinatesTests.swift
@@ -14,10 +14,12 @@ import Testing
 /// Regression tests for the synthetic event coordinates used to move menu bar items.
 @Suite("Move event coordinates")
 struct MoveEventCoordinatesTests {
-    /// Off-screen destinations preserve their horizontal edge while keeping the
-    /// event away from the top-left Hot Corner.
-    @Test("An off-screen destination keeps its horizontal edge and uses the bounds midpoint")
-    func offscreenTargetPointsUseBoundsMidpoint() {
+    /// The target point is used unchanged for both halves of a teleport. In
+    /// particular, an off-screen press must stay off-screen rather than being
+    /// rewritten to a visible notch midpoint, which would flash the real item
+    /// in the center of the display before the release.
+    @Test("An off-screen teleport keeps its parked destination coordinate")
+    func offscreenTeleportKeepsParkedCoordinate() {
         let displayBounds = CGRect(x: 0, y: 0, width: 1470, height: 956)
         let bounds = CGRect(x: -4193, y: 0, width: 22, height: 33)
         let target = MenuBarItem.fixture(
@@ -39,6 +41,14 @@ struct MoveEventCoordinatesTests {
                 on: displayBounds
             ) == CGPoint(x: bounds.maxX, y: bounds.midY)
         )
+
+        let parkedPoint = CGPoint(x: bounds.minX, y: bounds.midY)
+        let eventLocations = MenuBarItemManager.moveEventLocations(
+            targetPoints: (start: parkedPoint, end: parkedPoint),
+            faithfulDragStart: nil
+        )
+        #expect(eventLocations.press == parkedPoint)
+        #expect(eventLocations.release == parkedPoint)
     }
 
     /// #923: dropping onto the exact coordinate of a section divider leaves
@@ -213,21 +223,5 @@ struct MoveEventCoordinatesTests {
         )
 
         #expect(point == CGPoint(x: bounds.minX, y: bounds.minY))
-    }
-
-    /// The notch frame comes from AppKit, so only its horizontal position is
-    /// safe to reuse in a Core Graphics event.
-    @Test("A notch mouse-down keeps the Core Graphics menu bar Y coordinate")
-    func notchMouseDownKeepsCoreGraphicsMenuBarYCoordinate() {
-        let notchFrameAppKit = CGRect(x: 646, y: 924, width: 179, height: 32)
-        let targetPointCoreGraphics = CGPoint(x: -4193, y: 16.5)
-
-        let point = MenuBarItemManager.notchMouseDownPoint(
-            notchFrameAppKit: notchFrameAppKit,
-            targetPointCoreGraphics: targetPointCoreGraphics
-        )
-
-        #expect(point == CGPoint(x: notchFrameAppKit.midX, y: targetPointCoreGraphics.y))
-        #expect(point.y != notchFrameAppKit.midY)
     }
 }

--- a/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
@@ -7,6 +7,7 @@
 //  Licensed under the GNU GPLv3
 
 import CoreGraphics
+import os.lock
 import Testing
 @testable import Thaw
 
@@ -14,6 +15,7 @@ import Testing
 @Suite("Move-gate preflight", .serialized)
 struct MoveGatePreflightTests {
     typealias EventError = MenuBarItemManager.EventError
+    typealias ScheduledAction = @Sendable () -> Void
 
     private func item(windowID: CGWindowID, title: String) -> MenuBarItem {
         .fixture(
@@ -82,5 +84,108 @@ struct MoveGatePreflightTests {
         #expect(MenuBarItemManager.pressReleaseDeadline(for: .milliseconds(100)) == .milliseconds(1500))
         #expect(MenuBarItemManager.pressReleaseDeadline(for: .milliseconds(350)) == .milliseconds(2100))
         #expect(MenuBarItemManager.pressReleaseDeadline(for: .seconds(1)) == .seconds(3))
+    }
+
+    @Test("A confirmed mouse-up cancels the safety release")
+    func confirmedMouseUpCancelsSafetyRelease() {
+        let scheduled = OSAllocatedUnfairLock<ScheduledAction?>(initialState: nil)
+        let safetyPosts = OSAllocatedUnfairLock(initialState: 0)
+        let guardState = MenuBarItemManager.PressReleaseGuard(
+            deadline: .seconds(1),
+            item: item(windowID: 51, title: "Moved"),
+            scheduler: { _, action in scheduled.withLock { $0 = action } },
+            postSafetyRelease: { safetyPosts.withLock { $0 += 1 } }
+        )
+
+        guardState.arm()
+        guardState.recordReleaseAttempt(delivered: true)
+        scheduled.withLock { $0 }?()
+
+        #expect(guardState.state == .releaseConfirmed)
+        #expect(safetyPosts.withLock { $0 } == 0)
+    }
+
+    @Test("Failed mouse-ups leave the safety release armed")
+    func failedMouseUpsKeepSafetyReleaseArmed() {
+        let scheduled = OSAllocatedUnfairLock<ScheduledAction?>(initialState: nil)
+        let safetyPosts = OSAllocatedUnfairLock(initialState: 0)
+        let guardState = MenuBarItemManager.PressReleaseGuard(
+            deadline: .seconds(1),
+            item: item(windowID: 52, title: "Moved"),
+            scheduler: { _, action in scheduled.withLock { $0 = action } },
+            postSafetyRelease: { safetyPosts.withLock { $0 += 1 } }
+        )
+
+        guardState.arm()
+        guardState.recordReleaseAttempt(delivered: false)
+        guardState.recordReleaseAttempt(delivered: false)
+        #expect(guardState.state == .armed)
+
+        scheduled.withLock { $0 }?()
+        #expect(guardState.state == .fired)
+        #expect(safetyPosts.withLock { $0 } == 1)
+    }
+
+    @Test("Pre-gate waiting does not retain the move permit")
+    func inputWaitingDoesNotRetainMovePermit() async throws {
+        let firstWaitStarted = MoveTestLatch()
+        let releaseFirstWait = MoveTestLatch()
+        let secondBodyEntered = MoveTestLatch()
+        let releaseSecondBody = MoveTestLatch()
+        var events = [String]()
+
+        let first = Task { @MainActor in
+            try await MenuBarItemManager.performWithMoveGate(
+                timeout: .seconds(5),
+                waitBeforeGate: {
+                    events.append("first-wait")
+                    await firstWaitStarted.open()
+                    await releaseFirstWait.wait()
+                },
+                operation: { events.append("first-body") }
+            )
+        }
+
+        await firstWaitStarted.wait()
+        let second = Task { @MainActor in
+            try await MenuBarItemManager.performWithMoveGate(
+                timeout: .seconds(5),
+                operation: {
+                    events.append("second-body")
+                    await secondBodyEntered.open()
+                    await releaseSecondBody.wait()
+                }
+            )
+        }
+
+        await secondBodyEntered.wait()
+        await releaseFirstWait.open()
+        await releaseSecondBody.open()
+        try await second.value
+        try await first.value
+
+        #expect(events == ["first-wait", "second-body", "first-body"])
+    }
+}
+
+private actor MoveTestLatch {
+    private var isOpen = false
+    private var waiters = [CheckedContinuation<Void, Never>]()
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func open() {
+        guard !isOpen else {
+            return
+        }
+        isOpen = true
+        let continuations = waiters
+        waiters.removeAll()
+        continuations.forEach { $0.resume() }
     }
 }

--- a/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
@@ -1,0 +1,86 @@
+//
+//  MoveGatePreflightTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Testing
+@testable import Thaw
+
+@MainActor
+@Suite("Move-gate preflight", .serialized)
+struct MoveGatePreflightTests {
+    typealias EventError = MenuBarItemManager.EventError
+
+    private func item(windowID: CGWindowID, title: String) -> MenuBarItem {
+        .fixture(
+            tag: .appItem(bundleID: "com.example.MoveGatePreflight", title: title),
+            windowID: windowID
+        )
+    }
+
+    /// A manager without AppState cannot perform any live move. Reaching the
+    /// preflight's named error instead proves that the one-shot gate-owned
+    /// check runs before the mover touches AppState or WindowServer state.
+    @Test("A rejected gate-owned preflight stops before live move work")
+    func rejectedPreflightStopsBeforeLiveMoveWork() async {
+        let manager = MenuBarItemManager()
+        let movedItem = item(windowID: 41, title: "Moved")
+        let targetItem = item(windowID: 42, title: "Target")
+        var events = [String]()
+
+        do {
+            try await manager.move(
+                item: movedItem,
+                to: .leftOfItem(targetItem),
+                options: .init(
+                    shouldBegin: {
+                        events.append("preflight")
+                        return false
+                    },
+                    didFinishWhileHoldingGate: {
+                        events.append("finish")
+                    }
+                )
+            )
+            Issue.record("Expected the rejected preflight to throw moveSuperseded")
+        } catch let error as EventError {
+            guard case .moveSuperseded = error else {
+                Issue.record("Expected moveSuperseded, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected EventError.moveSuperseded, got \(error)")
+        }
+
+        #expect(events == ["preflight", "finish"])
+    }
+
+    /// The semaphore is intentionally private. Exercise the exact exit helper
+    /// instead so this assertion has no scheduler or timing dependency.
+    @Test("Batch timestamp ownership updates before the move gate is released")
+    func finishRunsBeforeRelease() {
+        var events = [String]()
+
+        MenuBarItemManager.performMoveGateExitActions(
+            didFinishWhileHoldingGate: {
+                events.append("finish")
+            },
+            releaseGate: {
+                events.append("release")
+            }
+        )
+
+        #expect(events == ["finish", "release"])
+    }
+
+    @Test("Press-release deadlines are bounded")
+    func pressReleaseDeadlinesAreBounded() {
+        #expect(MenuBarItemManager.pressReleaseDeadline(for: .milliseconds(100)) == .milliseconds(1500))
+        #expect(MenuBarItemManager.pressReleaseDeadline(for: .milliseconds(350)) == .milliseconds(2100))
+        #expect(MenuBarItemManager.pressReleaseDeadline(for: .seconds(1)) == .seconds(3))
+    }
+}


### PR DESCRIPTION
# Summary

Serializes complete menu-bar move transactions instead of serializing only individual event posts. A queued move now acquires one app-wide gate for its preflight, attempts, verification, and completion, preventing independent retry loops from interleaving and undoing one another.

After the gate is acquired, the source and destination are re-enumerated on the selected display and active Space. Both must still match the planned window ID, owner PID, stable tag, and resolved source PID. Geometry and landing verification use those exact windows only: same-tag replacements are not silent fallbacks, equal-X endpoints remain inconclusive, and a vanished anchor is reported separately from a vanished source. A deadline guard posts a matching release if an asynchronous attempt leaves a synthetic press held.

The former off-screen notch-midpoint rewrite is removed. A parked teleport keeps its exact parked press/release coordinate, so the real item is not first moved through the visible center of the display.

**Scope:** This PR changes 4 files with 970 insertions and 144 deletions. It adds whole-move serialization, bounded gate admission, gate-owned preflight and completion seams, exact endpoint verification, the release-confirmed press guard, safe parked coordinates, and focused Swift Testing coverage. It does not add the faithful transport policy or replace the legacy retry loop; those are the next movement PRs. Trigger ownership/callers, LayoutApply coordination, and Layout Bar UI work remain excluded. This may be suitable for 2.2.

Dependency: #997 must be merged first or used as this PR's base. This PR uses that PR's precise move errors and supersession/deadline outcomes; it is not independently cherry-pickable onto `development` without that policy foundation.

## Linked issue (required)

Closes: N/A

Related: #900, #923

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- One app-wide gate covers a move's full lifecycle, including retries and verification, rather than only each low-level event post.
- Nested recovery moves inherit task-local gate ownership and do not deadlock waiting on their parent move.
- Gate admission waits for recent keyboard/mouse input for no more than two seconds, then `shouldBegin` is evaluated exactly once after acquisition so a queued stale plan stops before touching AppState or WindowServer state.
- A gate-owned completion callback runs before the semaphore is released, so a batch can adopt its completed move's timestamp before another contender enters.
- Source and anchor identities are revalidated after the wait using one selected-display, active-Space enumeration with source-PID resolution.
- Exact window bounds replace same-tag geometry fallback for movement; recycled IDs with a different owner, same-tag replacement windows, and changed source PIDs are rejected.
- Landing verification uses one exact-window snapshot. Equal-X overlap is ambiguous rather than being assigned enumeration order, and an anchor missing from the selected display cannot verify.
- Missing source and missing destination bounds remain distinct errors.
- A press-release deadline guard independently releases a synthetic press that outlives its attempt and records whether release was actually confirmed.
- Off-screen teleports retain the requested parked coordinate for both press and release instead of rewriting the press to a visible notch midpoint.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawPR6SafeBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test-without-building -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawPR6SafeBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/MoveEndpointIdentityTests -only-testing:ThawTests/MoveGatePreflightTests`

The test build succeeded, and all 14 selected tests across the endpoint-identity and gate/preflight suites passed. Final-stack SwiftFormat lint passed for every changed Swift file; strict SwiftLint reported 0 violations; the generated SwiftLint input list and `git diff --check` matched cleanly.

## Known limitations / follow-ups

- This PR intentionally retains the existing transport selection and retry loop. The next PR adds explicit faithful/parked/cross-notch transport decisions, and the following PR wires retries and terminal verdicts through `MovePolicy`.
- The exact preflight prevents stale endpoint use after the gate, but macOS can still reject a valid synthetic gesture after it begins.
- Trigger-owned movement, automatic reporting, LayoutApply batch/cancellation coordination, cache transactions, and Layout Bar UI transitions are intentionally excluded.
- This stacked PR should remain based on PR 4 until that dependency merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or interactive menu-bar run was performed for this PR; verification was through the focused automated tests, build, formatting, lint, generated-file comparison, and diff checks above.

The commit includes a `Signed-off-by` trailer for the project's DCO requirement. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 6 of 12  
**Git base:** #997  
**Functional dependencies:** #997.
