### PR TITLE
fix(menubar): coordinate automatic move batches

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -38,6 +38,15 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Reference box recording whether a queued move was accepted by its
+    /// preflight. ``MoveOptions/shouldBegin`` escapes the call frame — it is
+    /// stored in the options struct — so a captured local cannot be mutated
+    /// from inside the closure.
+    private final class MoveAttemptAcceptanceRecorder {
+        var didAcceptMoveAttempt = false
+        var didAcceptCurrentMove = false
+    }
+
     /// Relocates any newly appearing items that macOS placed to the left
     /// of our control items back into the visible section.
     ///
@@ -52,6 +61,7 @@ extension MenuBarItemManager {
         recentWindowIDs: Set<CGWindowID>,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard appState != nil else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
@@ -161,28 +171,28 @@ extension MenuBarItemManager {
 
         case let .systemItem(systemItem):
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: systemItem,
                     to: .rightOfItem(controlItems.hidden),
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale system-item relocation for \(systemItem.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -202,10 +212,10 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.info(
                     "Skipping new-item relocation for Thaw spacer \(candidate.logString)"
                 )
-                // Nothing was relocated: reporting true would make the caller
-                // treat this cycle as interrupted and schedule an extra
+                // Nothing was relocated: reporting an attempt would make the
+                // caller treat this cycle as interrupted and schedule an extra
                 // recache for a no-op. The spacer is already marked known.
-                return false
+                return .noAttempt
             }
 
             let destination = newItemsMoveDestination(for: controlItems, among: items)
@@ -222,28 +232,28 @@ extension MenuBarItemManager {
                 return .noAttempt
             }
 
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: candidate,
                     to: destination,
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale new-item relocation for \(candidate.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -272,6 +282,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         // The destination is the right of H_ctrl. When the divider itself is
         // parked offscreen, that destination is in the parked zone: the drag
         // strands the chevron beside it, invisible to the user (#958's
@@ -289,28 +300,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             try await move(
                 item: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug(
                 "Skipping stale Thaw-icon relocation for \(thawIcon.logString)"
             )
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
         return .completed
     }
@@ -331,6 +342,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocatePendingItems: skipping for provisional AX-frame correlation"
@@ -367,7 +379,7 @@ extension MenuBarItemManager {
             }
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         var didCompleteMove = false
         var didFailAcceptedMove = false
         func outcome() -> CacheDrivenMoveOutcome {
@@ -377,7 +389,7 @@ extension MenuBarItemManager {
             if didCompleteMove {
                 return .completed
             }
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
 
         // Iterate a snapshot of the dict keys so promotions of waitForRelaunch
@@ -467,27 +479,27 @@ extension MenuBarItemManager {
                         item: item,
                         to: destination,
                         skipInputPause: true,
-                        shouldBegin: {
-                            let shouldBegin = shouldBeginMove?() ?? true
+                        options: .init(shouldBegin: {
+                            let shouldBegin = beginMove?() ?? true
                             if shouldBegin {
-                                didAcceptMoveAttempt = true
-                                didAcceptCurrentMove = true
+                                attemptRecorder.didAcceptMoveAttempt = true
+                                attemptRecorder.didAcceptCurrentMove = true
                             }
                             return shouldBegin
-                        }
+                        })
                     )
                     pendingRelocations.removeValue(forKey: tagIdentifier)
                     pendingReturnDestinations.removeValue(forKey: tagIdentifier)
                     didCompleteMove = true
                 } catch EventError.moveSuperseded {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.debug(
                         "Stopping stale pending-item relocations before moving \(item.logString)"
                     )
                     persistPendingRelocations()
                     return outcome()
                 } catch {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.error(
                         """
                         Failed to relocate \(item.logString) back to \
@@ -536,6 +548,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Skipping control item order enforcement for provisional AX-frame correlation"
@@ -565,28 +578,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             MenuBarItemManager.diagLog.debug("Control items have incorrect order")
             try await move(
                 item: alwaysHidden,
                 to: .leftOfItem(hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
             return .completed
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug("Skipping stale control-item order enforcement")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -14,22 +14,50 @@ import Cocoa
 // MARK: - Control Item Order
 
 extension MenuBarItemManager {
+    /// Result of one cache-driven move helper.
+    ///
+    /// A failed attempt still needs one authoritative cache read because
+    /// synthetic events may have changed position before verification failed.
+    /// It must not immediately rerun the same automatic helper, however, or a
+    /// persistent refusal becomes an unbounded recache/retry chain.
+    enum CacheDrivenMoveOutcome: Equatable {
+        case noAttempt
+        case completed
+        case failedAttempt
+
+        var needsAuthoritativeRecache: Bool {
+            self != .noAttempt
+        }
+
+        var shouldSuppressAutomaticMovesDuringRecache: Bool {
+            self == .failedAttempt
+        }
+
+        var shouldSuppressSavedOrderPersistenceDuringRecache: Bool {
+            self == .failedAttempt
+        }
+    }
+
     /// Relocates any newly appearing items that macOS placed to the left
     /// of our control items back into the visible section.
     ///
-    /// Returns true if a relocation was performed.
+    /// Returns whether no move began, a move completed, or an accepted move
+    /// later failed. Even a failed attempt may have displaced the item, so
+    /// callers must follow every accepted attempt with an authoritative
+    /// recache without persisting that possibly partial geometry.
     func relocateNewLeftmostItems(
         _ items: [MenuBarItem],
         controlItems: ControlItemPair,
         previousWindowIDs: [CGWindowID],
-        recentWindowIDs: Set<CGWindowID>
-    ) async -> Bool {
-        guard appState != nil else { return false }
+        recentWindowIDs: Set<CGWindowID>,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
+        guard appState != nil else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocateNewLeftmostItems: skipping for provisional AX-frame correlation"
             )
-            return false
+            return .noAttempt
         }
 
         if suppressNextNewLeftmostItemRelocation {
@@ -43,7 +71,7 @@ extension MenuBarItemManager {
             knownItemIdentifiers.formUnion(identifiers)
             persistKnownItemIdentifiers()
             suppressNextNewLeftmostItemRelocation = false
-            return false
+            return .noAttempt
         }
 
         // During startup settling, the first cache pass may have items tagged
@@ -78,9 +106,13 @@ extension MenuBarItemManager {
                 items: items,
                 hiddenBounds: bestBounds(for: controlItems.hidden)
             ) {
-                return await relocateThawIcon(thawIcon, controlItems: controlItems)
+                return await relocateThawIcon(
+                    thawIcon,
+                    controlItems: controlItems,
+                    shouldBeginMove: shouldBeginMove
+                )
             }
-            return false
+            return .noAttempt
         }
 
         // Cached hidden / always-hidden tags from the prior cache cycle.
@@ -121,21 +153,38 @@ extension MenuBarItemManager {
 
         switch decision {
         case let .thawIcon(thawIcon):
-            return await relocateThawIcon(thawIcon, controlItems: controlItems)
+            return await relocateThawIcon(
+                thawIcon,
+                controlItems: controlItems,
+                shouldBeginMove: shouldBeginMove
+            )
 
         case let .systemItem(systemItem):
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
+            var didAcceptMoveAttempt = false
             do {
                 try await move(
                     item: systemItem,
                     to: .rightOfItem(controlItems.hidden),
-                    skipInputPause: true
+                    skipInputPause: true,
+                    shouldBegin: {
+                        let shouldBegin = shouldBeginMove?() ?? true
+                        if shouldBegin {
+                            didAcceptMoveAttempt = true
+                        }
+                        return shouldBegin
+                    }
                 )
+            } catch EventError.moveSuperseded {
+                MenuBarItemManager.diagLog.debug(
+                    "Skipping stale system-item relocation for \(systemItem.logString)"
+                )
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return false
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
-            return true
+            return .completed
 
         case let .newHideableItem(candidate, identifierToMark):
             // Track this item so future cache cycles don't treat it as new.
@@ -170,20 +219,33 @@ extension MenuBarItemManager {
             // it requires Bridging.
             guard Bridging.getWindowBounds(for: candidate.windowID) != nil else {
                 MenuBarItemManager.diagLog.warning("Skipping relocation for \(candidate.logString); no valid bounds, likely transient")
-                return false
+                return .noAttempt
             }
 
+            var didAcceptMoveAttempt = false
             do {
                 try await move(
                     item: candidate,
                     to: destination,
-                    skipInputPause: true
+                    skipInputPause: true,
+                    shouldBegin: {
+                        let shouldBegin = shouldBeginMove?() ?? true
+                        if shouldBegin {
+                            didAcceptMoveAttempt = true
+                        }
+                        return shouldBegin
+                    }
                 )
+            } catch EventError.moveSuperseded {
+                MenuBarItemManager.diagLog.debug(
+                    "Skipping stale new-item relocation for \(candidate.logString)"
+                )
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return false
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
-            return true
+            return .completed
 
         case let .noop(reason):
             switch reason {
@@ -198,7 +260,7 @@ extension MenuBarItemManager {
             case .noNewCandidate, .noLeftmostItems:
                 break
             }
-            return false
+            return .noAttempt
         }
     }
 
@@ -207,8 +269,9 @@ extension MenuBarItemManager {
     /// planner path, which reach the same decision from different inputs.
     private func relocateThawIcon(
         _ thawIcon: MenuBarItem,
-        controlItems: ControlItemPair
-    ) async -> Bool {
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         // The destination is the right of H_ctrl. When the divider itself is
         // parked offscreen, that destination is in the parked zone: the drag
         // strands the chevron beside it, invisible to the user (#958's
@@ -223,20 +286,33 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "Skipping Thaw icon relocation, the hidden divider is parked offscreen (minX=\(controlItems.hidden.bounds.minX)); moving the icon beside it would strand both"
             )
-            return false
+            return .noAttempt
         }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
+        var didAcceptMoveAttempt = false
         do {
             try await move(
                 item: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
-                skipInputPause: true
+                skipInputPause: true,
+                shouldBegin: {
+                    let shouldBegin = shouldBeginMove?() ?? true
+                    if shouldBegin {
+                        didAcceptMoveAttempt = true
+                    }
+                    return shouldBegin
+                }
             )
+        } catch EventError.moveSuperseded {
+            MenuBarItemManager.diagLog.debug(
+                "Skipping stale Thaw-icon relocation for \(thawIcon.logString)"
+            )
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return false
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
-        return true
+        return .completed
     }
 
     /// Relocates items whose apps quit while they were temporarily shown
@@ -247,20 +323,23 @@ extension MenuBarItemManager {
     /// back, the icon will reappear in the visible section on relaunch.
     /// This method checks for such items and moves them back.
     ///
-    /// Returns `true` if any items were relocated.
+    /// Returns whether no move began, a move completed, or an accepted move
+    /// later failed. A failed accepted attempt can still leave position-only
+    /// geometry that the normal window-ID change detector cannot observe.
     func relocatePendingItems(
         _ items: [MenuBarItem],
-        controlItems: ControlItemPair
-    ) async -> Bool {
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocatePendingItems: skipping for provisional AX-frame correlation"
             )
-            return false
+            return .noAttempt
         }
 
         guard !pendingRelocations.isEmpty else {
-            return false
+            return .noAttempt
         }
 
         // Don't interfere with items that are currently temporarily shown ;
@@ -288,7 +367,18 @@ extension MenuBarItemManager {
             }
         }
 
-        var didRelocate = false
+        var didAcceptMoveAttempt = false
+        var didCompleteMove = false
+        var didFailAcceptedMove = false
+        func outcome() -> CacheDrivenMoveOutcome {
+            if didFailAcceptedMove {
+                return .failedAttempt
+            }
+            if didCompleteMove {
+                return .completed
+            }
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+        }
 
         // Iterate a snapshot of the dict keys so promotions of waitForRelaunch
         // sentinels mid-loop don't disturb iteration. The planner is called
@@ -356,6 +446,7 @@ extension MenuBarItemManager {
 
             switch decision {
             case let .move(item, destination):
+                var didAcceptCurrentMove = false
                 let targetSection: MenuBarSection.Name = {
                     if case let .section(section) = entry.kind {
                         return section
@@ -372,11 +463,31 @@ extension MenuBarItemManager {
                     """
                 )
                 do {
-                    try await move(item: item, to: destination, skipInputPause: true)
+                    try await move(
+                        item: item,
+                        to: destination,
+                        skipInputPause: true,
+                        shouldBegin: {
+                            let shouldBegin = shouldBeginMove?() ?? true
+                            if shouldBegin {
+                                didAcceptMoveAttempt = true
+                                didAcceptCurrentMove = true
+                            }
+                            return shouldBegin
+                        }
+                    )
                     pendingRelocations.removeValue(forKey: tagIdentifier)
                     pendingReturnDestinations.removeValue(forKey: tagIdentifier)
-                    didRelocate = true
+                    didCompleteMove = true
+                } catch EventError.moveSuperseded {
+                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    MenuBarItemManager.diagLog.debug(
+                        "Stopping stale pending-item relocations before moving \(item.logString)"
+                    )
+                    persistPendingRelocations()
+                    return outcome()
                 } catch {
+                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
                     MenuBarItemManager.diagLog.error(
                         """
                         Failed to relocate \(item.logString) back to \
@@ -410,7 +521,7 @@ extension MenuBarItemManager {
         }
 
         persistPendingRelocations()
-        return didRelocate
+        return outcome()
     }
 
     /// Returns the best-known bounds for a menu bar item.
@@ -421,12 +532,15 @@ extension MenuBarItemManager {
     /// Enforces the order of the given control items, ensuring that the
     /// control item for the always-hidden section is positioned to the
     /// left of control item for the hidden section.
-    func enforceControlItemOrder(controlItems: ControlItemPair) async {
+    func enforceControlItemOrder(
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Skipping control item order enforcement for provisional AX-frame correlation"
             )
-            return
+            return .noAttempt
         }
 
         let hidden = controlItems.hidden
@@ -435,7 +549,7 @@ extension MenuBarItemManager {
             let alwaysHidden = controlItems.alwaysHidden,
             bestBounds(for: hidden).maxX <= bestBounds(for: alwaysHidden).minX
         else {
-            return
+            return .noAttempt
         }
 
         // Moving AH_ctrl to the left of a parked H_ctrl drops the entire
@@ -448,14 +562,31 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "Skipping control item order enforcement, the hidden divider is parked offscreen (minX=\(hidden.bounds.minX))"
             )
-            return
+            return .noAttempt
         }
 
+        var didAcceptMoveAttempt = false
         do {
             MenuBarItemManager.diagLog.debug("Control items have incorrect order")
-            try await move(item: alwaysHidden, to: .leftOfItem(hidden), skipInputPause: true)
+            try await move(
+                item: alwaysHidden,
+                to: .leftOfItem(hidden),
+                skipInputPause: true,
+                shouldBegin: {
+                    let shouldBegin = shouldBeginMove?() ?? true
+                    if shouldBegin {
+                        didAcceptMoveAttempt = true
+                    }
+                    return shouldBegin
+                }
+            )
+            return .completed
+        } catch EventError.moveSuperseded {
+            MenuBarItemManager.diagLog.debug("Skipping stale control-item order enforcement")
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -2012,7 +2012,40 @@ extension MenuBarItemManager {
 
         guard snapshotIsCurrent("before control-item order enforcement") else { return }
         if !suppressAutomaticMoves {
-            await enforceControlItemOrder(controlItems: controlItems)
+            let controlItemOrderOutcome = await enforceControlItemOrder(
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("control-item order move preflight")
+                }
+            )
+            if controlItemOrderOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Control-item reorder attempt reached moveGate; scheduling authoritative recache"
+                )
+                // A pure position change does not change the window-ID set, so
+                // cacheItemsIfNeeded cannot discover it. Hand the waiter to an
+                // explicit post-settle cycle instead of leaving itemCache at
+                // the geometry observed before the divider move.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || controlItemOrderOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || controlItemOrderOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || controlItemOrderOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
+            }
         }
 
         guard !Task.isCancelled else {
@@ -2120,27 +2153,38 @@ extension MenuBarItemManager {
         }
 
         if !suppressAutomaticMoves {
-            if await relocateNewLeftmostItems(
+            let newLeftmostOutcome = await relocateNewLeftmostItems(
                 items,
                 controlItems: controlItems,
                 previousWindowIDs: previousWindowIDs,
-                recentWindowIDs: recentWindowIDs
-            ) {
-                MenuBarItemManager.diagLog.debug("Relocated new leftmost items; scheduling recache")
+                recentWindowIDs: recentWindowIDs,
+                shouldBeginMove: {
+                    snapshotIsCurrent("new-item relocation move preflight")
+                }
+            )
+            if newLeftmostOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "New-leftmost relocation attempt reached moveGate; scheduling authoritative recache"
+                )
                 // Ownership transfers to the nested recache: the waiter must not
                 // be told the cache is settled until the second cycle finishes.
                 ownsWaiter = false
                 Task { [weak self] in
                     try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
                     // Carry the caller policy across the hand-off: this recache
-                    // is where the launch restore actually runs after the move.
+                    // is where the launch restore actually runs after a completed
+                    // relocation. A failed accepted attempt gets one read-and-
+                    // publish pass with movers suppressed so it cannot retry-loop.
                     await self?.cacheItemsRegardless(
                         skipRecentMoveCheck: true,
                         resolveSourcePID: resolveSourcePID,
                         reuseCachedIdentities: reuseCachedIdentities,
-                        skipSavedLayoutApply: skipSavedLayoutApply,
-                        suppressAutomaticMoves: suppressAutomaticMoves,
-                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || newLeftmostOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || newLeftmostOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || newLeftmostOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
                         bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
                         forcePersistSavedOrder: forcePersistSavedOrder,
                         waiterToken: waiterToken
@@ -2152,8 +2196,17 @@ extension MenuBarItemManager {
         guard snapshotIsCurrent("after new-item relocation check") else { return }
 
         if !suppressAutomaticMoves {
-            if await relocatePendingItems(items, controlItems: controlItems) {
-                MenuBarItemManager.diagLog.debug("Relocated pending temporarily-shown items; scheduling recache")
+            let pendingRelocationOutcome = await relocatePendingItems(
+                items,
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("pending-item relocation move preflight")
+                }
+            )
+            if pendingRelocationOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Pending-item relocation attempt reached moveGate; scheduling authoritative recache"
+                )
                 // Ownership transfers to the nested recache: the waiter must not
                 // be told the cache is settled until the second cycle finishes.
                 ownsWaiter = false
@@ -2163,9 +2216,12 @@ extension MenuBarItemManager {
                         skipRecentMoveCheck: true,
                         resolveSourcePID: resolveSourcePID,
                         reuseCachedIdentities: reuseCachedIdentities,
-                        skipSavedLayoutApply: skipSavedLayoutApply,
-                        suppressAutomaticMoves: suppressAutomaticMoves,
-                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || pendingRelocationOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || pendingRelocationOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || pendingRelocationOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
                         bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
                         forcePersistSavedOrder: forcePersistSavedOrder,
                         waiterToken: waiterToken
@@ -2232,7 +2288,10 @@ extension MenuBarItemManager {
                     controlItems: controlItems,
                     currentDisplayID: displayID,
                     bypassMoveCooldown: true,
-                    resolvedIdentitiesOnly: true
+                    resolvedIdentitiesOnly: true,
+                    shouldBegin: {
+                        snapshotIsCurrent("early saved-layout apply preflight")
+                    }
                 )
                 // Spend the one attempt only on a dispatch that happened. The
                 // flag used to be set before the call, so an apply rejected by
@@ -2286,7 +2345,10 @@ extension MenuBarItemManager {
                 ),
                 controlItems: controlItems,
                 currentDisplayID: displayID,
-                bypassMoveCooldown: bypassSavedLayoutCooldown
+                bypassMoveCooldown: bypassSavedLayoutCooldown,
+                shouldBegin: {
+                    snapshotIsCurrent("saved-layout apply preflight")
+                }
             )
             if didApplySavedLayout {
                 return
@@ -2427,7 +2489,41 @@ extension MenuBarItemManager {
         // and self-gates on every in-flight mover.
         guard snapshotIsCurrent("before notch-overflow rebalance") else { return }
         if !suppressAutomaticMoves {
-            await rebalanceNotchOverflowIfNeeded(items: items, controlItems: controlItems)
+            let notchRebalanceOutcome = await rebalanceNotchOverflowIfNeeded(
+                items: items,
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("notch-overflow move preflight")
+                }
+            )
+            if notchRebalanceOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Notch-overflow rebalance attempted item moves; scheduling authoritative recache"
+                )
+                // The cache above describes the pre-ejection geometry. Position
+                // moves keep their window IDs, so the change detector cannot
+                // discover the stale reading; explicitly hand the waiter and
+                // caller policy to a fresh post-settle cycle.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || notchRebalanceOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || notchRebalanceOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || notchRebalanceOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
+            }
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1883,8 +1883,10 @@ extension MenuBarItemManager {
                                     item: hItem,
                                     to: dest,
                                     skipInputPause: true,
-                                    shouldBegin: shouldBeginBatchMove,
-                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                    options: .init(
+                                        shouldBegin: shouldBeginBatchMove,
+                                        didFinishWhileHoldingGate: didFinishBatchMove
+                                    )
                                 )
                                 movedCount += 1
                                 failureLedger.recordSuccess(for: hItem)
@@ -2005,8 +2007,10 @@ extension MenuBarItemManager {
                             item: item,
                             to: dest,
                             skipInputPause: true,
-                            shouldBegin: shouldBeginBatchMove,
-                            didFinishWhileHoldingGate: didFinishBatchMove
+                            options: .init(
+                                shouldBegin: shouldBeginBatchMove,
+                                didFinishWhileHoldingGate: didFinishBatchMove
+                            )
                         )
                         movedCount += 1
                         didCrossHiddenBoundary = true
@@ -2222,8 +2226,10 @@ extension MenuBarItemManager {
                         item: ahItem,
                         to: dest,
                         skipInputPause: true,
-                        shouldBegin: shouldBeginBatchMove,
-                        didFinishWhileHoldingGate: didFinishBatchMove
+                        options: .init(
+                            shouldBegin: shouldBeginBatchMove,
+                            didFinishWhileHoldingGate: didFinishBatchMove
+                        )
                     )
                     movedCount += 1
                     try? await Task.sleep(for: .milliseconds(200))
@@ -2332,8 +2338,10 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .leftOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+                                    shouldBegin: shouldBeginBatchMove,
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2372,8 +2380,10 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .rightOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+                                    shouldBegin: shouldBeginBatchMove,
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2600,8 +2610,10 @@ extension MenuBarItemManager {
                     item: item,
                     to: dest,
                     skipInputPause: true,
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+                        shouldBegin: shouldBeginBatchMove,
+                        didFinishWhileHoldingGate: didFinishBatchMove
+                    )
                 )
                 movedCount += 1
                 consecutiveMoveFailures = 0

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1463,7 +1463,6 @@ extension MenuBarItemManager {
             )
         }
 
-
         // Divider-order gate (#1027). The room gate above catches dividers
         // collapsed onto one coordinate; this catches them drifted into
         // foreign sections, which leaves the same room between them and so

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -11,6 +11,32 @@ import Cocoa
 // MARK: Layout Reset
 
 extension MenuBarItemManager {
+    /// Tracks which move timestamp belongs to a multi-item automatic apply.
+    ///
+    /// Before the first move, the cache snapshot's preflight owns the verdict.
+    /// After each move releases `moveGate`, the batch adopts the timestamp seen
+    /// while it still owned that gate. The next item therefore accepts changes
+    /// made by this batch and rejects a user move that lands between items.
+    nonisolated struct BatchMovePreflightState {
+        private var didFinishMove = false
+        private var expectedTimestamp: ContinuousClock.Instant?
+
+        func shouldBeginMove(
+            currentTimestamp: ContinuousClock.Instant?,
+            initialPreflight: () -> Bool
+        ) -> Bool {
+            guard didFinishMove else {
+                return initialPreflight()
+            }
+            return currentTimestamp == expectedTimestamp
+        }
+
+        mutating func recordMoveGateExit(timestamp: ContinuousClock.Instant?) {
+            didFinishMove = true
+            expectedTimestamp = timestamp
+        }
+    }
+
     /// Errors that can occur during a layout reset.
     enum LayoutResetError: LocalizedError {
         case missingAppState
@@ -109,7 +135,7 @@ extension MenuBarItemManager {
                     }
                     MenuBarItemManager.diagLog.info("Recovered hidden section control item after re-enabling always-hidden section")
                     prepareLayoutStateForReset()
-                    await enforceControlItemOrder(controlItems: retryControlItems)
+                    _ = await enforceControlItemOrder(controlItems: retryControlItems)
                     return try await resetLayoutWithControlItems(
                         controlItems: retryControlItems,
                         items: items,
@@ -138,7 +164,7 @@ extension MenuBarItemManager {
         // authoritative; a provisional lookup must leave the saved layout intact.
         prepareLayoutStateForReset()
 
-        await enforceControlItemOrder(controlItems: controlItems)
+        _ = await enforceControlItemOrder(controlItems: controlItems)
 
         return try await resetLayoutWithControlItems(
             controlItems: controlItems,
@@ -796,7 +822,8 @@ extension MenuBarItemManager {
         _ spec: ProfileLayoutSpec,
         source: ApplySource = .profile,
         automatic: Bool = false,
-        duringSettling: Bool = false
+        duringSettling: Bool = false,
+        shouldBegin: (@MainActor () -> Bool)? = nil
     ) async {
         let pinnedHidden = spec.pinnedHidden
         let pinnedAlwaysHidden = spec.pinnedAlwaysHidden
@@ -870,6 +897,12 @@ extension MenuBarItemManager {
         // during the settling wait (a newer apply has replaced us via
         // applyProfile's layoutTask?.cancel()).
         if Task.isCancelled {
+            return
+        }
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: skipping automatic apply superseded during its idle wait"
+            )
             return
         }
 
@@ -946,6 +979,14 @@ extension MenuBarItemManager {
         // and reshuffling the bar. This fetch is independent of the cache
         // path, so it needs its own filter.
         items.removeAll(where: \.isSystemClone)
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded during item discovery"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
 
         // Skip the bulk apply while the majority of items have no resolved
         // sourcePID — uniqueIdentifier (used to match items against
@@ -964,7 +1005,16 @@ extension MenuBarItemManager {
         // Never drag items while a menu bar item menu is tracking — a synthetic
         // Cmd-drag would tear down the user's interaction (Wi-Fi picker, input
         // methods). State is unwound so a subsequent apply can retry cleanly.
-        if await isAnyMenuBarItemMenuOpen() {
+        let menuIsOpen = await isAnyMenuBarItemMenuOpen()
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded during its menu check"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
+        if menuIsOpen {
             MenuBarItemManager.diagLog.info("applyProfileLayout: skipping, a menu bar item menu is open")
             clearProfileState(source: source, items: items)
             return
@@ -1384,6 +1434,36 @@ extension MenuBarItemManager {
             return
         }
 
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded while planning"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
+
+        // Each actual move validates the expected timestamp only after it
+        // acquires moveGate. After an owned attempt, the callback advances the
+        // expectation while the gate is still held. A user move that wins the
+        // gate during an inter-item sleep therefore invalidates the next move,
+        // while this batch's own timestamp updates remain accepted.
+        var batchMovePreflight = BatchMovePreflightState()
+        func shouldBeginBatchMove() -> Bool {
+            batchMovePreflight.shouldBeginMove(
+                currentTimestamp: lastMoveOperationTimestamp,
+                initialPreflight: {
+                    shouldBegin?() ?? true
+                }
+            )
+        }
+        func didFinishBatchMove() {
+            batchMovePreflight.recordMoveGateExit(
+                timestamp: lastMoveOperationTimestamp
+            )
+        }
+
+
         // Divider-order gate (#1027). The room gate above catches dividers
         // collapsed onto one coordinate; this catches them drifted into
         // foreign sections, which leaves the same room between them and so
@@ -1490,6 +1570,17 @@ extension MenuBarItemManager {
                 )
             }
             recordBulkApplyOutcome(unenactedMoveCount: unenactedMoveCount)
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+        }
+
+        /// A manual move that wins moveGate supersedes an automatic plan; it
+        /// is not a failed batch and must not back off an item or trip the
+        /// automatic-apply circuit breaker.
+        func finishSupersededApply(items: [MenuBarItem]) {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: user move superseded the automatic plan; leaving the user's arrangement authoritative"
+            )
             clearProfileState(source: source, items: items)
             scheduleDeferredCacheRefresh()
         }
@@ -1664,6 +1755,10 @@ extension MenuBarItemManager {
             )
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var allFreshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &allFreshItemsCopy,
@@ -1785,11 +1880,21 @@ extension MenuBarItemManager {
                             MenuBarItemManager.diagLog.debug("Profile layout: moving H_ctrl → \(dest.logString)")
                             didAttemptHCtrl = true
                             do {
-                                try await move(item: hItem, to: dest, skipInputPause: true)
+                                try await move(
+                                    item: hItem,
+                                    to: dest,
+                                    skipInputPause: true,
+                                    shouldBegin: shouldBeginBatchMove,
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                )
                                 movedCount += 1
                                 failureLedger.recordSuccess(for: hItem)
                                 try? await Task.sleep(for: .milliseconds(200))
                             } catch {
+                                if case EventError.moveSuperseded = error {
+                                    finishSupersededApply(items: allFreshItems)
+                                    return
+                                }
                                 unenactedMoveCount += 1
                                 // A move cancelled by a newer apply says nothing
                                 // about the divider, and recording it would earn
@@ -1897,7 +2002,13 @@ extension MenuBarItemManager {
                         "Profile layout: moving \(item.logString) → \(dest.logString) to fix the H_ctrl boundary"
                     )
                     do {
-                        try await move(item: item, to: dest, skipInputPause: true)
+                        try await move(
+                            item: item,
+                            to: dest,
+                            skipInputPause: true,
+                            shouldBegin: shouldBeginBatchMove,
+                            didFinishWhileHoldingGate: didFinishBatchMove
+                        )
                         movedCount += 1
                         didCrossHiddenBoundary = true
                         failureLedger.recordSuccess(for: item)
@@ -1908,6 +2019,10 @@ extension MenuBarItemManager {
                         // the previous arrangement says it should.
                         try? await Task.sleep(for: .milliseconds(200))
                     } catch {
+                        if case EventError.moveSuperseded = error {
+                            finishSupersededApply(items: allFreshItems)
+                            return
+                        }
                         unenactedMoveCount += 1
                         // A move cancelled by a newer apply says nothing about
                         // the item, and recording it would earn a backoff
@@ -1936,6 +2051,10 @@ extension MenuBarItemManager {
         // (and its per-item fallback) is still warranted.
         if didAttemptHCtrl || didCrossHiddenBoundary {
             var postMoveItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: postMoveItems)
+                return
+            }
             postMoveItems.removeAll(where: \.isSystemClone)
             var postMoveItemsCopy = postMoveItems
             if let postMoveControl = ControlItemPair(
@@ -2015,6 +2134,10 @@ extension MenuBarItemManager {
             )
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var allFreshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &allFreshItemsCopy,
@@ -2096,10 +2219,20 @@ extension MenuBarItemManager {
             if let dest, !Task.isCancelled {
                 MenuBarItemManager.diagLog.debug("Profile layout: moving AH_ctrl → \(dest.logString)")
                 do {
-                    try await move(item: ahItem, to: dest, skipInputPause: true)
+                    try await move(
+                        item: ahItem,
+                        to: dest,
+                        skipInputPause: true,
+                        shouldBegin: shouldBeginBatchMove,
+                        didFinishWhileHoldingGate: didFinishBatchMove
+                    )
                     movedCount += 1
                     try? await Task.sleep(for: .milliseconds(200))
                 } catch {
+                    if case EventError.moveSuperseded = error {
+                        finishSupersededApply(items: allFreshItems)
+                        return
+                    }
                     unenactedMoveCount += 1
                     MenuBarItemManager.diagLog.error("Profile layout: failed to move AH_ctrl: \(error)")
                 }
@@ -2123,6 +2256,10 @@ extension MenuBarItemManager {
             // the LCS pass below only re-sorts concealed sections when
             // enforceConcealedSectionOrder is on, and it defaults off.
             let freshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: freshItems)
+                return
+            }
             var freshItemsCopy = freshItems
             if let freshControl = ControlItemPair(
                 items: &freshItemsCopy,
@@ -2192,10 +2329,20 @@ extension MenuBarItemManager {
                             let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
                         else { continue }
                         do {
-                            try await move(item: item, to: .leftOfItem(ahItem), skipInputPause: true)
+                            try await move(
+                                item: item,
+                                to: .leftOfItem(ahItem),
+                                skipInputPause: true,
+                                shouldBegin: shouldBeginBatchMove,
+                                didFinishWhileHoldingGate: didFinishBatchMove
+                            )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
                         } catch {
+                            if case EventError.moveSuperseded = error {
+                                finishSupersededApply(items: freshItems)
+                                return
+                            }
                             unenactedMoveCount += 1
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to AH failed for \(uid): \(error)"
@@ -2222,10 +2369,20 @@ extension MenuBarItemManager {
                             let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
                         else { continue }
                         do {
-                            try await move(item: item, to: .rightOfItem(ahItem), skipInputPause: true)
+                            try await move(
+                                item: item,
+                                to: .rightOfItem(ahItem),
+                                skipInputPause: true,
+                                shouldBegin: shouldBeginBatchMove,
+                                didFinishWhileHoldingGate: didFinishBatchMove
+                            )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
                         } catch {
+                            if case EventError.moveSuperseded = error {
+                                finishSupersededApply(items: freshItems)
+                                return
+                            }
                             unenactedMoveCount += 1
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to hidden failed for \(uid): \(error)"
@@ -2244,6 +2401,10 @@ extension MenuBarItemManager {
             // Re-fetch items and rebuild section assignments after
             // the control item move changed section boundaries.
             items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: items)
+                return
+            }
             var itemsCopy2 = items
             guard let freshControl = ControlItemPair(
                 items: &itemsCopy2,
@@ -2359,6 +2520,10 @@ extension MenuBarItemManager {
             }
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var freshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &freshItemsCopy,
@@ -2432,12 +2597,22 @@ extension MenuBarItemManager {
             }
 
             do {
-                try await move(item: item, to: dest, skipInputPause: true)
+                try await move(
+                    item: item,
+                    to: dest,
+                    skipInputPause: true,
+                    shouldBegin: shouldBeginBatchMove,
+                    didFinishWhileHoldingGate: didFinishBatchMove
+                )
                 movedCount += 1
                 consecutiveMoveFailures = 0
                 failureLedger.recordSuccess(for: item)
                 try? await Task.sleep(for: .milliseconds(200))
             } catch {
+                if case EventError.moveSuperseded = error {
+                    finishSupersededApply(items: allFreshItems)
+                    return
+                }
                 // The loop head's rule extends to a move that was in flight
                 // when the cancellation arrived: the failure is the newer
                 // apply's takeover, not the item's. Recording it would earn
@@ -3232,8 +3407,13 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         currentDisplayID: CGDirectDisplayID? = nil,
         bypassMoveCooldown: Bool = false,
-        resolvedIdentitiesOnly: Bool = false
+        resolvedIdentitiesOnly: Bool = false,
+        shouldBegin: (@MainActor () -> Bool)? = nil
     ) async -> Bool {
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug("applySavedLayout: skipping superseded cache snapshot")
+            return false
+        }
         // Each guard logs a distinct reason so a "Thaw stopped
         // restoring my layout" bug report can be diagnosed from the
         // first set of logs. Order is significant: the cheap state
@@ -3379,7 +3559,14 @@ extension MenuBarItemManager {
         // Never drag items while a menu bar item menu is tracking — a synthetic
         // Cmd-drag would tear down the user's interaction (Wi-Fi picker, input
         // methods). The change gate stays armed, so the next cache cycle retries.
-        if await isAnyMenuBarItemMenuOpen() {
+        let menuIsOpen = await isAnyMenuBarItemMenuOpen()
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug(
+                "applySavedLayout: skipping, a user move superseded the snapshot during the menu check"
+            )
+            return false
+        }
+        if menuIsOpen {
             MenuBarItemManager.diagLog.info("applySavedLayout: skipping, a menu bar item menu is open")
             return false
         }
@@ -3561,6 +3748,13 @@ extension MenuBarItemManager {
 
         MenuBarItemManager.diagLog.info("applySavedLayout: dispatching bulk apply (\(trigger))")
 
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug(
+                "applySavedLayout: skipping, a user move superseded the snapshot before dispatch"
+            )
+            return false
+        }
+
         // The shared body uses itemOrder as the per-section ordered
         // identifier list, which is structurally identical to
         // savedSectionOrder. Pass the saved order through unchanged.
@@ -3590,7 +3784,8 @@ extension MenuBarItemManager {
             ),
             source: .savedOrder,
             automatic: true,
-            duringSettling: resolvedIdentitiesOnly
+            duringSettling: resolvedIdentitiesOnly,
+            shouldBegin: shouldBegin
         )
         if bulkApplyCompletionGeneration != completionGenerationBeforeApply,
            lastCompletedBulkApplyUnenactedMoveCount == 0

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -135,14 +135,18 @@ extension MenuBarItemManager {
     /// handoff waits until the planner has actually found overflow — a pass
     /// with nothing to do must return without arming anything, or it drives
     /// the apply on every cache tick forever (#881).
-    func rebalanceNotchOverflowIfNeeded(items: [MenuBarItem], controlItems: ControlItemPair) async {
-        guard let appState else { return }
-        guard appState.settings.advanced.enableMenuBarItemOverflow else { return }
+    func rebalanceNotchOverflowIfNeeded(
+        items: [MenuBarItem],
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
+        guard let appState else { return .noAttempt }
+        guard appState.settings.advanced.enableMenuBarItemOverflow else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Notch overflow rebalance: skipping for provisional AX-frame correlation"
             )
-            return
+            return .noAttempt
         }
 
         // Never fight another mover. Each of these owns the layout while it
@@ -152,12 +156,12 @@ extension MenuBarItemManager {
               !isRestoringItemOrder,
               !isInStartupSettling,
               !isBulkApplyInProgress
-        else { return }
+        else { return .noAttempt }
 
         // A temporarily-shown item is deliberately parked in visible for as
         // long as the user is interacting with it. Ejecting it would cancel
         // the reveal the user just asked for.
-        guard temporarilyShownItemContexts.isEmpty else { return }
+        guard temporarilyShownItemContexts.isEmpty else { return .noAttempt }
 
         // If the bar just refused synthetic drags in a profile apply, the
         // rebalance's own drags will fare no better — and each eject is a
@@ -168,7 +172,7 @@ extension MenuBarItemManager {
         // backoff cannot help because the rebalance's items are typically
         // different from the ones that failed in the batch.
         guard isAutomaticBulkApplyPermitted(caller: "Notch overflow rebalance", quietly: true) else {
-            return
+            return .noAttempt
         }
 
         let activeMenuBarScreen = NSScreen.screenWithActiveMenuBar
@@ -180,7 +184,7 @@ extension MenuBarItemManager {
         ),
             let screen = activeMenuBarScreen,
             let notch = screen.frameOfNotch
-        else { return }
+        else { return .noAttempt }
 
         // Mid-relocation between displays the item bounds straddle two screens
         // and the budget cannot be trusted. Same guard the persist path uses,
@@ -208,12 +212,12 @@ extension MenuBarItemManager {
         guard !LayoutSolver.itemsSpanMultipleDisplays(
             itemCenters: unparkedItems.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) },
             screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-        ) else { return }
+        ) else { return .noAttempt }
 
         if let last = lastNotchRebalanceTimestamp,
            Date.now.timeIntervalSince(last) < Self.notchRebalanceCooldown
         {
-            return
+            return .noAttempt
         }
 
         let hiddenCtrlUID = controlItems.hidden.uniqueIdentifier
@@ -286,7 +290,7 @@ extension MenuBarItemManager {
             uidWidths: uidWidths,
             availableWidth: availableWidth
         )
-        guard !result.overflowUIDs.isEmpty else { return }
+        guard !result.overflowUIDs.isEmpty else { return .noAttempt }
 
         // A profile apply is the better tool: it re-runs this same planner and
         // restores the saved order at the same time.
@@ -307,7 +311,7 @@ extension MenuBarItemManager {
                 "Notch overflow rebalance: deferring \(result.overflowUIDs.count) item(s) to the profile apply"
             )
             scheduleProfileResort()
-            return
+            return .noAttempt
         }
 
         // Bounce-back guard. Every UID the planner wants to eject is one this
@@ -319,7 +323,7 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug(
                 "Notch overflow rebalance: standing down; all \(result.overflowUIDs.count) candidate(s) were already ejected once"
             )
-            return
+            return .noAttempt
         }
 
         lastNotchRebalanceTimestamp = .now
@@ -329,6 +333,33 @@ extension MenuBarItemManager {
             \(budget.logString)
             """
         )
+
+        // The cache snapshot owns the first move. Each accepted attempt then
+        // adopts its timestamp before releasing moveGate, so later moves in
+        // this batch accept its own work but reject an intervening user move.
+        var batchMovePreflight = BatchMovePreflightState()
+        var didAcceptMoveAttempt = false
+        var didAcceptCurrentMove = false
+        var didCompleteMove = false
+        var didFailAcceptedMove = false
+        func shouldBeginBatchMove() -> Bool {
+            let shouldBegin = batchMovePreflight.shouldBeginMove(
+                currentTimestamp: lastMoveOperationTimestamp,
+                initialPreflight: {
+                    shouldBeginMove?() ?? true
+                }
+            )
+            if shouldBegin {
+                didAcceptMoveAttempt = true
+                didAcceptCurrentMove = true
+            }
+            return shouldBegin
+        }
+        func didFinishBatchMove() {
+            batchMovePreflight.recordMoveGateExit(
+                timestamp: lastMoveOperationTimestamp
+            )
+        }
 
         // Leftmost-first, so each ejected item lands deeper in hidden than the
         // one before it and the surviving visible order is preserved.
@@ -345,11 +376,28 @@ extension MenuBarItemManager {
                 )
                 continue
             }
+            didAcceptCurrentMove = false
             do {
-                try await move(item: item, to: .leftOfItem(controlItems.hidden))
+                try await move(
+                    item: item,
+                    to: .leftOfItem(controlItems.hidden),
+                    shouldBegin: shouldBeginBatchMove,
+                    didFinishWhileHoldingGate: didFinishBatchMove
+                )
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)
+                didCompleteMove = true
+            } catch EventError.moveSuperseded {
+                didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                MenuBarItemManager.diagLog.debug(
+                    "Stopping stale notch-overflow rebalance before moving \(item.logString)"
+                )
+                if didFailAcceptedMove {
+                    return .failedAttempt
+                }
+                return didCompleteMove ? .completed : .noAttempt
             } catch {
+                didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
                 if !Self.moveAlreadyFiledFailure(for: error) {
                     failureLedger.recordFailure(for: item, kind: ledgerFailureKind(for: error, item: item))
                 }
@@ -358,5 +406,12 @@ extension MenuBarItemManager {
                 )
             }
         }
+        if didFailAcceptedMove {
+            return .failedAttempt
+        }
+        if didCompleteMove {
+            return .completed
+        }
+        return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -381,8 +381,10 @@ extension MenuBarItemManager {
                 try await move(
                     item: item,
                     to: .leftOfItem(controlItems.hidden),
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+                        shouldBegin: shouldBeginBatchMove,
+                        didFinishWhileHoldingGate: didFinishBatchMove
+                    )
                 )
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)

--- a/ThawTests/MenuBar/Items/BulkMoveCoordinationTests.swift
+++ b/ThawTests/MenuBar/Items/BulkMoveCoordinationTests.swift
@@ -1,0 +1,107 @@
+//
+//  BulkMoveCoordinationTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+@Suite("Bulk move coordination")
+struct BulkMoveCoordinationTests {
+    typealias Outcome = MenuBarItemManager.CacheDrivenMoveOutcome
+    typealias State = MenuBarItemManager.BatchMovePreflightState
+
+    private let initialTimestamp = ContinuousClock.now
+
+    @Test("Only failed cache-driven moves suppress recovery side effects", arguments: [
+        (Outcome.noAttempt, false, false, false),
+        (Outcome.completed, true, false, false),
+        (Outcome.failedAttempt, true, true, true),
+    ])
+    @MainActor
+    func cacheDrivenMoveRecoveryPolicy(
+        outcome: Outcome,
+        needsRecache: Bool,
+        suppressesMoves: Bool,
+        suppressesPersistence: Bool
+    ) {
+        #expect(outcome.needsAuthoritativeRecache == needsRecache)
+        #expect(outcome.shouldSuppressAutomaticMovesDuringRecache == suppressesMoves)
+        #expect(outcome.shouldSuppressSavedOrderPersistenceDuringRecache == suppressesPersistence)
+    }
+
+    @Test("The cache snapshot owns the first move's preflight")
+    func firstMoveUsesInitialPreflight() {
+        let state = State()
+        var initialPreflightCalls = 0
+
+        let shouldBegin = state.shouldBeginMove(
+            currentTimestamp: initialTimestamp,
+            initialPreflight: {
+                initialPreflightCalls += 1
+                return false
+            }
+        )
+
+        #expect(!shouldBegin)
+        #expect(initialPreflightCalls == 1)
+    }
+
+    @Test("A batch adopts its own move timestamp for the next item")
+    func ownedTimestampAllowsNextItem() {
+        var state = State()
+        let ownedTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        state.recordMoveGateExit(timestamp: ownedTimestamp)
+        var initialPreflightCalls = 0
+
+        let shouldBegin = state.shouldBeginMove(
+            currentTimestamp: ownedTimestamp,
+            initialPreflight: {
+                initialPreflightCalls += 1
+                return false
+            }
+        )
+
+        #expect(shouldBegin)
+        #expect(initialPreflightCalls == 0)
+    }
+
+    @Test("A user timestamp between batch items supersedes the remainder")
+    func interveningUserTimestampStopsBatch() {
+        var state = State()
+        let ownedTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        let userTimestamp = initialTimestamp.advanced(by: .milliseconds(2))
+        state.recordMoveGateExit(timestamp: ownedTimestamp)
+
+        #expect(!state.shouldBeginMove(
+            currentTimestamp: userTimestamp,
+            initialPreflight: { true }
+        ))
+    }
+
+    @Test("Each owned item advances the batch timestamp")
+    func successiveOwnedMovesAdvanceTimestamp() {
+        var state = State()
+        let firstMoveTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        let secondMoveTimestamp = initialTimestamp.advanced(by: .milliseconds(2))
+
+        state.recordMoveGateExit(timestamp: firstMoveTimestamp)
+        #expect(state.shouldBeginMove(
+            currentTimestamp: firstMoveTimestamp,
+            initialPreflight: { false }
+        ))
+
+        state.recordMoveGateExit(timestamp: secondMoveTimestamp)
+        #expect(state.shouldBeginMove(
+            currentTimestamp: secondMoveTimestamp,
+            initialPreflight: { false }
+        ))
+        #expect(!state.shouldBeginMove(
+            currentTimestamp: firstMoveTimestamp,
+            initialPreflight: { true }
+        ))
+    }
+}


