### PR TITLE
fix(menubar): keep menu bar move transport on safe paths

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemEventTypes.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemEventTypes.swift
@@ -46,7 +46,7 @@ nonisolated enum MenuBarItemEventType {
     // MARK: Subtypes
 
     /// Subtype for menu bar item move events.
-    enum MoveSubtype {
+    enum MoveSubtype: Equatable {
         case mouseDown
         case mouseDragged
         case mouseUp

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
@@ -78,6 +78,9 @@ extension MenuBarItemManager {
         /// the move as a whole ran past its deadline. Whatever reply came
         /// back after that describes a press that was no longer down.
         case moveTimedOut(MenuBarItem)
+        /// The planned endpoints do not form a safe transport on the selected
+        /// display. No synthetic press was posted.
+        case unsafeMovePath(MenuBarItem)
 
         var description: String {
             switch self {
@@ -117,6 +120,8 @@ extension MenuBarItemManager {
                 "\(Self.self).moveEngineBusy(item: \(item.tag))"
             case let .moveTimedOut(item):
                 "\(Self.self).moveTimedOut(item: \(item.tag))"
+            case let .unsafeMovePath(item):
+                "\(Self.self).unsafeMovePath(item: \(item.tag))"
             }
         }
 
@@ -158,6 +163,8 @@ extension MenuBarItemManager {
                 "Another move was still in progress when \"\(item.displayName)\" was to be moved"
             case let .moveTimedOut(item):
                 "Moving \"\(item.displayName)\" took too long and was stopped"
+            case let .unsafeMovePath(item):
+                "The path for moving \"\(item.displayName)\" is no longer safe"
             }
         }
 
@@ -202,7 +209,7 @@ extension MenuBarItemManager {
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
                  .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
                  .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
-                 .moveEngineBusy, .moveTimedOut:
+                 .moveEngineBusy, .moveTimedOut, .unsafeMovePath:
                 false
             }
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -120,6 +120,168 @@ extension MenuBarItemManager {
         }
     }
 
+    /// The event transport selected for one attempt. Parked and cross-notch
+    /// teleports are named separately so an unsafe faithful plan can never
+    /// silently collapse into the legacy press-at-destination path.
+    nonisolated enum MoveStrategy: Equatable, CustomStringConvertible {
+        case teleport
+        case faithfulDrag
+        case parkedTeleport
+        case crossNotchTeleport
+
+        var description: String {
+            switch self {
+            case .teleport: "teleport"
+            case .faithfulDrag: "faithfulDrag"
+            case .parkedTeleport: "parkedTeleport"
+            case .crossNotchTeleport: "crossNotchTeleport"
+            }
+        }
+    }
+
+    /// Whether a horizontal on-bar gesture can stay inside one safe segment.
+    nonisolated enum HorizontalPathDisposition: Equatable {
+        case sameSafeSegment
+        case crossesNotch
+        case invalidEndpoint
+    }
+
+    /// The strict transport decision, including a refusal to post events.
+    nonisolated enum MoveTransportDecision: Equatable {
+        case use(MoveStrategy)
+        case rejectUnsafePath
+    }
+
+    /// Logical placement of a move endpoint relative to the selected menu-bar
+    /// lane. Screen coordinates alone cannot identify parked items because a
+    /// physical display may legitimately sit to the selected display's left.
+    nonisolated enum MoveEndpointDisposition: Equatable {
+        case selectedDisplay
+        case parked
+        case otherDisplay(CGDirectDisplayID)
+        case invalid
+    }
+
+    nonisolated struct MoveDisplayGeometry: Equatable {
+        let id: CGDirectDisplayID
+        let bounds: CGRect
+    }
+
+    static nonisolated func moveEndpointDisposition(
+        bounds: CGRect,
+        isOnScreen: Bool,
+        selectedDisplayID: CGDirectDisplayID,
+        displays: [MoveDisplayGeometry],
+        parkedLaneYRange: ClosedRange<CGFloat>?,
+        controlDividerX: CGFloat?
+    ) -> MoveEndpointDisposition {
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        if isOnScreen {
+            guard let physicalDisplay = displays.first(where: { $0.bounds.contains(center) }) else {
+                return .invalid
+            }
+            return physicalDisplay.id == selectedDisplayID
+                ? .selectedDisplay
+                : .otherDisplay(physicalDisplay.id)
+        }
+
+        guard
+            let parkedLaneYRange,
+            let controlDividerX,
+            parkedLaneYRange.contains(bounds.midY),
+            bounds.maxX <= controlDividerX
+        else {
+            return .invalid
+        }
+        return .parked
+    }
+
+    /// Classifies a horizontal menu-bar path without consulting AppKit.
+    static nonisolated func horizontalPathDisposition(
+        sourceX: CGFloat,
+        destinationX: CGFloat,
+        displayXRange: ClosedRange<CGFloat>,
+        reservedNotchXRange: ClosedRange<CGFloat>?
+    ) -> HorizontalPathDisposition {
+        guard displayXRange.contains(sourceX), displayXRange.contains(destinationX) else {
+            return .invalidEndpoint
+        }
+        guard let notch = reservedNotchXRange else {
+            return .sameSafeSegment
+        }
+        guard !notch.contains(sourceX), !notch.contains(destinationX) else {
+            return .invalidEndpoint
+        }
+        let crosses = (sourceX < notch.lowerBound && destinationX > notch.upperBound)
+            || (destinationX < notch.lowerBound && sourceX > notch.upperBound)
+        return crosses ? .crossesNotch : .sameSafeSegment
+    }
+
+    /// Selects a transport from explicit display membership and path safety.
+    /// A `nil` endpoint display means WindowServer has parked it off-screen;
+    /// a non-selected display means the plan is stale or cross-display and is
+    /// rejected instead of being teleported.
+    static nonisolated func strictTransportDecision(
+        faithfulDragEnabled: Bool,
+        itemIsControlItem: Bool,
+        sourceDisplayID: CGDirectDisplayID?,
+        destinationDisplayID: CGDirectDisplayID?,
+        selectedDisplayID: CGDirectDisplayID,
+        horizontalPath: HorizontalPathDisposition
+    ) -> MoveTransportDecision {
+        if let sourceDisplayID, sourceDisplayID != selectedDisplayID {
+            return .rejectUnsafePath
+        }
+        if let destinationDisplayID, destinationDisplayID != selectedDisplayID {
+            return .rejectUnsafePath
+        }
+        if sourceDisplayID == nil || destinationDisplayID == nil {
+            return .use(.parkedTeleport)
+        }
+        return switch horizontalPath {
+        case .invalidEndpoint:
+            .rejectUnsafePath
+        case .crossesNotch:
+            .use(.crossNotchTeleport)
+        case .sameSafeSegment:
+            .use(faithfulDragEnabled && !itemIsControlItem ? .faithfulDrag : .teleport)
+        }
+    }
+
+    /// What one round of move events observed, beyond the timeout budget the
+    /// next round inherits.
+    nonisolated struct MoveEventsOutcome {
+        var timeout: Duration
+        var revertedToStart: Bool
+        var strategy: MoveStrategy
+    }
+
+    /// Pure construction of a faithful, horizontal command-drag gesture.
+    nonisolated enum MoveGesture {
+        struct Step: Equatable {
+            let subtype: MenuBarItemEventType.MoveSubtype
+            let point: CGPoint
+        }
+
+        static func faithfulDrag(start: CGPoint, end: CGPoint, intermediateSteps: Int) -> [Step] {
+            let steps = max(1, intermediateSteps)
+            var result = [Step(subtype: .mouseDown, point: start)]
+            for index in 1 ... steps {
+                let t = CGFloat(index) / CGFloat(steps + 1)
+                result.append(Step(
+                    subtype: .mouseDragged,
+                    point: CGPoint(
+                        x: start.x + (end.x - start.x) * t,
+                        y: start.y + (end.y - start.y) * t
+                    )
+                ))
+            }
+            result.append(Step(subtype: .mouseDragged, point: end))
+            result.append(Step(subtype: .mouseUp, point: end))
+            return result
+        }
+    }
+
     /// Final coordinates used to create the opening and closing events for a
     /// move. A teleport has no visible intermediate press: its mouse-down is
     /// stamped directly at the destination, including when that destination
@@ -530,6 +692,83 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Validates both endpoint locations and distinguishes a genuinely parked
+    /// status item from a window belonging to a physical display on the left.
+    private func validateMoveEndpointGeometry(
+        item: MenuBarItem,
+        target: MenuBarItem,
+        snapshot: [MenuBarItem],
+        on displayID: CGDirectDisplayID
+    ) throws -> (source: MoveEndpointDisposition, target: MoveEndpointDisposition) {
+        let selectedBounds = CGDisplayBounds(displayID)
+        let displays = NSScreen.screens.map {
+            MoveDisplayGeometry(id: $0.displayID, bounds: CGDisplayBounds($0.displayID))
+        }
+        let dividers = snapshot.filter {
+            ($0.tag == .hiddenControlItem || $0.tag == .alwaysHiddenControlItem)
+                && (selectedBounds.minX ... selectedBounds.maxX).contains($0.bounds.maxX)
+                && (selectedBounds.minY ... selectedBounds.maxY).contains($0.bounds.midY)
+        }
+        let parkedLaneYRange: ClosedRange<CGFloat>? = if
+            let minY = dividers.map(\.bounds.minY).min(),
+            let maxY = dividers.map(\.bounds.maxY).max()
+        {
+            minY ... maxY
+        } else {
+            selectedBounds.minY ... (selectedBounds.minY + 64)
+        }
+        let dividerX = dividers.map(\.bounds.maxX).max() ?? selectedBounds.minX
+
+        func disposition(for endpoint: MenuBarItem) throws -> MoveEndpointDisposition {
+            let value = Self.moveEndpointDisposition(
+                bounds: endpoint.bounds,
+                isOnScreen: endpoint.isOnScreen,
+                selectedDisplayID: displayID,
+                displays: displays,
+                parkedLaneYRange: parkedLaneYRange,
+                controlDividerX: dividerX
+            )
+            switch value {
+            case .selectedDisplay, .parked:
+                return value
+            case .otherDisplay, .invalid:
+                MenuBarItemManager.diagLog.warning(
+                    "Move rejected stale or cross-display endpoint geometry for \(endpoint.logString)"
+                )
+                throw EventError.staleDestination(item)
+            }
+        }
+        return try (disposition(for: item), disposition(for: target))
+    }
+
+    private func transportDecision(
+        item: MenuBarItem,
+        itemBounds: CGRect,
+        targetPoint: CGPoint,
+        geometry: (source: MoveEndpointDisposition, target: MoveEndpointDisposition),
+        on displayID: CGDirectDisplayID
+    ) -> MoveTransportDecision {
+        let displayBounds = CGDisplayBounds(displayID)
+        let screen = NSScreen.screens.first { $0.displayID == displayID }
+        let notchRange = screen?.frameOfNotch.map { notch in
+            (notch.minX - 2) ... (notch.maxX + 2)
+        }
+        let path = Self.horizontalPathDisposition(
+            sourceX: itemBounds.midX,
+            destinationX: targetPoint.x,
+            displayXRange: displayBounds.minX ... displayBounds.maxX,
+            reservedNotchXRange: notchRange
+        )
+        return Self.strictTransportDecision(
+            faithfulDragEnabled: faithfulDragMovesEnabled,
+            itemIsControlItem: item.isControlItem,
+            sourceDisplayID: geometry.source == .selectedDisplay ? displayID : nil,
+            destinationDisplayID: geometry.target == .selectedDisplay ? displayID : nil,
+            selectedDisplayID: displayID,
+            horizontalPath: path
+        )
+    }
+
     /// Returns the target points for creating the events needed to
     /// move a menu bar item to the given destination.
     private nonisolated func getTargetPoints(
@@ -653,7 +892,7 @@ extension MenuBarItemManager {
         destination: MoveDestination,
         on displayID: CGDirectDisplayID,
         warpCursorAfter: Bool = true
-    ) async throws -> Duration {
+    ) async throws -> MoveEventsOutcome {
         var acquiredSemaphore = false
         do {
             try await eventSemaphore.wait(timeout: .milliseconds(3500))
@@ -682,6 +921,12 @@ extension MenuBarItemManager {
             on: displayID
         )
         let initialDestination = initialEndpoints.destination(matching: destination)
+        let initialGeometry = try validateMoveEndpointGeometry(
+            item: initialEndpoints.source,
+            target: initialEndpoints.target,
+            snapshot: initialEndpoints.snapshot,
+            on: displayID
+        )
         let initialTargetPoints = getTargetPoints(
             forMoving: initialEndpoints.source,
             to: initialDestination,
@@ -714,17 +959,28 @@ extension MenuBarItemManager {
             throw EventError.ownerUnresponsive(item)
         }
 
-        // Press and release at the *destination* (targetPoints.start == .end
-        // == the target edge) with the moved item's window ID stamped on the
-        // press, relying on the owner to relocate its item to the press
-        // location. Every move observed in #881 needed a warm-up attempt
-        // before that took: the first press nudged the item a pixel, the
-        // second teleported it. A drag-gesture geometry was trialled behind
-        // a setting to remove that warm-up and did not fix it, so it was
-        // withdrawn; the warm-up attempt remains an open problem.
+        let initialStrategy: MoveStrategy
+        switch transportDecision(
+            item: initialEndpoints.source,
+            itemBounds: initialEndpoints.source.bounds,
+            targetPoint: initialTargetPoints.end,
+            geometry: initialGeometry,
+            on: displayID
+        ) {
+        case let .use(selected):
+            initialStrategy = selected
+        case .rejectUnsafePath:
+            throw EventError.unsafeMovePath(initialEndpoints.source)
+        }
+        let initialDragPlan = initialStrategy == .faithfulDrag
+            ? faithfulDragSteps(
+                itemBounds: initialEndpoints.source.bounds,
+                targetPoints: initialTargetPoints
+            )
+            : nil
         let initialEventLocations = Self.moveEventLocations(
             targetPoints: initialTargetPoints,
-            faithfulDragStart: nil
+            faithfulDragStart: initialDragPlan?.first?.point
         )
 
         // Capture mouse location only when this call owns the cursor warp.
@@ -740,9 +996,7 @@ extension MenuBarItemManager {
         // when slow apps have to register the tracking events before the
         // mouseDown; irrelevant offscreen.
         let warpPoint = initialEventLocations.press
-        let warpIsOnScreen = NSScreen.screens.contains {
-            CGDisplayBounds($0.displayID).contains(warpPoint)
-        }
+        let warpIsOnScreen = initialGeometry.target == .selectedDisplay
         if warpIsOnScreen {
             // Load-bearing for event delivery — keep unconditionally, even
             // during a bulk apply: the receiving app's tracking needs the
@@ -793,6 +1047,12 @@ extension MenuBarItemManager {
         )
         let liveItem = endpoints.source
         let liveDestination = endpoints.destination(matching: destination)
+        let geometry = try validateMoveEndpointGeometry(
+            item: liveItem,
+            target: endpoints.target,
+            snapshot: endpoints.snapshot,
+            on: displayID
+        )
         let itemBounds = liveItem.bounds
         var itemOrigin = itemBounds.origin
         let targetPoints = getTargetPoints(
@@ -802,15 +1062,35 @@ extension MenuBarItemManager {
             targetBounds: endpoints.target.bounds,
             on: displayID
         )
+        let strategy: MoveStrategy
+        switch transportDecision(
+            item: liveItem,
+            itemBounds: itemBounds,
+            targetPoint: targetPoints.end,
+            geometry: geometry,
+            on: displayID
+        ) {
+        case let .use(selected):
+            strategy = selected
+        case .rejectUnsafePath:
+            MenuBarItemManager.diagLog.warning(
+                "Move transport rejected unsafe or cross-display geometry for \(liveItem.logString)"
+            )
+            throw EventError.unsafeMovePath(liveItem)
+        }
+        let dragPlan = strategy == .faithfulDrag
+            ? faithfulDragSteps(itemBounds: itemBounds, targetPoints: targetPoints)
+            : nil
         let eventLocations = Self.moveEventLocations(
             targetPoints: targetPoints,
-            faithfulDragStart: nil
+            faithfulDragStart: dragPlan?.first?.point
         )
         if warpIsOnScreen, eventLocations.press != warpPoint {
             MouseHelpers.warpCursor(to: eventLocations.press)
         }
         let source = try getEventSource()
         try permitLocalEvents()
+        let releaseItem = strategy == .faithfulDrag ? liveItem : endpoints.target
         guard
             let mouseDown = CGEvent.menuBarItemEvent(
                 item: liveItem,
@@ -819,7 +1099,7 @@ extension MenuBarItemManager {
                 location: eventLocations.press
             ),
             let mouseUp = CGEvent.menuBarItemEvent(
-                item: endpoints.target,
+                item: releaseItem,
                 source: source,
                 type: .move(.mouseUp),
                 location: eventLocations.release
@@ -830,6 +1110,9 @@ extension MenuBarItemManager {
 
         var timeout = getMoveOperationTimeout(for: liveItem)
         MenuBarItemManager.diagLog.debug("Move operation timeout: \(timeout)")
+        MenuBarItemManager.diagLog.info(
+            "Move strategy: \(strategy) for \(liveItem.logString); press at (\(eventLocations.press.x),\(eventLocations.press.y)), release at (\(eventLocations.release.x),\(eventLocations.release.y))"
+        )
         let releaseGuard = makePressReleaseGuard(
             for: liveItem,
             mouseUp: mouseUp,
@@ -840,52 +1123,72 @@ extension MenuBarItemManager {
         // release even if the async attempt stops making progress.
         releaseGuard.arm()
         do {
-            try await scrombleEvent(
-                mouseDown,
-                item: liveItem,
-                timeout: timeout
-            )
-            itemOrigin = try await waitForMoveEventResponse(
-                from: liveItem,
-                initialOrigin: itemOrigin,
-                timeout: timeout
-            )
+            if let dragPlan {
+                itemOrigin = try await postFaithfulDragSteps(
+                    dragPlan,
+                    item: liveItem,
+                    source: source,
+                    startOrigin: itemOrigin,
+                    timeout: timeout,
+                    openingEvent: mouseDown,
+                    releaseGuard: releaseGuard,
+                    destination: destination,
+                    on: displayID
+                )
+            } else {
+                try await scrombleEvent(
+                    mouseDown,
+                    item: liveItem,
+                    timeout: timeout
+                )
+                itemOrigin = try await waitForMoveEventResponse(
+                    from: liveItem,
+                    initialOrigin: itemOrigin,
+                    timeout: timeout
+                )
 
-            // Reflow after the opening press can move the target edge. Release
-            // against a newly resolved exact endpoint rather than stale bounds.
-            let releaseEndpoints = try await resolveCurrentMoveEndpoints(
-                source: item,
-                destination: destination.targetItem,
-                on: displayID
-            )
-            let releaseDestination = releaseEndpoints.destination(matching: destination)
-            let releasePoints = getTargetPoints(
-                forMoving: releaseEndpoints.source,
-                to: releaseDestination,
-                itemBounds: releaseEndpoints.source.bounds,
-                targetBounds: releaseEndpoints.target.bounds,
-                on: displayID
-            )
-            guard let liveMouseUp = CGEvent.menuBarItemEvent(
-                item: releaseEndpoints.target,
-                source: source,
-                type: .move(.mouseUp),
-                location: releasePoints.end
-            ) else {
-                throw EventError.eventCreationFailure(releaseEndpoints.source)
+                // Reflow after the opening press can move the target edge.
+                // Release against a freshly validated endpoint snapshot.
+                let releaseEndpoints = try await resolveCurrentMoveEndpoints(
+                    source: item,
+                    destination: destination.targetItem,
+                    on: displayID
+                )
+                _ = try validateMoveEndpointGeometry(
+                    item: releaseEndpoints.source,
+                    target: releaseEndpoints.target,
+                    snapshot: releaseEndpoints.snapshot,
+                    on: displayID
+                )
+                let releaseDestination = releaseEndpoints.destination(matching: destination)
+                let releasePoints = getTargetPoints(
+                    forMoving: releaseEndpoints.source,
+                    to: releaseDestination,
+                    itemBounds: releaseEndpoints.source.bounds,
+                    targetBounds: releaseEndpoints.target.bounds,
+                    on: displayID
+                )
+                guard let liveMouseUp = CGEvent.menuBarItemEvent(
+                    item: releaseEndpoints.target,
+                    source: source,
+                    type: .move(.mouseUp),
+                    location: releasePoints.end
+                ) else {
+                    throw EventError.eventCreationFailure(releaseEndpoints.source)
+                }
+                try await scrombleEvent(
+                    liveMouseUp,
+                    item: releaseEndpoints.source,
+                    timeout: timeout,
+                    repeating: 2 // Double mouse up prevents invalid item state.
+                )
+                releaseGuard.recordReleaseAttempt(delivered: true)
+                itemOrigin = try await waitForMoveEventResponse(
+                    from: releaseEndpoints.source,
+                    initialOrigin: itemOrigin,
+                    timeout: timeout
+                )
             }
-            try await scrombleEvent(
-                liveMouseUp,
-                item: releaseEndpoints.source,
-                timeout: timeout,
-                repeating: 2 // Double mouse up prevents invalid item state.
-            )
-            releaseGuard.recordReleaseAttempt(delivered: true)
-            itemOrigin = try await waitForMoveEventResponse(
-                from: releaseEndpoints.source,
-                initialOrigin: itemOrigin,
-                timeout: timeout
-            )
         } catch {
             let attemptError = error
             do {
@@ -912,7 +1215,154 @@ extension MenuBarItemManager {
         guard !releaseGuard.didFire else {
             throw EventError.moveTimedOut(item)
         }
-        return timeout
+        let revertedToStart = itemOrigin == itemBounds.origin
+        if revertedToStart {
+            MenuBarItemManager.diagLog.debug(
+                "Move events (\(strategy)) left \(liveItem.logString) at its starting origin (\(itemOrigin.x),\(itemOrigin.y))"
+            )
+        }
+        return MoveEventsOutcome(
+            timeout: timeout,
+            revertedToStart: revertedToStart,
+            strategy: strategy
+        )
+    }
+
+    /// Builds a faithful drag on the item's own menu-bar row. The strict
+    /// transport classifier has already proved both endpoints are on the
+    /// selected display and in one notch-safe segment.
+    private func faithfulDragSteps(
+        itemBounds: CGRect,
+        targetPoints: (start: CGPoint, end: CGPoint)
+    ) -> [MoveGesture.Step] {
+        let barY = itemBounds.minY
+        return MoveGesture.faithfulDrag(
+            start: CGPoint(x: itemBounds.midX, y: barY),
+            end: CGPoint(x: targetPoints.end.x, y: barY),
+            intermediateSteps: 3
+        )
+    }
+
+    /// Posts one coherent faithful drag, and always ends it with a release on
+    /// the bar before propagating a failure.
+    private func postFaithfulDragSteps(
+        _ steps: [MoveGesture.Step],
+        item: MenuBarItem,
+        source: CGEventSource,
+        startOrigin: CGPoint,
+        timeout: Duration,
+        openingEvent: CGEvent,
+        releaseGuard: PressReleaseGuard,
+        destination: MoveDestination,
+        on displayID: CGDirectDisplayID
+    ) async throws -> CGPoint {
+        guard steps.last?.subtype == .mouseUp else {
+            throw EventError.eventCreationFailure(item)
+        }
+        let dragSteps = steps.dropLast()
+
+        var itemOrigin = startOrigin
+        var responseItem = item
+        for (index, step) in dragSteps.enumerated() {
+            let liveItem: MenuBarItem
+            let event: CGEvent
+            if index == 0 {
+                guard step.subtype == .mouseDown else {
+                    throw EventError.eventCreationFailure(item)
+                }
+                liveItem = item
+                event = openingEvent
+            } else {
+                let endpoints = try await resolveCurrentMoveEndpoints(
+                    source: item,
+                    destination: destination.targetItem,
+                    on: displayID
+                )
+                _ = try validateMoveEndpointGeometry(
+                    item: endpoints.source,
+                    target: endpoints.target,
+                    snapshot: endpoints.snapshot,
+                    on: displayID
+                )
+                liveItem = endpoints.source
+                guard let liveEvent = CGEvent.menuBarItemEvent(
+                    item: liveItem,
+                    source: source,
+                    type: .move(step.subtype),
+                    location: step.point
+                ) else {
+                    throw EventError.eventCreationFailure(liveItem)
+                }
+                event = liveEvent
+            }
+            try await scrombleEvent(event, item: liveItem, timeout: timeout)
+            responseItem = liveItem
+            if step.subtype == .mouseDragged {
+                await eventSleep(for: .milliseconds(8))
+            }
+        }
+        itemOrigin = try await waitForMoveEventResponse(
+            from: responseItem,
+            initialOrigin: startOrigin,
+            timeout: timeout
+        )
+
+        // Reflow can move the anchor while the button is held. Re-resolve and
+        // validate the exact release edge instead of using the planned one.
+        let releaseEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        _ = try validateMoveEndpointGeometry(
+            item: releaseEndpoints.source,
+            target: releaseEndpoints.target,
+            snapshot: releaseEndpoints.snapshot,
+            on: displayID
+        )
+        let releaseDestination = releaseEndpoints.destination(matching: destination)
+        let releasePoints = getTargetPoints(
+            forMoving: releaseEndpoints.source,
+            to: releaseDestination,
+            itemBounds: releaseEndpoints.source.bounds,
+            targetBounds: releaseEndpoints.target.bounds,
+            on: displayID
+        )
+        let releasePoint = CGPoint(
+            x: releasePoints.end.x,
+            y: releaseEndpoints.source.bounds.minY
+        )
+        guard let releaseEvent = CGEvent.menuBarItemEvent(
+            item: releaseEndpoints.source,
+            source: source,
+            type: .move(.mouseUp),
+            location: releasePoint
+        ) else {
+            throw EventError.eventCreationFailure(releaseEndpoints.source)
+        }
+        try await scrombleEvent(
+            releaseEvent,
+            item: releaseEndpoints.source,
+            timeout: timeout,
+            repeating: 2
+        )
+        releaseGuard.recordReleaseAttempt(delivered: true)
+
+        // A revert returns to the start and therefore cannot be awaited as an
+        // origin change after release. Give the drop one short settling beat
+        // and re-resolve the exact source before reading its resting origin.
+        await eventSleep(for: .milliseconds(30))
+        let restingEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        itemOrigin = restingEndpoints.source.bounds.origin
+        return itemOrigin
+    }
+
+    private var faithfulDragMovesEnabled: Bool {
+        (Defaults.object(forKey: .faithfulDragMoves) as? Bool) ?? Defaults.DefaultValue.faithfulDragMoves
     }
 
     /// Checks if a menu bar item is in a "blocked" state (positioned at x=-1 off-screen).
@@ -1478,7 +1928,7 @@ extension MenuBarItemManager {
                     attemptMouseLocation = try getMouseLocation()
                     MouseHelpers.hideCursor(watchdogTimeout: options.watchdogTimeout ?? .seconds(2))
                 }
-                let attemptTimeout = try await postMoveEvents(
+                let outcome = try await postMoveEvents(
                     item: item,
                     destination: destination,
                     on: resolvedDisplayID,
@@ -1501,7 +1951,7 @@ extension MenuBarItemManager {
                 // successful moves (#889).
                 updateMoveOperationTimeout(
                     Self.nextMoveOperationTimeout(
-                        after: attemptTimeout,
+                        after: outcome.timeout,
                         outcome: landedOnDestination ? .landed : .displacedWithoutLanding
                     ),
                     for: item
@@ -1592,6 +2042,9 @@ extension MenuBarItemManager {
                     throw error
                 }
                 if case EventError.moveTimedOut = error {
+                    throw error
+                }
+                if case EventError.unsafeMovePath = error {
                     throw error
                 }
                 // Also definitive for the duration of this call: a hung owner

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
@@ -53,6 +53,8 @@ extension MenuBarItemManager {
             case superseded
             /// The press outlived its deadline and was released by the guard.
             case overran
+            /// The selected endpoints do not form a safe path on one display.
+            case unsafePath
             /// Anything else.
             case other
         }
@@ -86,6 +88,8 @@ extension MenuBarItemManager {
             /// A press was released by the deadline guard, or the move as a
             /// whole ran past its deadline.
             case overran
+            /// No transport can safely connect the selected endpoints.
+            case unsafePath
             /// Every attempt displaced the item without landing it.
             case budgetExhausted
             /// The final attempt failed for an unclassified reason.
@@ -103,7 +107,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .targetMoved, .targetRetreating, .ownerAlwaysSilent, .ownerSilent, .overran, .budgetExhausted, .other:
                     true
-                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded:
+                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded, .unsafePath:
                     false
                 }
             }
@@ -115,7 +119,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent:
                     true
-                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other:
+                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .unsafePath, .budgetExhausted, .other:
                     false
                 }
             }
@@ -132,6 +136,7 @@ extension MenuBarItemManager {
                 case .destinationGone: "destination gone"
                 case .superseded: "superseded"
                 case .overran: "overran deadline"
+                case .unsafePath: "unsafe path"
                 case .budgetExhausted: "budget exhausted"
                 case .other: "other"
                 }
@@ -248,6 +253,8 @@ extension MenuBarItemManager {
                     return .stop(.superseded)
                 case .overran:
                     return .stop(.overran)
+                case .unsafePath:
+                    return .stop(.unsafePath)
                 case .ownerSilent:
                     // An owner with a standing record of ignoring synthetic
                     // events gets no further attempts once it fails this way
@@ -308,6 +315,8 @@ extension MenuBarItemManager {
                 .superseded
             case .moveTimedOut:
                 .overran
+            case .unsafeMovePath:
+                .unsafePath
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
                  .itemNotMovable, .menuTrackingActive, .eventWindowMismatch, .staleDestination,
                  .inputPauseTimedOut, .dropReverted, .moveEngineBusy:
@@ -344,7 +353,7 @@ extension MenuBarItemManager {
         case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
              .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
              .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
-             .moveEngineBusy, .moveTimedOut:
+             .moveEngineBusy, .moveTimedOut, .unsafeMovePath:
             return .other
         }
     }
@@ -411,6 +420,8 @@ extension MenuBarItemManager {
             EventError.moveSuperseded(item)
         case .overran:
             EventError.moveTimedOut(item)
+        case .unsafePath:
+            EventError.unsafeMovePath(item)
         case .ownerAlwaysSilent, .ownerSilent, .other:
             (lastError as? EventError) ?? EventError.cannotComplete
         case .budgetExhausted:

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -245,6 +245,7 @@ nonisolated extension Defaults {
         static let postMoveEventsToWindowOwner = true
         static let discardStrayMoveEvents = true
         static let failFastOnEventWindowMismatch = false
+        static let faithfulDragMoves = false
         static let axMessagingTimeout = SharedConstants.axMessagingTimeout
     }
 }
@@ -545,6 +546,31 @@ nonisolated extension Defaults {
         ///
         /// Hidden diagnostic flag; not exposed in Settings. Default: false.
         case failFastOnEventWindowMismatch = "failFastOnEventWindowMismatch"
+
+        /// Whether an eligible move presses on the item where it sits and
+        /// drags it to the destination (a faithful gesture) instead of the
+        /// press-at-destination "teleport".
+        ///
+        /// On macOS 26 Control Center hosts every status item as a remote
+        /// FrontBoard scene owned by the source app. The teleport presses at
+        /// the destination with the item's window stamped and relies on
+        /// Control Center to relocate a passive item; when the source app's
+        /// status-item scene is cold, the drop can complete on Control
+        /// Center's side while the app never commits the new position, so
+        /// Control Center restores the item's autosaved slot (the "revert").
+        /// Pressing on the item makes the source app start the drag itself
+        /// (`NSStatusItemStartDragAction`) with a warm scene. The transport
+        /// classifier uses this only for an on-screen path inside one safe
+        /// notch segment. Parked and cross-notch endpoints have explicitly
+        /// named teleport transports; invalid or cross-display geometry is
+        /// rejected rather than silently falling back. Inferred from field
+        /// logs, not yet confirmed on a live bar, so it is opt-in.
+        ///
+        /// Enable with:
+        ///   defaults write com.stonerl.Thaw faithfulDragMoves -bool YES
+        ///
+        /// Hidden diagnostic flag; not exposed in Settings. Default: false.
+        case faithfulDragMoves = "faithfulDragMoves"
 
         /// Seconds an accessibility message may block before it fails.
         ///

--- a/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
@@ -127,4 +127,38 @@ struct MoveEndpointIdentityTests {
             destinationWindowID: destination.windowID
         ) == nil)
     }
+
+    @Test("Parked lane geometry is not mistaken for a left display")
+    func parkedLaneIsExplicit() {
+        let selected: CGDirectDisplayID = 1
+        let left: CGDirectDisplayID = 2
+        let displays = [
+            MenuBarItemManager.MoveDisplayGeometry(
+                id: selected,
+                bounds: CGRect(x: 0, y: 0, width: 1728, height: 1117)
+            ),
+            MenuBarItemManager.MoveDisplayGeometry(
+                id: left,
+                bounds: CGRect(x: -2560, y: 0, width: 2560, height: 1440)
+            ),
+        ]
+        let parked = CGRect(x: -2450, y: 0, width: 24, height: 24)
+
+        #expect(MenuBarItemManager.moveEndpointDisposition(
+            bounds: parked,
+            isOnScreen: false,
+            selectedDisplayID: selected,
+            displays: displays,
+            parkedLaneYRange: 0 ... 24,
+            controlDividerX: 1400
+        ) == .parked)
+        #expect(MenuBarItemManager.moveEndpointDisposition(
+            bounds: parked,
+            isOnScreen: true,
+            selectedDisplayID: selected,
+            displays: displays,
+            parkedLaneYRange: 0 ... 24,
+            controlDividerX: 1400
+        ) == .otherDisplay(left))
+    }
 }

--- a/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
@@ -83,6 +83,7 @@ struct MoveFailureAttributionTests {
         .staleDestination(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .moveTimedOut(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .moveEngineBusy(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .unsafeMovePath(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .missingItemBounds(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .cannotComplete,
     ])

--- a/ThawTests/MenuBar/Items/MoveGestureTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGestureTests.swift
@@ -1,0 +1,231 @@
+//
+//  MoveGestureTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Thaw
+
+/// Tests for the pure faithful-drag gesture builder used by the on-item drop
+/// strategy. The geometry is exercised without a live menu bar.
+@Suite("Move gesture")
+struct MoveGestureTests {
+    private typealias Gesture = MenuBarItemManager.MoveGesture
+    private typealias Path = MenuBarItemManager.HorizontalPathDisposition
+    private typealias Transport = MenuBarItemManager.MoveTransportDecision
+
+    /// A gesture is a well-formed drag: it opens with a mouse-down on the
+    /// press point and closes with a mouse-up on the destination, with a
+    /// settling drag onto the destination just before the release.
+    @Test("A faithful drag opens with a down on the item and closes with an up on the destination")
+    func gestureIsWellFormed() {
+        let start = CGPoint(x: 1452, y: 16.5)
+        let end = CGPoint(x: -3725, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 3)
+
+        #expect(steps.first == Gesture.Step(subtype: .mouseDown, point: start))
+        #expect(steps.last == Gesture.Step(subtype: .mouseUp, point: end))
+        #expect(steps.dropLast().last == Gesture.Step(subtype: .mouseDragged, point: end))
+        // down + 3 interpolated drags + settle drag + up.
+        #expect(steps.count == 6)
+        // Exactly one down and one up; everything else is a drag.
+        #expect(steps.count(where: { $0.subtype == .mouseDown }) == 1)
+        #expect(steps.count(where: { $0.subtype == .mouseUp }) == 1)
+        #expect(steps.count(where: { $0.subtype == .mouseDragged }) == 4)
+    }
+
+    /// The gesture always contains at least one interpolated drag, even when
+    /// the caller asks for none, so the item is never teleported by a bare
+    /// down/up pair on this path.
+    @Test("The intermediate step count is clamped to at least one")
+    func intermediateStepsAreClamped() {
+        let start = CGPoint(x: 1000, y: 16.5)
+        let end = CGPoint(x: 200, y: 16.5)
+
+        let zero = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 0)
+        let negative = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: -5)
+
+        // down + 1 interpolated drag + settle drag + up.
+        #expect(zero.count == 4)
+        #expect(negative.count == 4)
+    }
+
+    /// Every event of an on-bar gesture shares the caller-pinned vertical
+    /// coordinate. This is the invariant that keeps Control Center reading a
+    /// reorder: a path that dips below the bar is read as a removal, which is
+    /// what orphaned a hosted item's scene in the field.
+    @Test("A gesture pinned to one bar line keeps every event on that line")
+    func gestureStaysOnTheBarLine() {
+        let barY: CGFloat = 16.5
+        let start = CGPoint(x: 1452, y: barY)
+        let end = CGPoint(x: -3725, y: barY)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 4)
+
+        #expect(steps.allSatisfy { $0.point.y == barY })
+    }
+
+    /// The interpolated drag points march monotonically from the press toward
+    /// the destination and never overshoot either endpoint, so the drag reads
+    /// as one continuous sweep.
+    @Test("Interpolated points advance monotonically and stay between the endpoints")
+    func interpolatedPointsAreMonotonic() {
+        let start = CGPoint(x: 1452, y: 16.5)
+        let end = CGPoint(x: -3725, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 5)
+        // The release intentionally repeats the destination occupied by the
+        // settling drag, so monotonicity applies through the final drag rather
+        // than across the stationary mouse-up event.
+        let xs = steps.dropLast().map(\.point.x)
+
+        // Strictly decreasing overall (start.x > end.x here).
+        #expect(zip(xs, xs.dropFirst()).allSatisfy { $0 > $1 })
+        let lowerBound = min(start.x, end.x)
+        let upperBound = max(start.x, end.x)
+        #expect(steps.allSatisfy { $0.point.x >= lowerBound && $0.point.x <= upperBound })
+    }
+
+    /// A rightward move (destination to the right of the item) advances the
+    /// other way, confirming the builder is direction-agnostic.
+    @Test("A rightward move advances left to right")
+    func rightwardMoveAdvances() {
+        let start = CGPoint(x: 200, y: 16.5)
+        let end = CGPoint(x: 1000, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 3)
+        let xs = steps.dropLast().map(\.point.x)
+
+        #expect(zip(xs, xs.dropFirst()).allSatisfy { $0 < $1 })
+    }
+
+    // MARK: Transport safety
+
+    @Test("Horizontal paths distinguish safe segments, notch crossings, and invalid endpoints")
+    func horizontalPathClassification() {
+        let display: ClosedRange<CGFloat> = 0 ... 1470
+        let notch: ClosedRange<CGFloat> = 645 ... 825
+
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 100,
+            destinationX: 600,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .sameSafeSegment)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 900,
+            destinationX: 1400,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .sameSafeSegment)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 600,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .crossesNotch)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 700,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .invalidEndpoint)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: -1,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .invalidEndpoint)
+    }
+
+    @Test("Faithful dragging is selected only for one safe on-screen segment")
+    func faithfulTransportSelection() {
+        let selected: CGDirectDisplayID = 1
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.faithfulDrag))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: false,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.teleport))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: true,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.teleport))
+    }
+
+    @Test("Parked and cross-notch teleports are explicit decisions")
+    func explicitTeleportSelection() {
+        let selected: CGDirectDisplayID = 1
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: nil,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .invalidEndpoint
+        ) == .use(.parkedTeleport))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .crossesNotch
+        ) == .use(.crossNotchTeleport))
+    }
+
+    @Test("Cross-display and invalid on-screen paths are rejected")
+    func unsafeTransportIsRejected() {
+        let selected: CGDirectDisplayID = 1
+        let other: CGDirectDisplayID = 2
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: other,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .rejectUnsafePath)
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .invalidEndpoint
+        ) == .rejectUnsafePath)
+    }
+
+    @Test("A cross-notch teleport posts no intermediate center coordinate")
+    func crossNotchTeleportUsesExactDestination() {
+        let destination = CGPoint(x: 1200, y: 0)
+        let locations = MenuBarItemManager.moveEventLocations(
+            targetPoints: (start: destination, end: destination),
+            faithfulDragStart: nil
+        )
+
+        #expect(locations.press == destination)
+        #expect(locations.release == destination)
+        #expect(locations.press.x != 735)
+    }
+}

