### PR TITLE
fix(layout): stabilize editor transitions

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBar.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBar.swift
@@ -25,8 +25,6 @@ struct LayoutBar: View {
     }
 
     @Environment(AppState.self) var appState: AppState
-    let imageCache: MenuBarItemImageCache
-
     let section: MenuBarSection.Name
 
     private var backgroundShape: some InsettableShape {
@@ -34,7 +32,7 @@ struct LayoutBar: View {
     }
 
     var body: some View {
-        mainContent
+        Representable(appState: appState, section: section)
             .frame(height: 48)
             .frame(maxWidth: .infinity)
             .menuBarItemContainer(appState: appState)
@@ -45,16 +43,5 @@ struct LayoutBar: View {
                 backgroundShape
                     .strokeBorder(.quaternary)
             }
-    }
-
-    @ViewBuilder
-    private var mainContent: some View {
-        if imageCache.cacheFailed(for: section) {
-            // Avoid flicker during rapid cache refreshes; hold a blank placeholder instead of the error text.
-            Color.clear
-                .frame(height: 20)
-        } else {
-            Representable(appState: appState, section: section)
-        }
     }
 }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
@@ -18,6 +18,14 @@ class LayoutBarArrangedView: NSView {
     /// Temporary information retained while dragging between layout containers.
     var oldContainerInfo: (container: LayoutBarContainer, index: Int)?
 
+    /// The container frozen when the drag began.
+    ///
+    /// `oldContainerInfo` is populated only after a destination receives an
+    /// update. A drag cancelled before that point would otherwise leave its
+    /// source container frozen indefinitely, so retain the source separately
+    /// for the lifetime of the dragging session.
+    private weak var frozenSourceContainer: LayoutBarContainer?
+
     /// A Boolean value that indicates whether the view is currently inside a container.
     var hasContainer = false
 
@@ -56,6 +64,21 @@ class LayoutBarArrangedView: NSView {
     func draggingImage() -> NSImage? {
         nil
     }
+
+    /// Whether this container is the row where the current drag began.
+    /// Intermediate rows may thaw as soon as the pointer exits, but the
+    /// original row must stay frozen so a cache refresh does not insert a
+    /// duplicate view behind the drag.
+    func beganDragging(in container: LayoutBarContainer) -> Bool {
+        frozenSourceContainer === container
+    }
+
+    /// A row stays frozen while an asynchronous system move is being
+    /// verified. Starting another drag from that row would let the older move
+    /// thaw and reconcile it underneath the newer drag.
+    var canBeginDraggingFromCurrentContainer: Bool {
+        (superview as? LayoutBarContainer)?.canSetArrangedViews == true
+    }
 }
 
 // MARK: LayoutBarArrangedView: NSDraggingSource
@@ -66,33 +89,67 @@ extension LayoutBarArrangedView: NSDraggingSource {
     }
 
     func draggingSession(_ session: NSDraggingSession, willBeginAt _: NSPoint) {
-        if let container = superview as? LayoutBarContainer {
-            container.canSetArrangedViews = false
+        let container = superview as? LayoutBarContainer
+        container?.canSetArrangedViews = false
+        frozenSourceContainer = container
+        if let container,
+           let sourceIndex = container.arrangedViews.firstIndex(of: self)
+        {
+            // Record the source synchronously. A quick cross-row drag can
+            // reach its destination before draggingUpdated gets a chance to
+            // populate this, which otherwise leaves the real source frozen
+            // and unavailable for final reconciliation.
+            oldContainerInfo = (container, sourceIndex)
         }
 
         session.animatesToStartingPositionsOnCancelOrFail = false
 
-        Task { @MainActor in
-            isDraggingPlaceholder = true
-        }
+        // This callback is already delivered on the main thread. Set the
+        // placeholder synchronously so a short drag cannot end before a queued
+        // task turns the placeholder back on.
+        isDraggingPlaceholder = true
     }
 
-    func draggingSession(_: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
+    func draggingSession(_: NSDraggingSession, endedAt _: NSPoint, operation: NSDragOperation) {
         let sourceContainer = oldContainerInfo?.container
+        let frozenContainer = frozenSourceContainer
+        let currentContainer = superview as? LayoutBarContainer
         defer {
             oldContainerInfo = nil
+            frozenSourceContainer = nil
         }
 
         isDraggingPlaceholder = false
 
+        // Successful item drops keep both rows frozen until the asynchronous
+        // system move settles. Cancelled and rejected drops never start that
+        // task. Transfer the original view back before thawing either row;
+        // otherwise the source rebuilds a replacement from the old cache and
+        // the detached drag view is inserted beside it a moment later.
+        if operation == [] {
+            if let (container, index) = oldContainerInfo {
+                container.restoreArrangedViewAfterCancelledDrag(
+                    self,
+                    from: currentContainer,
+                    at: index
+                )
+            }
+
+            // `frozenContainer` covers a cancellation that happened before
+            // `oldContainerInfo` was populated.
+            currentContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            frozenContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+
         if isNewItemsBadge {
-            sourceContainer?.canSetArrangedViews = true
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             if let appState = sourceContainer?.appState {
                 sourceContainer?.setArrangedViews(items: appState.itemManager.itemCache.managedItems(for: sourceContainer?.section ?? .hidden))
             }
         }
 
-        if !hasContainer {
+        if operation != [], !hasContainer {
             guard let (container, index) = oldContainerInfo else {
                 return
             }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -62,6 +62,19 @@ final class LayoutBarContainer: NSView {
         }
     }
 
+    /// Resumes cache-driven updates after a drag without animating from the
+    /// editor's temporary arrangement to the settled system snapshot.
+    ///
+    /// The container is trailing-aligned. Animating child origins while its
+    /// width changes makes those children appear to fly across the row, even
+    /// though both layouts are valid. Commit the first reconciled layout as a
+    /// single frame instead.
+    func resumeArrangedViewUpdatesWithoutAnimation() {
+        guard !canSetArrangedViews else { return }
+        shouldAnimateNextLayoutPass = false
+        canSetArrangedViews = true
+    }
+
     /// The contaner's arranged views.
     ///
     /// The views are laid out from left to right in the order that they
@@ -237,6 +250,10 @@ final class LayoutBarContainer: NSView {
 
         // remove views that are no longer part of the arranged views
         for view in oldViews where !arrangedViews.contains(view) {
+            // A cross-row drag transfers the same NSView instance to the
+            // destination. A stale source snapshot must never detach a view
+            // that is already owned by another container.
+            guard view.superview === self else { continue }
             view.removeFromSuperview()
             view.hasContainer = false
         }
@@ -300,16 +317,22 @@ final class LayoutBarContainer: NSView {
             arrangedViews.removeAll()
             return
         }
+        // Thumbnail refreshes below can trigger an immediate size-only layout,
+        // which normally resets this flag. Preserve the caller's animation
+        // choice for the actual ordered reconciliation that follows.
+        let shouldAnimateReconciledLayout = shouldAnimateNextLayoutPass
         var newViews = [LayoutBarArrangedView]()
         let itemIdentifiers = items.map(\.uniqueIdentifier)
         let badgeIndex = appState.itemManager.newItemsBadgeIndex(in: section, itemIdentifiers: itemIdentifiers)
         for item in items {
-            if let existingView = arrangedViews.first(where: {
-                if case let .item(existingItem) = $0.kind {
-                    return existingItem == item
-                }
-                return false
-            }) {
+            if let existingView = arrangedViews.lazy
+                .compactMap({ $0 as? LayoutBarItemView })
+                .first(where: { Self.canReuseItemView(representing: $0.item, for: item) })
+            {
+                // Keep the view's last stable thumbnail through reconciliation.
+                // A capture that completed while this row was frozen may still
+                // be a transient crop from the physical system move; the fresh
+                // post-thaw image-cache pass will publish the settled image.
                 newViews.append(existingView)
             } else {
                 let view = LayoutBarItemView(appState: appState, item: item)
@@ -322,7 +345,35 @@ final class LayoutBarContainer: NSView {
             let insertionIndex = badgeIndex.clamped(to: newViews.startIndex ... newViews.endIndex)
             newViews.insert(badgeView, at: insertionIndex)
         }
+
+        // Observation can publish the same ordered cache more than once while
+        // a move settles. Avoid re-targeting animator proxies for a no-op.
+        guard !arrangedViews.elementsEqual(newViews, by: { $0 === $1 }) else {
+            // Before this no-op guard existed, assigning the identical array
+            // still completed a layout pass and reset this flag.
+            shouldAnimateNextLayoutPass = true
+            return
+        }
+        shouldAnimateNextLayoutPass = shouldAnimateReconciledLayout
         arrangedViews = newViews
+    }
+
+    /// Whether an existing view still represents the same live status-item
+    /// window after a cache refresh.
+    ///
+    /// Full `MenuBarItem` equality includes origin and on-screen state, both of
+    /// which necessarily change during a move. Ignore only those transient
+    /// fields; every value retained by `LayoutBarItemView` must still match.
+    static nonisolated func canReuseItemView(
+        representing existingItem: MenuBarItem,
+        for refreshedItem: MenuBarItem
+    ) -> Bool {
+        existingItem.windowID == refreshedItem.windowID &&
+            existingItem.tag == refreshedItem.tag &&
+            existingItem.ownerPID == refreshedItem.ownerPID &&
+            existingItem.sourcePID == refreshedItem.sourcePID &&
+            existingItem.bounds.size == refreshedItem.bounds.size &&
+            existingItem.title == refreshedItem.title
     }
 
     /// Updates the positions of the container's arranged views using the
@@ -374,6 +425,7 @@ final class LayoutBarContainer: NSView {
                         in: arrangedViews,
                         excludingBadge: excludeBadge
                     )
+                    transferArrangedViewFromSourceIfNeeded(sourceView)
                     arrangedViews.insert(sourceView, at: insertionIndex)
                 }
                 return .move
@@ -408,13 +460,54 @@ final class LayoutBarContainer: NSView {
                 arrangedViews.move(fromOffsets: [sourceIndex], toOffset: targetIndex)
             } else {
                 // source view is being dragged from another container,
-                // so just insert it
+                // so transfer array ownership before adopting the NSView.
+                // NSView.addSubview moves the view between superviews, but it
+                // cannot remove the stale reference from the source's
+                // arrangedViews; leaving that reference lets the source
+                // detach the icon from this destination during reconciliation.
+                transferArrangedViewFromSourceIfNeeded(sourceView)
                 arrangedViews.insert(sourceView, at: destinationIndex)
             }
             return .move
         case .ended:
             return .move
         }
+    }
+
+    private func transferArrangedViewFromSourceIfNeeded(_ view: LayoutBarArrangedView) {
+        guard let sourceContainer = view.oldContainerInfo?.container,
+              sourceContainer !== self
+        else {
+            return
+        }
+        sourceContainer.removeArrangedViewForTransfer(view)
+    }
+
+    private func removeArrangedViewForTransfer(_ view: LayoutBarArrangedView) {
+        guard let index = arrangedViews.firstIndex(of: view) else { return }
+        shouldAnimateNextLayoutPass = false
+        arrangedViews.remove(at: index)
+    }
+
+    /// Returns a cancelled drag's original view to this container before
+    /// cache-driven updates resume. Restoring the existing instance first is
+    /// important: thawing this row while the view still belongs to another
+    /// row makes the old cache construct a replacement, briefly duplicating
+    /// the icon when the detached drag view is inserted afterward.
+    func restoreArrangedViewAfterCancelledDrag(
+        _ view: LayoutBarArrangedView,
+        from currentContainer: LayoutBarContainer?,
+        at originalIndex: Int
+    ) {
+        if let currentContainer, currentContainer !== self {
+            currentContainer.removeArrangedViewForTransfer(view)
+        }
+
+        shouldAnimateNextLayoutPass = false
+        var restoredViews = arrangedViews.filter { $0 !== view }
+        let insertionIndex = originalIndex.clamped(to: restoredViews.startIndex ... restoredViews.endIndex)
+        restoredViews.insert(view, at: insertionIndex)
+        arrangedViews = restoredViews
     }
 
     static func enabledDropTargets(

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -121,6 +121,35 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         )
     }
 
+    /// Whether a cache observation may replace the thumbnail currently shown
+    /// by the layout editor.
+    ///
+    /// A system move temporarily relocates the real status-item window. Live
+    /// capture can observe it under the notch or between sections and publish
+    /// a transient thumbnail while the drag UI is intentionally frozen. Keep
+    /// the last stable thumbnail until the container thaws.
+    static nonisolated func shouldUpdateCachedImage(
+        hasContainer: Bool,
+        containerAllowsUpdates: Bool
+    ) -> Bool {
+        !hasContainer || containerAllowsUpdates
+    }
+
+    /// Opacity used for the captured icon.
+    ///
+    /// The dragged view remains in the arranged views as the drop placeholder.
+    /// Keeping a dimmed snapshot there avoids a blank slot while the dragging
+    /// image follows the pointer.
+    static nonisolated func iconFraction(
+        isDraggingPlaceholder: Bool,
+        isEnabled: Bool
+    ) -> CGFloat {
+        if isDraggingPlaceholder {
+            return 0.45
+        }
+        return isEnabled ? 1.0 : 0.67
+    }
+
     override var kind: Kind {
         .item(effectiveItem)
     }
@@ -271,7 +300,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
                     guard let self else { return }
                     guard !MenuBarItemImageCache.CapturedImage.isVisuallyEqual(previous, image) else { continue }
                     previous = image
-                    self.cachedImage = image
+                    self.updateCachedImageIfAllowed(image)
                 }
             }
 
@@ -442,26 +471,33 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     }
 
     override func draw(_: NSRect) {
+        // A trigger-owned item draws slightly dimmed so the badge reads as a
+        // state marker rather than a rendering bug.
+        let fraction: CGFloat = if !isDraggingPlaceholder && isTriggerControlled {
+            Metrics.triggerControlledFraction
+        } else {
+            Self.iconFraction(
+                isDraggingPlaceholder: isDraggingPlaceholder,
+                isEnabled: isEnabled
+            )
+        }
+        // When the user prefers app icons, the placeholder — which resolves
+        // app icons — draws instead of the captured glyph.
+        if !usesAppIcon, let capturedImage = cachedImage?.nsImage {
+            capturedImage.draw(
+                in: bounds,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: fraction
+            )
+        } else {
+            drawPlaceholder(fraction: fraction)
+        }
+
+        // Keep status badges out of the drag placeholder; the dimmed icon is
+        // enough to preserve identity without making the slot visually busy.
         if !isDraggingPlaceholder {
-            let triggerControlled = isTriggerControlled
-            if !usesAppIcon, let capturedImage = cachedImage?.nsImage {
-                let fraction: CGFloat = if triggerControlled {
-                    Metrics.triggerControlledFraction
-                } else if isEnabled {
-                    1.0
-                } else {
-                    0.67
-                }
-                capturedImage.draw(
-                    in: bounds,
-                    from: .zero,
-                    operation: .sourceOver,
-                    fraction: fraction
-                )
-            } else {
-                drawPlaceholder()
-            }
-            if triggerControlled {
+            if isTriggerControlled {
                 drawTriggerBadge()
             }
             if Bridging.isProcessUnresponsive(item.ownerPID) {
@@ -488,6 +524,10 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         super.mouseDragged(with: event)
         didBeginDraggingForCurrentClick = true
         tooltipController.cancel()
+
+        guard canBeginDraggingFromCurrentContainer else {
+            return
+        }
 
         // #905 fallback: before refusing an `unresolvedControlCenterPlaceholder`
         // drag, attempt to re-tag the slot with its app-owned identity (when
@@ -535,6 +575,17 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         draggingItem.setDraggingFrame(bounds, contents: draggingImage())
 
         beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    private func updateCachedImageIfAllowed(_ image: MenuBarItemImageCache.CapturedImage?) {
+        let container = superview as? LayoutBarContainer
+        guard Self.shouldUpdateCachedImage(
+            hasContainer: container != nil,
+            containerAllowsUpdates: container?.canSetArrangedViews ?? true
+        ) else {
+            return
+        }
+        cachedImage = image
     }
 
     private func preferredSize(for image: MenuBarItemImageCache.CapturedImage?) -> CGSize {
@@ -620,7 +671,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         )
     }
 
-    private func drawPlaceholder() {
+    private func drawPlaceholder(fraction: CGFloat) {
         let placeholderRect = bounds.insetBy(
             dx: Metrics.placeholderHorizontalInset,
             dy: Metrics.placeholderVerticalInset
@@ -630,10 +681,10 @@ final class LayoutBarItemView: LayoutBarArrangedView {
             xRadius: Metrics.placeholderCornerRadius,
             yRadius: Metrics.placeholderCornerRadius
         )
-        NSColor.quaternaryLabelColor.withAlphaComponent(0.35).setFill()
+        NSColor.quaternaryLabelColor.withAlphaComponent(0.35 * fraction).setFill()
         backgroundPath.fill()
 
-        NSColor.separatorColor.withAlphaComponent(0.6).setStroke()
+        NSColor.separatorColor.withAlphaComponent(0.6 * fraction).setStroke()
         backgroundPath.lineWidth = 1
         backgroundPath.stroke()
 
@@ -641,21 +692,11 @@ final class LayoutBarItemView: LayoutBarArrangedView {
             return
         }
 
-        // #981: if the placeholder fell back to the generic symbol at init
-        // because the owning app was not launchable yet, try the app icon
-        // again now. The view is reused across cache refreshes when the
-        // item's identity is stable, so this is the one place a later
-        // resolution surfaces. One lookup per resolution; the flag stops
-        // repeat work once an icon is in hand.
         if !placeholderResolvedFromApp,
            let icon = Self.resolvedAppIcon(for: item)
         {
             self.placeholderImage = icon
             placeholderResolvedFromApp = true
-            // Draw the resolved icon in this pass. Assigning only the stored
-            // property left the local binding above holding the generic
-            // symbol, so the icon swap waited on an unrelated invalidation
-            // that never comes for items the image cache can't capture.
             placeholderImage = icon
         }
 
@@ -683,14 +724,14 @@ final class LayoutBarItemView: LayoutBarArrangedView {
                 in: iconRect,
                 from: .zero,
                 operation: .sourceOver,
-                fraction: isEnabled ? 0.8 : 0.5
+                fraction: (isEnabled ? 0.8 : 0.5) * fraction
             )
         } else {
             placeholderImage.draw(
                 in: iconRect,
                 from: .zero,
                 operation: .sourceOver,
-                fraction: isEnabled ? 0.9 : 0.5
+                fraction: (isEnabled ? 0.9 : 0.5) * fraction
             )
         }
     }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
@@ -19,13 +19,17 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
 
     /// Returns text attributes adapted to the menu bar background brightness.
     /// When the background is bright, uses dark text; otherwise uses light text.
-    private var textAttributes: [NSAttributedString.Key: Any] {
+    private func textAttributes(opacity: CGFloat = 1) -> [NSAttributedString.Key: Any] {
         let isBright = isBrightForActiveScreen()
         let foregroundColor: NSColor = isBright ? .black : .white
         return [
             .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-            .foregroundColor: foregroundColor,
+            .foregroundColor: foregroundColor.withAlphaComponent(opacity),
         ]
+    }
+
+    static nonisolated func contentOpacity(isDraggingPlaceholder: Bool) -> CGFloat {
+        isDraggingPlaceholder ? 0.45 : 1
     }
 
     override var kind: Kind {
@@ -59,10 +63,7 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
     }
 
     override func draw(_: NSRect) {
-        guard !isDraggingPlaceholder else {
-            return
-        }
-
+        let opacity = Self.contentOpacity(isDraggingPlaceholder: isDraggingPlaceholder)
         let isBright = isBrightForActiveScreen()
         let pillPath = NSBezierPath(roundedRect: bounds, xRadius: Metrics.cornerRadius, yRadius: Metrics.cornerRadius)
 
@@ -70,16 +71,16 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
         let fillColor: NSColor = isBright ? .black : .white
         let strokeColor: NSColor = isBright ? .black : .white
 
-        fillColor.withAlphaComponent(0.25).setFill()
+        fillColor.withAlphaComponent(0.25 * opacity).setFill()
         pillPath.fill()
 
-        strokeColor.withAlphaComponent(0.65).setStroke()
+        strokeColor.withAlphaComponent(0.65 * opacity).setStroke()
         pillPath.lineWidth = Metrics.borderWidth
         pillPath.stroke()
 
         let title = NSAttributedString(
             string: String(localized: "New Items"),
-            attributes: textAttributes
+            attributes: textAttributes(opacity: opacity)
         )
         let titleSize = title.size()
         let titleOrigin = CGPoint(
@@ -97,6 +98,10 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
 
     override func mouseDragged(with event: NSEvent) {
         super.mouseDragged(with: event)
+
+        guard canBeginDraggingFromCurrentContainer else {
+            return
+        }
 
         let pasteboardItem = NSPasteboardItem()
         pasteboardItem.setData(Data(), forType: .layoutBarItem)

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -13,9 +13,13 @@ import Observation
 /// A Cocoa view that manages the menu bar layout interface.
 final class LayoutBarPaddingView: NSView {
     private static let diagLog = DiagLog(category: "LayoutBarPaddingView")
+    private static let stabilizationRecoveryTimeout: Duration = .seconds(45)
 
     private let container: LayoutBarContainer
     private var isStabilizing = false
+    private var stabilizationGeneration = 0
+    private var stabilizationTask: Task<Void, Never>?
+    private weak var acceptedDraggingSource: LayoutBarArrangedView?
 
     private var notchView: NotchIndicatorView?
     private var notchWidthConstraint: NSLayoutConstraint?
@@ -31,6 +35,7 @@ final class LayoutBarPaddingView: NSView {
 
     deinit {
         averageColorInfoObservationTask?.cancel()
+        stabilizationTask?.cancel()
     }
 
     /// The layout view's arranged views.
@@ -73,7 +78,15 @@ final class LayoutBarPaddingView: NSView {
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard !isStabilizing else { return [] }
+        guard !isStabilizing,
+              let sourceView = sender.draggingSource as? LayoutBarArrangedView,
+              Self.canAcceptDrag(
+                  containerAllowsUpdates: container.canSetArrangedViews,
+                  beganInContainer: sourceView.beganDragging(in: container),
+                  alreadyAccepted: acceptedDraggingSource === sourceView
+              )
+        else { return [] }
+        acceptedDraggingSource = sourceView
         // Freeze the destination's arrangedViews so that the cache refresh
         // triggered while the system move is in flight cannot overwrite the
         // mid-drag visual state. updateNewItemsPlacement at the end of move()
@@ -85,26 +98,46 @@ final class LayoutBarPaddingView: NSView {
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
         guard !isStabilizing else { return }
+        guard let acceptedDraggingSource else { return }
         if let sender {
+            guard sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource else {
+                return
+            }
             container.updateArrangedViewsForDrag(with: sender, phase: .exited)
         }
+
+        // A pointer can cross one or more rows before it reaches the final
+        // destination. Each entered row is frozen above, so thaw a row as
+        // soon as it is no longer participating in the drag. Keep only the
+        // original source frozen; refreshing it now would reinsert a duplicate
+        // item behind the dragging image.
+        if !acceptedDraggingSource.beganDragging(in: container) {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+        self.acceptedDraggingSource = nil
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard !isStabilizing else { return [] }
+        guard !isStabilizing,
+              sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource
+        else { return [] }
         return container.updateArrangedViewsForDrag(with: sender, phase: .updated)
     }
 
     override func draggingEnded(_ sender: NSDraggingInfo) {
-        guard !isStabilizing else { return }
+        guard !isStabilizing,
+              sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource
+        else { return }
         container.updateArrangedViewsForDrag(with: sender, phase: .ended)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        guard let draggingSource = sender.draggingSource as? LayoutBarArrangedView else {
-            container.canSetArrangedViews = true
+        guard let draggingSource = sender.draggingSource as? LayoutBarArrangedView,
+              acceptedDraggingSource === draggingSource
+        else {
             return false
         }
+        defer { acceptedDraggingSource = nil }
 
         if case let .item(draggingItem) = draggingSource.kind,
            draggingItem.tag == .visibleControlItem,
@@ -124,7 +157,7 @@ final class LayoutBarPaddingView: NSView {
             container.updateArrangedViewsForDrag(with: sender, phase: .exited)
             draggingSource.hasContainer = false
 
-            container.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
             return false
         }
 
@@ -135,8 +168,8 @@ final class LayoutBarPaddingView: NSView {
                 arrangedViews: arrangedViews
             )
             draggingSource.oldContainerInfo = nil
-            container.canSetArrangedViews = true
-            sourceContainer?.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             if let appState = container.appState {
                 sourceContainer?.setArrangedViews(items: appState.itemManager.itemCache.managedItems(for: sourceContainer?.section ?? container.section))
                 if sourceContainer !== container {
@@ -189,16 +222,16 @@ final class LayoutBarPaddingView: NSView {
                 willMove = true
                 Task {
                     guard case let .item(draggingItem) = draggingSource.kind else {
-                        self.container.canSetArrangedViews = true
-                        sourceContainer?.canSetArrangedViews = true
+                        self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                        sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                         return
                     }
                     if let destination = await self.liveFallbackDestinationForDraggedItem() {
                         self.move(items: draggedUnit, startingWith: draggingItem, to: destination, sourceContainer: sourceContainer)
                     } else {
                         Self.diagLog.error("No target item for layout bar drag")
-                        self.container.canSetArrangedViews = true
-                        sourceContainer?.canSetArrangedViews = true
+                        self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                        sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                     }
                 }
             } else if case let .item(draggingItem) = draggingSource.kind {
@@ -215,8 +248,8 @@ final class LayoutBarPaddingView: NSView {
                             self.move(items: draggedUnit, startingWith: draggingItem, to: destination, sourceContainer: sourceContainer)
                         } else {
                             Self.diagLog.error("No target item for layout bar drag")
-                            self.container.canSetArrangedViews = true
-                            sourceContainer?.canSetArrangedViews = true
+                            self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                         }
                     }
                 }
@@ -226,7 +259,11 @@ final class LayoutBarPaddingView: NSView {
         // Only re-enable view updates here if no move was initiated.
         // When a move IS initiated, the move() Task re-enables after stabilization.
         if !willMove {
-            container.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            if sourceContainer !== container {
+                sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            }
+            draggingSource.oldContainerInfo = nil
         }
 
         return true
@@ -270,7 +307,6 @@ final class LayoutBarPaddingView: NSView {
                 return
             }
             isStabilizing = true
-            await MainActor.run { self.showOverlay(true) }
             guard await (try? Task.sleep(for: .milliseconds(150))) != nil else {
                 await resetStabilizingStateIfNeeded(sourceContainer: sourceContainer)
                 return
@@ -347,7 +383,8 @@ final class LayoutBarPaddingView: NSView {
                         of: last,
                         to: lastTarget,
                         expectedSection: container.section,
-                        appState: appState
+                        appState: appState,
+                        generation: stabilizationGeneration
                     ) {
                         appState.itemManager.recordExternalMoveOperation()
                     } else {
@@ -442,27 +479,58 @@ final class LayoutBarPaddingView: NSView {
         await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
     }
 
+    /// A frozen row accepts only the drag that already owns that freeze. This
+    /// prevents a second cross-row move from being reconciled by the first
+    /// move's eventual thaw.
+    static nonisolated func canAcceptDrag(
+        containerAllowsUpdates: Bool,
+        beganInContainer: Bool,
+        alreadyAccepted: Bool
+    ) -> Bool {
+        containerAllowsUpdates || beganInContainer || alreadyAccepted
+    }
+
     private func move(
         item: MenuBarItem,
         to destination: MenuBarItemManager.MoveDestination,
         sourceContainer: LayoutBarContainer? = nil
     ) {
         guard let appState = container.appState else {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             return
         }
+        guard !isStabilizing else {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            return
+        }
+        isStabilizing = true
+        stabilizationGeneration &+= 1
+        let generation = stabilizationGeneration
+
         // Explicit strong captures: the move must complete even if the view
         // is torn down mid-drag; only the longer-lived watchdog below holds
         // weak references.
-        Task { [self, appState] in
-            guard !isStabilizing else { return }
-            isStabilizing = true
-            await MainActor.run { self.showOverlay(true) }
+        stabilizationTask = Task { [self, appState] in
+            var didValidateUserMove = false
+            @MainActor
+            func acceptValidatedUserMove() {
+                // Clear an unfinished automatic-batch latch only after the
+                // editor move has reached its requested settled placement.
+                appState.itemManager.recordExternalMoveOperation()
+                didValidateUserMove = true
+            }
+
             // Increased delay to allow macOS to settle after operations like Reset Layout.
             // Prevents transient errors when dragging items immediately after reset.
-            // A cancelled sleep must not leave the overlay up and isStabilizing
+            // A cancelled sleep must not leave the layouts frozen or isStabilizing
             // stuck true (the watchdog that would reset them hasn't started yet).
             guard await (try? Task.sleep(for: .milliseconds(150))) != nil else {
-                await resetStabilizingStateIfNeeded()
+                _ = await resetStabilizingStateIfNeeded(
+                    generation: generation,
+                    sourceContainer: sourceContainer
+                )
                 return
             }
 
@@ -515,13 +583,11 @@ final class LayoutBarPaddingView: NSView {
                             "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (\(targetBounds.map { "minX=\($0.minX)" } ?? "no window bounds")); section is collapsed"
                         )
                         await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                        _ = await self.resetStabilizingStateIfNeeded(
+                            generation: generation,
+                            sourceContainer: sourceContainer
+                        )
                         await MainActor.run {
-                            self.isStabilizing = false
-                            self.showOverlay(false)
-                            self.container.canSetArrangedViews = true
-                            if sourceContainer !== self.container {
-                                sourceContainer?.canSetArrangedViews = true
-                            }
                             let alert = NSAlert()
                             alert.alertStyle = .warning
                             alert.messageText = String(localized: "Couldn't move \(item.displayName) right now.")
@@ -533,12 +599,45 @@ final class LayoutBarPaddingView: NSView {
                 }
             }
 
-            let watchdogTask = Task { [weak self, weak appState, revealedSections] in
-                try? await Task.sleep(for: MenuBarItemManager.layoutWatchdogTimeout + .seconds(1))
+            let watchdogTask = Task { [weak self, weak appState, weak sourceContainer, revealedSections] in
+                try? await Task.sleep(for: Self.stabilizationRecoveryTimeout)
                 guard let self, !Task.isCancelled else { return }
-                await recoverFromUnreturnedMove(revealedSections: revealedSections, appState: appState)
+                guard await self.resetStabilizingStateIfNeeded(
+                    generation: generation,
+                    sourceContainer: sourceContainer,
+                    cancelOwningTask: true
+                ) else { return }
+                guard let appState else { return }
+                // A drag that revealed a collapsed section (#988, #1010)
+                // must re-conceal it even when the move never returned: the
+                // completion path that re-conceals has not run and may never
+                // run. The reset above thawed the bars; park the divider
+                // back and give the spacer a beat before the closing cache
+                // pass records the settled bar.
+                if !revealedSections.isEmpty {
+                    await MainActor.run {
+                        for section in revealedSections {
+                            section.updateControlItemState(for: nil)
+                        }
+                    }
+                    try? await Task.sleep(for: .milliseconds(250))
+                }
+                // The owner task's cancellation runs its defer and cancels
+                // this watchdog. Launch recovery independently so that mutual
+                // cancellation cannot abort it, and retry until the old cache
+                // owner actually releases CacheGate instead of issuing a
+                // one-shot refresh that will probably be dropped.
+                Task { [weak appState] in
+                    guard let appState else { return }
+                    guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+                        return
+                    }
+                    await appState.imageCache.updateCacheWithoutChecks(
+                        sections: MenuBarSection.Name.allCases
+                    )
+                }
             }
-
+            defer { watchdogTask.cancel() }
             do {
                 try await appState.itemManager.move(
                     item: item,
@@ -546,34 +645,156 @@ final class LayoutBarPaddingView: NSView {
                     skipInputPause: true,
                     options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
                 )
-                // Record the user move before stabilization so the save
-                // gate's cooldown exemption is armed when stabilizePlacement's
-                // own cache pass reaches it. Recording it only after stabilize
-                // returned meant the first cache pass inside stabilize hit
-                // the 5s move cooldown with no user-move exemption, so the
-                // save was skipped; by the time the exemption armed, the
-                // mid-transition cache gate had re-armed and no accepting
-                // pass coincided with the cooldown window. The drag never
-                // saved (#983). move() threw no error, so the user's drag
-                // did land; the rescue-and-retry catch block below still
-                // owns the case where macOS didn't settle it.
-                appState.itemManager.recordExternalMoveOperation()
+                guard isCurrentStabilization(generation) else { return }
                 appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
-                _ = await stabilizePlacement(
+                if await stabilizePlacement(
                     of: item,
                     to: destination,
                     expectedSection: container.section,
-                    appState: appState
-                )
+                    appState: appState,
+                    generation: generation
+                ), isCurrentStabilization(generation) {
+                    acceptValidatedUserMove()
+                }
             } catch MenuBarItemManager.EventError.menuTrackingActive {
                 // A menu bar item's menu (Wi-Fi picker, input method panel,
                 // etc.) was open and the move was deferred to avoid tearing
                 // down the user's interaction. This isn't a failure worth
                 // alerting on — log only.
                 Self.diagLog.info("Move deferred, a menu bar item menu was open")
+            } catch MenuBarItemManager.EventError.moveEngineBusy {
+                // Another move held the bar for the whole wait. Nothing was
+                // tried, so nothing failed; the editor snaps the item back
+                // and the user can drag again once the bar is free.
+                Self.diagLog.info("Move deferred, another move held the bar")
             } catch {
+                guard isCurrentStabilization(generation) else { return }
                 Self.diagLog.error("Error moving menu bar item: \(error)")
-                await recoverFromFailedMove(of: item, to: destination, error: error, appState: appState)
+                // The system event-driven move sometimes throws cannotComplete
+                // after macOS has already settled the item into the requested
+                // slot: the click sequence bounces the item past the target
+                // and back during verification, but a subsequent reconciliation
+                // lands it where the user asked. Resample the cache after a
+                // short settle window and only show the alert when the item
+                // is NOT in the position the user actually dragged it to;
+                // showing it for a move that visibly worked is a false alarm.
+                try? await Task.sleep(for: .milliseconds(250))
+                guard isCurrentStabilization(generation) else { return }
+                _ = await appState.itemManager.refreshCacheAfterLayoutEditorMove()
+                guard isCurrentStabilization(generation) else { return }
+                let reachedPosition = didItemReachIntendedPosition(
+                    item: item,
+                    destination: destination,
+                    expectedSection: container.section,
+                    cache: appState.itemManager.itemCache
+                )
+                let isBlocked = if reachedPosition {
+                    false
+                } else {
+                    await appState.itemManager.isItemCurrentlyBlocked(item)
+                }
+                guard isCurrentStabilization(generation) else { return }
+                let action = MenuBarItemManager.classifyHiddenDragFailure(
+                    reachedPosition: reachedPosition,
+                    isBlocked: isBlocked,
+                    controlItemsMissing: appState.itemManager.areControlItemsMissing
+                )
+                switch action {
+                case .suppress:
+                    Self.diagLog.info("Move verification failed but \(item.logString) reached intended position in \(container.section.logString); suppressing alert")
+                    acceptValidatedUserMove()
+                case .rescueAndRetry:
+                    // The item is stuck at the x=-1 sentinel. Rescue it to
+                    // the visible section, let macOS settle, then retry the
+                    // original move exactly once (no loop). Only if that
+                    // retry also fails do we alert, and with a calm message
+                    // rather than the raw error, matching the safe-harbor
+                    // behavior of restoreBlockedItemsToVisible.
+                    Self.diagLog.warning("\(item.logString) is blocked (x=-1); attempting one rescue-and-retry before alerting")
+                    _ = await appState.itemManager.rescueBlockedItemToVisible(item)
+                    guard isCurrentStabilization(generation) else { return }
+                    try? await Task.sleep(for: .milliseconds(250))
+                    guard isCurrentStabilization(generation) else { return }
+                    _ = await appState.itemManager.refreshCacheAfterLayoutEditorMove()
+                    guard isCurrentStabilization(generation) else { return }
+                    do {
+                        try await appState.itemManager.move(
+                            item: item,
+                            to: destination,
+                            skipInputPause: true,
+                            options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
+                        )
+                        guard isCurrentStabilization(generation) else { return }
+                        appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
+                        if await stabilizePlacement(
+                            of: item,
+                            to: destination,
+                            expectedSection: container.section,
+                            appState: appState,
+                            generation: generation
+                        ), isCurrentStabilization(generation) {
+                            acceptValidatedUserMove()
+                        }
+                    } catch MenuBarItemManager.EventError.menuTrackingActive {
+                        // Same deferral the outer catch handles: the user
+                        // opened a menu bar item's menu while the retry was
+                        // in flight. Nothing failed, so don't alert.
+                        Self.diagLog.info("Rescue-and-retry deferred, a menu bar item menu was open")
+                    } catch {
+                        guard isCurrentStabilization(generation) else { return }
+                        Self.diagLog.error("Rescue-and-retry failed for \(item.logString): \(error)")
+                        let alert = NSAlert()
+                        alert.alertStyle = .warning
+                        alert.messageText = container.section == .alwaysHidden
+                            ? String(localized: "Couldn't move \(item.displayName) to the always-hidden section.")
+                            : String(localized: "Couldn't move \(item.displayName) to the hidden section.")
+                        alert.informativeText = String(localized: "The item was left in the visible section so it isn't stuck offscreen. Try dragging it again in a moment.")
+                        let report = await MoveFailureDiagnosticReport.generate(
+                            for: .init(
+                                item: item,
+                                destination: destination,
+                                expectedSection: container.section,
+                                error: error,
+                                note: "The item was stuck at x=-1; a rescue to the visible section and one retry of the move also failed."
+                            ),
+                            appState: appState
+                        )
+                        guard isCurrentStabilization(generation) else { return }
+                        report.run(alert, in: window)
+                    }
+                case .alertControlItemsMissing:
+                    let alert = NSAlert()
+                    alert.alertStyle = .warning
+                    alert.messageText = String(localized: "Couldn't move the item right now.")
+                    alert.informativeText = String(localized: "\(Constants.displayName) can't locate its hidden-section divider right now. It is attempting recovery in the background — try again in a few seconds.")
+                    let report = await MoveFailureDiagnosticReport.generate(
+                        for: .init(
+                            item: item,
+                            destination: destination,
+                            expectedSection: container.section,
+                            error: error,
+                            note: "The hidden-section divider could not be located; recovery was started in the background."
+                        ),
+                        appState: appState
+                    )
+                    guard isCurrentStabilization(generation) else { return }
+                    report.run(alert, in: window)
+                case .alertGeneric:
+                    // Generated before the alert shows so the "Save Diagnostic
+                    // Report…" button has the bar as it was at the failure,
+                    // not as it settles while the alert is up.
+                    let report = await MoveFailureDiagnosticReport.generate(
+                        for: .init(
+                            item: item,
+                            destination: destination,
+                            expectedSection: container.section,
+                            error: error
+                        ),
+                        appState: appState
+                    )
+                    guard isCurrentStabilization(generation) else { return }
+                    report.run(NSAlert(error: error), in: window)
+                }
             }
             if !revealedSections.isEmpty {
                 // Re-conceal the sections that were revealed for the drag
@@ -591,13 +812,24 @@ final class LayoutBarPaddingView: NSView {
                 // closing cache pass records the settled bar.
                 try? await Task.sleep(for: .milliseconds(250))
             }
-            watchdogTask.cancel()
-            if let appState = container.appState {
-                await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+            guard isCurrentStabilization(generation) else { return }
+            let didRefresh = await appState.itemManager.refreshCacheAfterLayoutEditorMove(
+                forcePersistSavedOrder: didValidateUserMove
+            )
+            guard isCurrentStabilization(generation) else { return }
+            if !didRefresh {
+                Self.diagLog.error(
+                    "Thawing Layout editor after post-move cache refresh timed out"
+                )
             }
-            await MainActor.run {
+            let didThawCurrentMove = await MainActor.run {
+                guard self.isStabilizing,
+                      self.stabilizationGeneration == generation
+                else {
+                    return false
+                }
                 self.isStabilizing = false
-                self.showOverlay(false)
+                self.stabilizationTask = nil
                 // Update the badge anchor BEFORE re-enabling view updates, using
                 // the current visual arrangement from the drag. This ensures the
                 // didSet refresh uses the correct anchor position.
@@ -615,10 +847,23 @@ final class LayoutBarPaddingView: NSView {
                 // the dragging session). Without resetting the source, its
                 // arrangedViews would stay frozen at the mid-drag snapshot
                 // until the next drag originated from that container.
-                self.container.canSetArrangedViews = true
+                self.container.resumeArrangedViewUpdatesWithoutAnimation()
                 if sourceContainer !== self.container {
-                    sourceContainer?.canSetArrangedViews = true
+                    sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                 }
+                return true
+            }
+
+            // Thumbnail capture is allowed to lag behind geometry. The moved
+            // view retains its last stable image, so holding both rows frozen
+            // while capture retries only makes the editor feel stuck.
+            if didThawCurrentMove {
+                await MainActor.run {
+                    appState.imageCache.performCacheCleanup()
+                }
+                await appState.imageCache.updateCacheWithoutChecks(
+                    sections: MenuBarSection.Name.allCases
+                )
             }
         }
     }
@@ -691,7 +936,8 @@ final class LayoutBarPaddingView: NSView {
                     of: item,
                     to: destination,
                     expectedSection: container.section,
-                    appState: appState
+                    appState: appState,
+                    generation: stabilizationGeneration
                 )
             } catch MenuBarItemManager.EventError.menuTrackingActive {
                 // Same deferral the outer catch handles: the user
@@ -731,15 +977,28 @@ final class LayoutBarPaddingView: NSView {
         expectedSection: MenuBarSection.Name,
         cache: MenuBarItemManager.ItemCache
     ) -> Bool {
-        let sectionItems = cache[expectedSection]
-        guard let itemIndex = sectionItems.firstIndex(where: { $0.tag == item.tag }) else {
+        Self.itemReachedIntendedPosition(
+            item: item,
+            destination: destination,
+            sectionItems: cache[expectedSection]
+        )
+    }
+
+    /// Whether `item` sits in `sectionItems` where `destination` asked for
+    /// it. Pure, so the identity rule below can be tested.
+    static nonisolated func itemReachedIntendedPosition(
+        item: MenuBarItem,
+        destination: MenuBarItemManager.MoveDestination,
+        sectionItems: [MenuBarItem]
+    ) -> Bool {
+        guard let itemIndex = sectionItems.firstIndex(where: { Self.isSameItem($0, item) }) else {
             return false
         }
         let target = destination.targetItem
         if target.isControlItem {
             return true
         }
-        guard let targetIndex = sectionItems.firstIndex(where: { $0.tag == target.tag }) else {
+        guard let targetIndex = sectionItems.firstIndex(where: { Self.isSameItem($0, target) }) else {
             return false
         }
         return switch destination {
@@ -752,7 +1011,6 @@ final class LayoutBarPaddingView: NSView {
     private func resetStabilizingStateIfNeeded(sourceContainer: LayoutBarContainer? = nil) async {
         if isStabilizing {
             isStabilizing = false
-            showOverlay(false)
             container.canSetArrangedViews = true
             // The source bar is frozen by the dragging session, so an abnormal
             // exit has to thaw it too or it stays at its mid-drag snapshot
@@ -763,8 +1021,49 @@ final class LayoutBarPaddingView: NSView {
         }
     }
 
-    private func showOverlay(_ visible: Bool) {
-        container.alphaValue = visible ? 0.6 : 1.0
+    /// Whether a cached item is the item that was dragged.
+    ///
+    /// The dragged item's tag is a snapshot. The cache refreshed after the
+    /// move can name the same window differently — a provisional
+    /// `com.apple.controlcenter:Item-0` resolves to its app's identifier
+    /// once the source process is known — and an exact tag comparison then
+    /// misses the item that just landed, which re-drags it (the move engine
+    /// finds it already in place and cancels) and, on the failure path,
+    /// alerts for a move that worked. The window is what moved: match it
+    /// first, and fall back to the tag without its window for a window that
+    /// was recreated in between.
+    static nonisolated func isSameItem(_ cached: MenuBarItem, _ dragged: MenuBarItem) -> Bool {
+        cached.windowID == dragged.windowID || cached.tag.matchesIgnoringWindowID(dragged.tag)
+    }
+
+    /// Whether the async continuation still belongs to the move that owns the
+    /// frozen editor rows. The recovery watchdog invalidates the generation
+    /// and cancels that task before reopening the editor, so a slow old move
+    /// cannot resume later and reorder the bar over a newer drag.
+    private func isCurrentStabilization(_ generation: Int) -> Bool {
+        isStabilizing && stabilizationGeneration == generation && !Task.isCancelled
+    }
+
+    @MainActor
+    private func resetStabilizingStateIfNeeded(
+        generation: Int,
+        sourceContainer: LayoutBarContainer? = nil,
+        cancelOwningTask: Bool = false
+    ) async -> Bool {
+        guard isStabilizing, stabilizationGeneration == generation else {
+            return false
+        }
+        if cancelOwningTask {
+            stabilizationTask?.cancel()
+            stabilizationGeneration &+= 1
+        }
+        stabilizationTask = nil
+        isStabilizing = false
+        container.resumeArrangedViewUpdatesWithoutAnimation()
+        if sourceContainer !== container {
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+        return true
     }
 
     private func containsNewItemsBadge() -> Bool {
@@ -822,7 +1121,13 @@ final class LayoutBarPaddingView: NSView {
     }
 
     private func liveFallbackDestinationForDraggedItem() async -> MenuBarItemManager.MoveDestination? {
-        let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        // This fallback only needs the section's control item. Resolving every
+        // item's source process can block on Accessibility for many seconds,
+        // leaving both drag rows frozen before move() can start its watchdog.
+        let items = await MenuBarItem.getMenuBarItems(
+            option: .activeSpace,
+            resolveSourcePID: false
+        )
         return switch container.section {
         case .visible:
             nil
@@ -1003,18 +1308,25 @@ final class LayoutBarPaddingView: NSView {
         of item: MenuBarItem,
         to destination: MenuBarItemManager.MoveDestination,
         expectedSection: MenuBarSection.Name,
-        appState: AppState
+        appState: AppState,
+        generation: Int
     ) async -> Bool {
-        // First refresh caches and verify placement.
-        await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+        guard isCurrentStabilization(generation) else { return false }
+        // A dropped refresh is not evidence. Keep the drag projection frozen
+        // until this move owns and completes a fast geometry cache pass.
+        guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+            return false
+        }
+        guard isCurrentStabilization(generation) else { return false }
 
         func isInExpectedSection() -> Bool {
-            appState.itemManager.itemCache[expectedSection].contains { $0.tag == item.tag }
+            appState.itemManager.itemCache[expectedSection].contains { Self.isSameItem($0, item) }
         }
 
         if !isInExpectedSection() {
             // Allow macOS a brief moment to settle, then retry once.
             try? await Task.sleep(for: .milliseconds(120))
+            guard isCurrentStabilization(generation) else { return false }
             do {
                 try await appState.itemManager.move(
                     item: item,
@@ -1022,17 +1334,17 @@ final class LayoutBarPaddingView: NSView {
                     skipInputPause: true,
                     options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
                 )
-                await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                guard isCurrentStabilization(generation) else { return false }
+                guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+                    return false
+                }
+                guard isCurrentStabilization(generation) else { return false }
             } catch {
+                guard isCurrentStabilization(generation) else { return false }
                 Self.diagLog.error("Stabilize move failed: \(error)")
             }
         }
 
-        // Refresh images so icons show immediately in the UI without clearing to avoid temporary gaps.
-        await MainActor.run {
-            appState.imageCache.performCacheCleanup()
-        }
-        await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
         return isInExpectedSection()
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -38,6 +38,15 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Reference box recording whether a queued move was accepted by its
+    /// preflight. ``MoveOptions/shouldBegin`` escapes the call frame — it is
+    /// stored in the options struct — so a captured local cannot be mutated
+    /// from inside the closure.
+    private final class MoveAttemptAcceptanceRecorder {
+        var didAcceptMoveAttempt = false
+        var didAcceptCurrentMove = false
+    }
+
     /// Relocates any newly appearing items that macOS placed to the left
     /// of our control items back into the visible section.
     ///
@@ -52,6 +61,7 @@ extension MenuBarItemManager {
         recentWindowIDs: Set<CGWindowID>,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard appState != nil else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
@@ -161,28 +171,28 @@ extension MenuBarItemManager {
 
         case let .systemItem(systemItem):
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: systemItem,
                     to: .rightOfItem(controlItems.hidden),
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale system-item relocation for \(systemItem.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -202,10 +212,10 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.info(
                     "Skipping new-item relocation for Thaw spacer \(candidate.logString)"
                 )
-                // Nothing was relocated: reporting true would make the caller
-                // treat this cycle as interrupted and schedule an extra
+                // Nothing was relocated: reporting an attempt would make the
+                // caller treat this cycle as interrupted and schedule an extra
                 // recache for a no-op. The spacer is already marked known.
-                return false
+                return .noAttempt
             }
 
             let destination = newItemsMoveDestination(for: controlItems, among: items)
@@ -222,28 +232,28 @@ extension MenuBarItemManager {
                 return .noAttempt
             }
 
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: candidate,
                     to: destination,
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale new-item relocation for \(candidate.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -272,6 +282,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         // The destination is the right of H_ctrl. When the divider itself is
         // parked offscreen, that destination is in the parked zone: the drag
         // strands the chevron beside it, invisible to the user (#958's
@@ -289,28 +300,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             try await move(
                 item: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug(
                 "Skipping stale Thaw-icon relocation for \(thawIcon.logString)"
             )
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
         return .completed
     }
@@ -331,6 +342,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocatePendingItems: skipping for provisional AX-frame correlation"
@@ -367,7 +379,7 @@ extension MenuBarItemManager {
             }
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         var didCompleteMove = false
         var didFailAcceptedMove = false
         func outcome() -> CacheDrivenMoveOutcome {
@@ -377,7 +389,7 @@ extension MenuBarItemManager {
             if didCompleteMove {
                 return .completed
             }
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
 
         // Iterate a snapshot of the dict keys so promotions of waitForRelaunch
@@ -467,27 +479,27 @@ extension MenuBarItemManager {
                         item: item,
                         to: destination,
                         skipInputPause: true,
-                        shouldBegin: {
-                            let shouldBegin = shouldBeginMove?() ?? true
+                        options: .init(shouldBegin: {
+                            let shouldBegin = beginMove?() ?? true
                             if shouldBegin {
-                                didAcceptMoveAttempt = true
-                                didAcceptCurrentMove = true
+                                attemptRecorder.didAcceptMoveAttempt = true
+                                attemptRecorder.didAcceptCurrentMove = true
                             }
                             return shouldBegin
-                        }
+                        })
                     )
                     pendingRelocations.removeValue(forKey: tagIdentifier)
                     pendingReturnDestinations.removeValue(forKey: tagIdentifier)
                     didCompleteMove = true
                 } catch EventError.moveSuperseded {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.debug(
                         "Stopping stale pending-item relocations before moving \(item.logString)"
                     )
                     persistPendingRelocations()
                     return outcome()
                 } catch {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.error(
                         """
                         Failed to relocate \(item.logString) back to \
@@ -536,6 +548,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Skipping control item order enforcement for provisional AX-frame correlation"
@@ -565,28 +578,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             MenuBarItemManager.diagLog.debug("Control items have incorrect order")
             try await move(
                 item: alwaysHidden,
                 to: .leftOfItem(hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
             return .completed
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug("Skipping stale control-item order enforcement")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1883,8 +1883,13 @@ extension MenuBarItemManager {
                                     item: hItem,
                                     to: dest,
                                     skipInputPause: true,
-                                    shouldBegin: shouldBeginBatchMove,
-                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                    options: .init(
+
+                                        shouldBegin: shouldBeginBatchMove,
+
+                                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                                    )
                                 )
                                 movedCount += 1
                                 failureLedger.recordSuccess(for: hItem)
@@ -2005,8 +2010,13 @@ extension MenuBarItemManager {
                             item: item,
                             to: dest,
                             skipInputPause: true,
-                            shouldBegin: shouldBeginBatchMove,
-                            didFinishWhileHoldingGate: didFinishBatchMove
+                            options: .init(
+
+                                shouldBegin: shouldBeginBatchMove,
+
+                                didFinishWhileHoldingGate: didFinishBatchMove
+
+                            )
                         )
                         movedCount += 1
                         didCrossHiddenBoundary = true
@@ -2222,8 +2232,13 @@ extension MenuBarItemManager {
                         item: ahItem,
                         to: dest,
                         skipInputPause: true,
-                        shouldBegin: shouldBeginBatchMove,
-                        didFinishWhileHoldingGate: didFinishBatchMove
+                        options: .init(
+
+                            shouldBegin: shouldBeginBatchMove,
+
+                            didFinishWhileHoldingGate: didFinishBatchMove
+
+                        )
                     )
                     movedCount += 1
                     try? await Task.sleep(for: .milliseconds(200))
@@ -2332,8 +2347,13 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .leftOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+
+                                    shouldBegin: shouldBeginBatchMove,
+
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2372,8 +2392,13 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .rightOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+
+                                    shouldBegin: shouldBeginBatchMove,
+
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2600,8 +2625,13 @@ extension MenuBarItemManager {
                     item: item,
                     to: dest,
                     skipInputPause: true,
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+
+                        shouldBegin: shouldBeginBatchMove,
+
+                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                    )
                 )
                 movedCount += 1
                 consecutiveMoveFailures = 0

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1884,11 +1884,8 @@ extension MenuBarItemManager {
                                     to: dest,
                                     skipInputPause: true,
                                     options: .init(
-
                                         shouldBegin: shouldBeginBatchMove,
-
                                         didFinishWhileHoldingGate: didFinishBatchMove
-
                                     )
                                 )
                                 movedCount += 1
@@ -2011,11 +2008,8 @@ extension MenuBarItemManager {
                             to: dest,
                             skipInputPause: true,
                             options: .init(
-
                                 shouldBegin: shouldBeginBatchMove,
-
                                 didFinishWhileHoldingGate: didFinishBatchMove
-
                             )
                         )
                         movedCount += 1
@@ -2233,11 +2227,8 @@ extension MenuBarItemManager {
                         to: dest,
                         skipInputPause: true,
                         options: .init(
-
                             shouldBegin: shouldBeginBatchMove,
-
                             didFinishWhileHoldingGate: didFinishBatchMove
-
                         )
                     )
                     movedCount += 1
@@ -2348,11 +2339,8 @@ extension MenuBarItemManager {
                                 to: .leftOfItem(ahItem),
                                 skipInputPause: true,
                                 options: .init(
-
                                     shouldBegin: shouldBeginBatchMove,
-
                                     didFinishWhileHoldingGate: didFinishBatchMove
-
                                 )
                             )
                             movedCount += 1
@@ -2393,11 +2381,8 @@ extension MenuBarItemManager {
                                 to: .rightOfItem(ahItem),
                                 skipInputPause: true,
                                 options: .init(
-
                                     shouldBegin: shouldBeginBatchMove,
-
                                     didFinishWhileHoldingGate: didFinishBatchMove
-
                                 )
                             )
                             movedCount += 1
@@ -2626,11 +2611,8 @@ extension MenuBarItemManager {
                     to: dest,
                     skipInputPause: true,
                     options: .init(
-
                         shouldBegin: shouldBeginBatchMove,
-
                         didFinishWhileHoldingGate: didFinishBatchMove
-
                     )
                 )
                 movedCount += 1

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -381,8 +381,13 @@ extension MenuBarItemManager {
                 try await move(
                     item: item,
                     to: .leftOfItem(controlItems.hidden),
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+
+                        shouldBegin: shouldBeginBatchMove,
+
+                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                    )
                 )
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)

--- a/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
+++ b/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
@@ -154,7 +154,7 @@ struct LayoutBarsSection: View {
                     .font(.headline)
                     .padding(.leading, 8)
 
-                LayoutBar(imageCache: appState.imageCache, section: name)
+                LayoutBar(section: name)
             }
         }
     }

--- a/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
+++ b/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
@@ -157,3 +157,245 @@ struct LayoutBarGroupResolutionOrderTests {
         #expect(unit == [first.tag, dragged.tag, stranded.tag])
     }
 }
+
+@Suite("Layout item drag presentation")
+struct LayoutBarItemDragPresentationTests {
+    @Test("A dragged item keeps a visible dimmed placeholder")
+    func draggedItemKeepsVisiblePlaceholder() {
+        let fraction = LayoutBarItemView.iconFraction(
+            isDraggingPlaceholder: true,
+            isEnabled: true
+        )
+
+        #expect(fraction > 0)
+        #expect(fraction < 1)
+    }
+
+    @Test("A frozen container keeps its last stable thumbnail")
+    func frozenContainerRejectsTransientThumbnail() {
+        #expect(!LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: true,
+            containerAllowsUpdates: false
+        ))
+        #expect(LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: true,
+            containerAllowsUpdates: true
+        ))
+        #expect(LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: false,
+            containerAllowsUpdates: false
+        ))
+    }
+
+    @Test("Geometry-only cache changes keep the existing item view")
+    func geometryChangeReusesItemView() {
+        let tag = MenuBarItemTag.appItem(
+            bundleID: "com.example.status-item",
+            title: "Item-0",
+            windowID: 711
+        )
+        let beforeMove = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: 1400, y: 0, width: 24, height: 33),
+            isOnScreen: true
+        )
+        let afterMove = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: -3700, y: 0, width: 24, height: 33),
+            isOnScreen: false
+        )
+
+        #expect(LayoutBarContainer.canReuseItemView(
+            representing: beforeMove,
+            for: afterMove
+        ))
+    }
+
+    @Test("A recreated status-item window gets a new item view")
+    func recreatedWindowDoesNotReuseItemView() {
+        let oldItem = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.status-item", title: "Item-0", windowID: 711),
+            windowID: 711
+        )
+        let recreatedItem = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.status-item", title: "Item-0", windowID: 812),
+            windowID: 812
+        )
+
+        #expect(!LayoutBarContainer.canReuseItemView(
+            representing: oldItem,
+            for: recreatedItem
+        ))
+    }
+
+    @Test("A changed status-item size gets a new item view")
+    func resizedItemDoesNotReuseItemView() {
+        let tag = MenuBarItemTag.appItem(
+            bundleID: "com.example.status-item",
+            title: "Item-0",
+            windowID: 711
+        )
+        let oldItem = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: 1400, y: 0, width: 24, height: 33)
+        )
+        let resizedItem = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: -3700, y: 0, width: 36, height: 33),
+            isOnScreen: false
+        )
+
+        #expect(!LayoutBarContainer.canReuseItemView(
+            representing: oldItem,
+            for: resizedItem
+        ))
+    }
+
+    @Test("The New Items badge remains visible while dragged")
+    func draggedBadgeKeepsVisiblePlaceholder() {
+        let opacity = LayoutBarNewItemsBadgeView.contentOpacity(isDraggingPlaceholder: true)
+
+        #expect(opacity > 0)
+        #expect(opacity < 1)
+    }
+
+    @Test("A cancelled cross-row drag restores the original view exactly once")
+    @MainActor
+    func cancelledCrossRowDragRestoresOriginalView() {
+        let appState = AppState()
+        let source = LayoutBarContainer(appState: appState, section: .visible)
+        let destination = LayoutBarContainer(appState: appState, section: .hidden)
+        let draggedView = LayoutBarNewItemsBadgeView()
+
+        source.arrangedViews = [draggedView]
+        source.arrangedViews.removeAll()
+        destination.arrangedViews = [draggedView]
+
+        source.restoreArrangedViewAfterCancelledDrag(
+            draggedView,
+            from: destination,
+            at: 0
+        )
+
+        #expect(source.arrangedViews.count { $0 === draggedView } == 1)
+        #expect(!destination.arrangedViews.contains { $0 === draggedView })
+        #expect(draggedView.superview === source)
+    }
+
+    @Test("A row frozen by another drag rejects a new drag")
+    func frozenRowRejectsUnrelatedDrag() {
+        #expect(!LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: false,
+            alreadyAccepted: false
+        ))
+        #expect(LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: true,
+            alreadyAccepted: false
+        ))
+        #expect(LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: false,
+            alreadyAccepted: true
+        ))
+    }
+}
+
+@Suite("Layout bar drag identity")
+struct LayoutBarDragIdentityTests {
+    private let provisional = MenuBarItem.fixture(
+        tag: MenuBarItemTag(
+            namespace: .controlCenter,
+            title: "Item-0",
+            windowID: 5467,
+            instanceIndex: 0
+        ),
+        windowID: 5467,
+        sourcePID: nil,
+        ownerPID: 645
+    )
+
+    private let resolved = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "IconSwitcher", title: "Item-0", windowID: 5467),
+        windowID: 5467,
+        sourcePID: 12460,
+        ownerPID: 645
+    )
+
+    private let otherItem = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "com.example.other", title: "Item-0", windowID: 2556),
+        windowID: 2556
+    )
+
+    @Test("The same window is the same item after its identity resolves")
+    func sameWindowIsSameItem() {
+        #expect(LayoutBarPaddingView.isSameItem(resolved, provisional))
+        #expect(!LayoutBarPaddingView.isSameItem(otherItem, provisional))
+    }
+
+    @Test("A recreated window still matches by tag")
+    func recreatedWindowMatchesByTag() {
+        let recreated = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "IconSwitcher", title: "Item-0", windowID: 5744),
+            windowID: 5744,
+            sourcePID: 12460,
+            ownerPID: 645
+        )
+
+        #expect(LayoutBarPaddingView.isSameItem(recreated, resolved))
+    }
+
+    @Test("The dragged item is found beside its target under its resolved name")
+    func reachedPositionUnderResolvedName() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(otherItem),
+            sectionItems: [resolved, otherItem]
+        )
+
+        #expect(reached)
+    }
+
+    @Test("The wrong side of the target is not the intended position")
+    func wrongSideIsNotReached() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .rightOfItem(otherItem),
+            sectionItems: [resolved, otherItem]
+        )
+
+        #expect(!reached)
+    }
+
+    @Test("Containment is enough when the target is a section divider")
+    func dividerTargetNeedsOnlyContainment() {
+        let divider = MenuBarItem.fixture(
+            tag: .hiddenControlItem,
+            windowID: 5134,
+            sourcePID: nil
+        )
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(divider),
+            sectionItems: [otherItem, resolved]
+        )
+
+        #expect(reached)
+    }
+
+    @Test("An item missing from the section has not reached its position")
+    func missingItemIsNotReached() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(otherItem),
+            sectionItems: [otherItem]
+        )
+
+        #expect(!reached)
+    }
+}


### PR DESCRIPTION
# Summary

Keeps Layout Bar row and AppKit view ownership stable while an item is dragged between sections and while the physical menu-bar move settles. Participating rows retain dimmed placeholders and frozen thumbnails instead of briefly removing an icon, duplicating it, or rebuilding it at an unrelated position.

After an authoritative cache refresh, the source and destination rows reconcile atomically without animation. Generation checks and a bounded watchdog ignore stale asynchronous completions and recover a frozen row if a refresh never arrives. Ordinary clicks still activate the represented menu-bar item, while a gesture that entered the drag path never fires the click action on mouse-up.

**Scope:** This PR changes 8 files with 831 insertions and 202 deletions. It is limited to generic Layout Bar presentation, drag/view identity, reconciliation, click activation, and focused Swift Testing coverage. It does not change physical move transport, cache publication, automatic batch coordination, trigger ownership, automatic failure reporting, signing, or localization. This may be suitable for 2.2.

Dependency: #1002 must be merged first or used as this PR's base. The final authoritative reconciliation also relies on #1000's bounded move verdicts and #1001's transactional cache refresh.

## Linked issue (required)

Closes: N/A

Related: #905, #923, #927, #981

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- A dragged item keeps a visible dimmed placeholder rather than disappearing from its source row.
- The New Items badge remains visible and preserves the side on which another item was dropped, including badge-only sections.
- Only the rows participating in a transfer are frozen; unrelated rows continue to update, and a row already frozen by another gesture rejects a competing drag.
- Frozen rows retain their last stable thumbnails while the physical bar and cache settle.
- Geometry-only cache changes reuse the existing item view, while a recreated status-item window or changed visual size gets a new view.
- Provisional and resolved identities for the same live status item reconcile without creating a duplicate.
- Cancelling a cross-row drag restores the original view exactly once.
- Authoritative source/destination reconciliation is nonanimated and generation-checked; stale completions cannot overwrite a newer drag.
- A watchdog thaws the editor if an expected completion never arrives.
- A left click activates the represented menu-bar item, but mouse-up after a drag, outside the item, or from another button does not.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawFinalStackBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/LayoutBarContainerTests -only-testing:ThawTests/LayoutBarItemActivationTests -only-testing:ThawTests/LayoutBarItemDragPresentationTests -only-testing:ThawTests/LayoutBarDragIdentityTests`

The final rebased stack built successfully, and all 20 focused tests across 4 suites passed. SwiftFormat lint reported 0 of 8 files requiring changes; strict SwiftLint reported 0 violations; the generated SwiftLint input list was unchanged and `git diff --check` was clean.

## Known limitations / follow-ups

- Automated tests cover the editor state machine and view identity but cannot reproduce private `CGEvent` behavior for every status-item app, display topology, Space transition, or macOS update.
- A physical move that macOS definitively rejects still returns the editor to confirmed state; the final PR in this series adds user-facing reporting for automatic movers.
- This stacked PR should remain based on #1002 until that dependency merges. It can then be rebased onto `development`.

## Other information

No manual live drag was performed for this isolated PR. Verification used the focused editor suites, the macOS build, formatting, lint, generated-file comparison, and diff checks.

The commit includes the required DCO sign-off. No dependency, lockfile, signing, or localization changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 11 of 12  
**Git base:** #1002  
**Functional dependencies:** #994 and #1000–#1002.