### PR DESCRIPTION
# Summary

Revalidates cache-driven and saved-layout move plans after asynchronous waits and again under the serialized move gate. Gate-owned timestamps now travel across multi-item applies, allowing a batch to accept its own completed moves while stopping cleanly when a user move or another newer transaction intervenes.

Every accepted automatic attempt is followed by an authoritative cache refresh. Failed or partial passes suppress automatic retries and saved-order persistence until confirmed state is available again, preventing a stale intermediate layout from scheduling another conflicting move.

**Scope:** This PR changes 5 files with 664 insertions and 81 deletions. It is limited to generic multi-item coordination, preflight/timestamp ownership, authoritative post-attempt refreshes, and focused Swift Testing coverage. It does not change Layout Bar presentation, trigger ownership, diagnostic-report UI, localization, or move transport. This may be suitable for 2.2.

Dependency: #1001 must be merged first or used as this PR's base. This PR consumes its authoritative cache transaction and the serialized move completion seams from #998.

## Linked issue (required)

Closes: N/A

Related: #900, #923, #927

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [x] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- Cache-driven and saved-layout plans are checked after asynchronous work and again after entering the serialized move gate.
- A batch carries the timestamp of its own most recently completed move, so its next item is not mistaken for an unrelated superseding edit.
- A user move or genuinely newer automatic transaction supersedes the remaining batch cleanly before another gesture begins.
- Every accepted automatic move is followed by an authoritative cache refresh before the next plan is chosen.
- A failed, partial, or superseded pass does not persist its intermediate order or immediately schedule another automatic retry.
- Saved-layout/profile application, control-divider ordering, newly discovered and pending-item placement, and notch-overflow rebalancing use the same outcome and timestamp policy.
- Focused policy tests cover accepted, failed, deferred, and superseded outcomes plus batch-owned timestamp progression.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -destination 'generic/platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/BulkMoveCoordinationTests -only-testing:ThawTests/MoveGatePreflightTests -only-testing:ThawTests/MoveLayoutSettlingTests`

The final stacked test build passed, and all 21 focused tests across 3 suites passed. The isolated change also passed a complete run of 2,667 tests across 335 suites before the clean rebase. SwiftFormat lint and strict SwiftLint reported no issues; `git diff --check` was clean.

## Known limitations / follow-ups

- The private macOS movement mechanism can still reject a correctly coordinated gesture; the preceding movement PRs bound and classify that outcome.
- This PR coordinates automatic callers but deliberately leaves their user-facing failure presentation to a later PR in this series.
- Layout Bar rendering and drag-preview stability remain isolated in the next PR.
- This stacked PR should remain based on #1001 until that dependency merges. It can then be rebased onto `development`.

## Other information

No manual live menu-bar batch was performed for this isolated PR. Verification used the focused coordination suites, a complete test run, the generic macOS build, formatting, lint, and diff checks.

The commit includes the required DCO sign-off. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 10 of 12  
**Git base:** #1001  
**Functional dependencies:** #998 and #1001.