--- a/ThawTests/MenuBar/Items/MovePolicyTests.swift
+++ b/ThawTests/MenuBar/Items/MovePolicyTests.swift
@@ -144,6 +144,7 @@ struct MovePolicyTests {
         (.ownerUnresponsive, .ownerUnresponsive),
         (.superseded, .superseded),
         (.overran, .overran),
+        (.unsafePath, .unsafePath),
     ])
     func definitiveFailuresStop(failure: Policy.AttemptFailure, reason: Policy.StopReason) {
         #expect(decisions([.failed(failure)]) == [.stop(reason)])
@@ -214,7 +215,7 @@ struct MovePolicyTests {
     }
 
     @Test("Reasons that prove the item did not land skip the final check", arguments: [
-        Policy.StopReason.refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded,
+        Policy.StopReason.refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded, .unsafePath,
     ])
     func noFinalCheckReasons(reason: Policy.StopReason) {
         #expect(!reason.deservesFinalLandingCheck)
@@ -223,7 +224,7 @@ struct MovePolicyTests {
     @Test("Only silence is filed against the owner")
     func onlySilenceIsFiled() {
         let filed: [Policy.StopReason] = [.ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent]
-        let notFiled: [Policy.StopReason] = [.refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other]
+        let notFiled: [Policy.StopReason] = [.refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .unsafePath, .budgetExhausted, .other]
         let everyFiledReasonIsFiled = filed.allSatisfy(\.isFiledAgainstOwner)
         let noOtherReasonIsFiled = notFiled.allSatisfy { !$0.isFiledAgainstOwner }
         #expect(everyFiledReasonIsFiled)
@@ -246,6 +247,7 @@ struct MovePolicyTests {
         #expect(Policy.attemptFailure(for: .missingDestinationBounds(item)) == .destinationGone)
         #expect(Policy.attemptFailure(for: .moveSuperseded(item)) == .superseded)
         #expect(Policy.attemptFailure(for: .moveTimedOut(item)) == .overran)
+        #expect(Policy.attemptFailure(for: .unsafeMovePath(item)) == .unsafePath)
         #expect(Policy.attemptFailure(for: .cannotComplete) == .other)
     }
 
@@ -258,6 +260,7 @@ struct MovePolicyTests {
         (.destinationGone, "missingDestinationBounds"),
         (.superseded, "moveSuperseded"),
         (.overran, "moveTimedOut"),
+        (.unsafePath, "unsafeMovePath"),
         (.budgetExhausted, "cannotComplete"),
         (.ownerSilent, "cannotComplete"),
         (.other, "cannotComplete"),


### PR DESCRIPTION
# Summary

Adds an explicit transport classifier for menu-bar moves and an opt-in faithful horizontal drag. A faithful move presses on the exact source window, stays on its menu-bar row through bounded intermediate drag events, settles at the exact destination edge, and releases there. This avoids presenting a horizontal reorder as a drag-to-remove gesture.

Transport fallback is no longer implicit. Parked endpoints use a named parked teleport, opposite sides of a notch use a named cross-notch teleport with no intermediate center coordinate, and a normal on-screen teleport remains explicit when faithful dragging is disabled or the source is a Thaw control item. An endpoint on another display, inside the reserved notch interval, or otherwise outside the selected display is rejected before any synthetic press is posted.

**Scope:** This PR changes 9 files with 835 insertions and 69 deletions. It adds the transport/geometry decision, faithful gesture construction and posting, per-step endpoint revalidation, the hidden opt-in default, a precise unsafe-path error, and Swift Testing coverage. It does not enable faithful dragging by default, alter trigger callers, coordinate LayoutApply batches, or change Layout Bar UI transitions. This may be suitable for 2.2.

Dependency: #998 must be merged first or used as this PR's base. The transport operates inside that PR's serialized transaction, relies on its exact endpoint geometry and press-release guard, and extends the move-outcome vocabulary introduced by #997.

## Linked issue (required)

Closes: N/A

Related: #881, #889

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- A pure classifier chooses among faithful drag, normal teleport, parked teleport, cross-notch teleport, and rejection.
- Faithful dragging is eligible only when enabled, both endpoints belong to the selected display, the item is not a Thaw control item, and the horizontal path stays inside one safe notch segment.
- The faithful sequence contains exactly one opening press, bounded interpolated drag events, a settling drag at the destination, and one release, all pinned to the source item's menu-bar row.
- The exact source and anchor identities plus their display/parked classification are revalidated before every faithful step and again before release; a changed endpoint stops the sequence safely.
- A failed faithful sequence releases on the bar before propagating its error, and the independent deadline guard is stamped for the source window used by that gesture.
- Parked source or destination windows use an explicit parked teleport; the stamped press and release remain at the exact requested destination.
- A notch crossing uses an explicit destination-stamped teleport, never a display-center or notch-midpoint intermediate coordinate.
- Vertically stacked or otherwise different displays are distinguished by display identity even when their horizontal ranges overlap.
- Endpoints inside the notch reserve, outside the selected display, or on another live display produce `unsafeMovePath` before events are posted; that terminal outcome is not attributed to the owner.
- The hidden `faithfulDragMoves` preference defaults to `false`, preserving the established transport unless explicitly enabled for testing.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build-for-testing -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawPR7SafeBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test-without-building -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawPR7SafeBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/MoveEndpointIdentityTests -only-testing:ThawTests/MoveGatePreflightTests -only-testing:ThawTests/MoveGestureTests -only-testing:ThawTests/MoveEventCoordinatesTests -only-testing:ThawTests/MovePolicyTests`

The test build succeeded, and all 57 selected tests across 5 endpoint, gate, transport, coordinate, and policy suites passed. SwiftFormat lint passed for every changed Swift file; strict SwiftLint reported 0 violations; the generated SwiftLint input list and `git diff --check` matched cleanly.

## Known limitations / follow-ups

- Faithful dragging remains a hidden, opt-in diagnostic setting because the private macOS transport has not been manually exercised across a representative set of status-item owners and display topologies.
- Parked and cross-notch moves still require explicitly classified teleports; macOS or an individual app can refuse them.
- The live loop still uses its prior retry structure at this stack point. The next PR adds settling, deadline, refusal, and bounded terminal-verdict handling.
- Trigger-owned movement, automatic reporting, LayoutApply coordination, cache transactions, and Layout Bar UI transitions remain separate work.
- This stacked PR should remain based on PR 5 until that dependency merges; after rebasing onto `development`, the target-branch checklist item can be checked.

## Other information

No manual app launch or live menu-bar gesture run was performed for this PR; verification was through pure geometry/gesture tests, focused automated tests, builds, formatting, lint, generated-file comparison, and diff checks.

The commit includes a `Signed-off-by` trailer for the project's DCO requirement. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 7 of 12  
**Git base:** #998  
**Functional dependencies:** #997 and #998.
