### PR TITLE
feat(menubar): report failed automatic moves

### DIFF
--- a/Thaw/MenuBar/LayoutBar/MoveFailureDiagnosticReport.swift
+++ b/Thaw/MenuBar/LayoutBar/MoveFailureDiagnosticReport.swift
@@ -24,11 +24,11 @@ nonisolated struct MoveFailureDiagnosticReport {
         /// The item that did not move.
         let item: MenuBarItem
 
-        /// Where it was supposed to go.
-        let destination: MenuBarItemManager.MoveDestination
+        /// Where it was supposed to go, when the caller still knows.
+        let destination: MenuBarItemManager.MoveDestination?
 
-        /// The section the destination lies in.
-        let expectedSection: MenuBarSection.Name
+        /// The section the destination lies in, when the caller knows.
+        let expectedSection: MenuBarSection.Name?
 
         /// The error the move ended with.
         let error: any Error
@@ -38,8 +38,8 @@ nonisolated struct MoveFailureDiagnosticReport {
 
         init(
             item: MenuBarItem,
-            destination: MenuBarItemManager.MoveDestination,
-            expectedSection: MenuBarSection.Name,
+            destination: MenuBarItemManager.MoveDestination?,
+            expectedSection: MenuBarSection.Name?,
             error: any Error,
             note: String? = nil
         ) {
@@ -185,6 +185,94 @@ nonisolated struct MoveFailureDiagnosticReport {
         try text.write(to: url, atomically: true, encoding: .utf8)
     }
 
+    /// Where reports for failed automatic moves are written without asking:
+    /// `~/Library/Logs/Thaw/Diagnostics`.
+    static var automaticReportsDirectory: URL {
+        DiagnosticLogger.shared.logDirectory.appendingPathComponent("Diagnostics", isDirectory: true)
+    }
+
+    /// How many automatic reports are kept; the oldest are removed.
+    static let automaticReportsKept = 20
+
+    /// Writes the report to the automatic diagnostics folder and removes old
+    /// automatic move reports beyond ``automaticReportsKept``.
+    ///
+    /// A suffix is added when two failures receive the same timestamp-based
+    /// name, so a burst never overwrites an earlier report before pruning can
+    /// account for it.
+    @discardableResult
+    func writeToAutomaticReports(in directory: URL = Self.automaticReportsDirectory) throws -> URL {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = Self.availableReportURL(
+            in: directory,
+            suggestedFileName: suggestedFileName,
+            fileExists: fileManager.fileExists(atPath:)
+        )
+        try write(to: url)
+        Self.pruneAutomaticReports(in: directory, keeping: Self.automaticReportsKept)
+        return url
+    }
+
+    /// Returns a non-existing URL for `suggestedFileName`, adding a numeric
+    /// suffix before its extension when needed.
+    static func availableReportURL(
+        in directory: URL,
+        suggestedFileName: String,
+        fileExists: (String) -> Bool
+    ) -> URL {
+        let suggestedURL = directory.appendingPathComponent(suggestedFileName)
+        guard fileExists(suggestedURL.path) else {
+            return suggestedURL
+        }
+
+        let base = suggestedURL.deletingPathExtension().lastPathComponent
+        let pathExtension = suggestedURL.pathExtension
+        var suffix = 2
+        while true {
+            let name = pathExtension.isEmpty
+                ? "\(base)-\(suffix)"
+                : "\(base)-\(suffix).\(pathExtension)"
+            let candidate = directory.appendingPathComponent(name)
+            if !fileExists(candidate.path) {
+                return candidate
+            }
+            suffix += 1
+        }
+    }
+
+    /// Removes all but the newest `keepCount` automatic move reports in
+    /// `directory`. Other text files in the diagnostics folder are retained.
+    static func pruneAutomaticReports(in directory: URL, keeping keepCount: Int) {
+        let fileManager = FileManager.default
+        guard let urls = try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: .skipsHiddenFiles
+        ) else {
+            return
+        }
+
+        func modified(_ url: URL) -> Date {
+            (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate
+                ?? .distantPast
+        }
+
+        let prefix = "\(Constants.displayName)-move-diagnostic-"
+        let reports = urls
+            .filter { $0.pathExtension == "txt" && $0.lastPathComponent.hasPrefix(prefix) }
+            .sorted {
+                let lhsDate = modified($0)
+                let rhsDate = modified($1)
+                return lhsDate == rhsDate
+                    ? $0.lastPathComponent > $1.lastPathComponent
+                    : lhsDate > rhsDate
+            }
+        for stale in reports.dropFirst(max(0, keepCount)) {
+            try? fileManager.removeItem(at: stale)
+        }
+    }
+
     /// Asks where to save the report, writes it, and reveals it in Finder.
     @MainActor
     func save(in window: NSWindow? = nil) {
@@ -286,8 +374,8 @@ private extension MoveFailureDiagnosticReport {
             and status text, and display/menu-bar geometry because they are needed to \
             investigate the failure. Those values may themselves be sensitive. The report \
             attempts to redact usernames and full names, home-directory paths, network and \
-            connected-device names, e-mail, IP and MAC addresses, trigger names and \
-            condition values, and precise location coordinates. Automated redaction cannot \
+            connected-device names, e-mail, IP and MAC addresses, script values, and \
+            precise location coordinates. Automated redaction cannot \
             be guaranteed to catch everything. Review the report before sharing it.
             """
         )
@@ -308,18 +396,22 @@ private extension MoveFailureDiagnosticReport {
         if let note = failure.note {
             writer.line("Note: \(note)")
         }
-        writer.line("Expected section: \(failure.expectedSection.logString)")
+        writer.line("Expected section: \(failure.expectedSection?.logString ?? "unknown")")
         writer.line("Item: \(failure.item.logString)")
         for line in itemLines(failure.item, cache: cache, manager: manager) {
             writer.line(line)
         }
-        let target = failure.destination.targetItem
-        writer.line("Destination: \(failure.destination.logString)")
-        for line in itemLines(target, cache: cache, manager: manager) {
-            writer.line(line)
-        }
-        if let liveTargetBounds = Bridging.getWindowBounds(for: target.windowID) {
-            writer.line("  liveBounds=\(format(liveTargetBounds))")
+        if let destination = failure.destination {
+            let target = destination.targetItem
+            writer.line("Destination: \(destination.logString)")
+            for line in itemLines(target, cache: cache, manager: manager) {
+                writer.line(line)
+            }
+            if let liveTargetBounds = Bridging.getWindowBounds(for: target.windowID) {
+                writer.line("  liveBounds=\(format(liveTargetBounds))")
+            }
+        } else {
+            writer.line("Destination: not recorded by the caller (see the log excerpt)")
         }
 
         let lastMove = manager.lastMoveOperationTimestamp.map { instant in

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -192,7 +192,6 @@ extension MenuBarItemManager {
                 return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
                 await reportAutomaticMoveFailure(
                     of: systemItem,
                     to: .rightOfItem(controlItems.hidden),
@@ -200,6 +199,7 @@ extension MenuBarItemManager {
                     error: error,
                     source: "the section layout"
                 )
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -260,7 +260,6 @@ extension MenuBarItemManager {
                 return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
                 await reportAutomaticMoveFailure(
                     of: candidate,
                     to: destination,
@@ -268,6 +267,7 @@ extension MenuBarItemManager {
                     error: error,
                     source: "new-item placement"
                 )
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -335,7 +335,6 @@ extension MenuBarItemManager {
             return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             await reportAutomaticMoveFailure(
                 of: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
@@ -343,6 +342,7 @@ extension MenuBarItemManager {
                 error: error,
                 source: "the section layout"
             )
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
         return .completed
     }
@@ -631,7 +631,6 @@ extension MenuBarItemManager {
             return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
-            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             await reportAutomaticMoveFailure(
                 of: alwaysHidden,
                 to: .leftOfItem(hidden),
@@ -639,6 +638,7 @@ extension MenuBarItemManager {
                 error: error,
                 source: "control-item ordering"
             )
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -193,6 +193,13 @@ extension MenuBarItemManager {
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
                 return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                await reportAutomaticMoveFailure(
+                    of: systemItem,
+                    to: .rightOfItem(controlItems.hidden),
+                    expectedSection: .visible,
+                    error: error,
+                    source: "the section layout"
+                )
             }
             return .completed
 
@@ -254,6 +261,13 @@ extension MenuBarItemManager {
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
                 return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                await reportAutomaticMoveFailure(
+                    of: candidate,
+                    to: destination,
+                    expectedSection: effectiveNewItemsSection,
+                    error: error,
+                    source: "new-item placement"
+                )
             }
             return .completed
 
@@ -322,6 +336,13 @@ extension MenuBarItemManager {
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
             return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            await reportAutomaticMoveFailure(
+                of: thawIcon,
+                to: .rightOfItem(controlItems.hidden),
+                expectedSection: .visible,
+                error: error,
+                source: "the section layout"
+            )
         }
         return .completed
     }
@@ -510,6 +531,13 @@ extension MenuBarItemManager {
                         \(targetSection.logString): \(error)
                         """
                     )
+                    await reportAutomaticMoveFailure(
+                        of: item,
+                        to: destination,
+                        expectedSection: targetSection,
+                        error: error,
+                        source: "pending item restoration"
+                    )
                 }
 
             case .clearEntry:
@@ -604,6 +632,13 @@ extension MenuBarItemManager {
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
             return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            await reportAutomaticMoveFailure(
+                of: alwaysHidden,
+                to: .leftOfItem(hidden),
+                expectedSection: nil,
+                error: error,
+                source: "control-item ordering"
+            )
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1556,6 +1556,29 @@ extension MenuBarItemManager {
         // as an order of record (#900).
         var unenactedMoveCount = 0
 
+        /// Automatic saved-layout restores and profile re-sorts report only
+        /// definitive failures. User-invoked profile applies already have
+        /// their own immediate UI and do not use this background channel.
+        func enqueueApplyMoveFailure(
+            _ error: any Error,
+            item: MenuBarItem,
+            destination: MoveDestination?,
+            expectedSection: MenuBarSection.Name?
+        ) {
+            guard automatic else { return }
+            let failureSource = switch source {
+            case .profile: "the active profile"
+            case .savedOrder: "the saved layout"
+            }
+            enqueueAutomaticMoveFailureReport(
+                of: item,
+                to: destination,
+                expectedSection: expectedSection,
+                error: error,
+                source: failureSource
+            )
+        }
+
         /// Every abandon exits the same way: the abandoned remainder is one
         /// more unenacted move, the outcome feeds the circuit breaker, and
         /// in-flight profile state is torn down before the deferred cache
@@ -1910,6 +1933,12 @@ extension MenuBarItemManager {
                                         failureLedger.recordFailure(for: hItem, kind: Self.failureKind(of: error))
                                     }
                                     MenuBarItemManager.diagLog.error("Profile layout: failed to move H_ctrl: \(error)")
+                                    enqueueApplyMoveFailure(
+                                        error,
+                                        item: hItem,
+                                        destination: dest,
+                                        expectedSection: nil
+                                    )
                                 }
                             }
                         }
@@ -1986,9 +2015,11 @@ extension MenuBarItemManager {
                     .compactMap { offenders[$0] }
                     .sorted { $0.bounds.minX > $1.bounds.minX }
 
-                for (item, dest) in toConceal.map({ ($0, MoveDestination.leftOfItem(hItem)) })
-                    + toReveal.map({ ($0, MoveDestination.rightOfItem(hItem)) })
-                {
+                for (item, dest, expectedSection) in toConceal.map({
+                    ($0, MoveDestination.leftOfItem(hItem), MenuBarSection.Name.hidden)
+                }) + toReveal.map({
+                    ($0, MoveDestination.rightOfItem(hItem), MenuBarSection.Name.visible)
+                }) {
                     if Task.isCancelled {
                         break
                     }
@@ -2040,6 +2071,12 @@ extension MenuBarItemManager {
                             }
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: failed to move \(item.logString) across the H_ctrl boundary: \(error)"
+                            )
+                            enqueueApplyMoveFailure(
+                                error,
+                                item: item,
+                                destination: dest,
+                                expectedSection: expectedSection
                             )
                         }
                     }
@@ -2240,6 +2277,12 @@ extension MenuBarItemManager {
                     }
                     unenactedMoveCount += 1
                     MenuBarItemManager.diagLog.error("Profile layout: failed to move AH_ctrl: \(error)")
+                    enqueueApplyMoveFailure(
+                        error,
+                        item: ahItem,
+                        destination: dest,
+                        expectedSection: nil
+                    )
                 }
             }
 
@@ -2354,6 +2397,12 @@ extension MenuBarItemManager {
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to AH failed for \(uid): \(error)"
                             )
+                            enqueueApplyMoveFailure(
+                                error,
+                                item: item,
+                                destination: .leftOfItem(ahItem),
+                                expectedSection: .alwaysHidden
+                            )
                         }
                     }
 
@@ -2395,6 +2444,12 @@ extension MenuBarItemManager {
                             unenactedMoveCount += 1
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to hidden failed for \(uid): \(error)"
+                            )
+                            enqueueApplyMoveFailure(
+                                error,
+                                item: item,
+                                destination: .rightOfItem(ahItem),
+                                expectedSection: .hidden
                             )
                         }
                     }
@@ -2643,6 +2698,12 @@ extension MenuBarItemManager {
                 }
                 MenuBarItemManager.diagLog.error(
                     "Profile layout: failed to move \(planned.uid): \(error)"
+                )
+                enqueueApplyMoveFailure(
+                    error,
+                    item: item,
+                    destination: dest,
+                    expectedSection: fallbackSection
                 )
                 if Self.moveBatchShouldAbandon(consecutiveFailures: consecutiveMoveFailures) {
                     unenactedMoveCount += plannedMoves.count - plannedIndex - 1

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+MoveFailureReporting.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+MoveFailureReporting.swift
@@ -61,7 +61,7 @@ extension MenuBarItemManager {
         switch error {
         case .missingItemBounds, .missingDestinationBounds, .menuTrackingActive,
              .staleDestination, .moveSuperseded, .moveEngineBusy,
-             .unsafeMovePath:
+             .unsafeMovePath, .inputPauseTimedOut:
             // The item or destination changed, the user still owns the menu,
             // or another transaction owns the bar. A fresh pass may produce
             // a different valid plan, and no terminal malfunction is proven.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+MoveFailureReporting.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+MoveFailureReporting.swift
@@ -1,0 +1,272 @@
+//
+//  MenuBarItemManager+MoveFailureReporting.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Cocoa
+
+/// Persists and presents diagnostic reports for automatic moves that reached
+/// a definitive failure. Expected deferrals are left to the caller's next
+/// cache or layout pass.
+extension MenuBarItemManager {
+    /// Whether an automatic move outcome is final enough to report.
+    nonisolated enum AutomaticMoveFailureDisposition: Equatable {
+        case report
+        case deferred
+    }
+
+    /// Whether the user-facing presentation is allowed by the cooldown.
+    /// This decision gates only the alert or notification; report persistence
+    /// is never skipped because presentation is rate-limited.
+    nonisolated enum AutomaticMoveFailurePresentationDecision: Equatable {
+        case present
+        case suppressSameItem(elapsed: TimeInterval)
+        case suppressBurst(elapsed: TimeInterval)
+    }
+
+    /// Where an allowed user-facing failure is presented.
+    nonisolated enum AutomaticMoveFailurePresentationRoute: Equatable {
+        case settingsSheet
+        case notification
+    }
+
+    /// Work performed for one classified outcome and cooldown decision.
+    nonisolated struct AutomaticMoveFailureHandlingPlan: Equatable {
+        let shouldPersist: Bool
+        let shouldPresent: Bool
+    }
+
+    /// How long one item's presentations stay quiet after an alert or
+    /// notification about it.
+    static nonisolated let automaticMoveFailureReportCooldown: TimeInterval = 10 * 60
+
+    /// Minimum spacing between presentations for different items, so one
+    /// failed bulk pass does not produce a notification storm.
+    static nonisolated let automaticMoveFailureReportSpacing: TimeInterval = 30
+
+    /// Classifies outcomes with no UI or live state, so every automatic mover
+    /// applies the same failure-versus-deferral rule.
+    static nonisolated func automaticMoveFailureDisposition(
+        for error: any Error
+    ) -> AutomaticMoveFailureDisposition {
+        if error is CancellationError {
+            return .deferred
+        }
+        guard let error = error as? EventError else {
+            return .report
+        }
+        switch error {
+        case .missingItemBounds, .missingDestinationBounds, .menuTrackingActive,
+             .staleDestination, .moveSuperseded, .moveEngineBusy,
+             .unsafeMovePath:
+            // The item or destination changed, the user still owns the menu,
+            // or another transaction owns the bar. A fresh pass may produce
+            // a different valid plan, and no terminal malfunction is proven.
+            return .deferred
+        case let .itemNotMovable(item):
+            // A generic Control Center slot can become movable as soon as its
+            // source identity resolves. A static macOS prohibition will not.
+            if case .unresolvedControlCenterPlaceholder? = item.immovabilityReason {
+                return .deferred
+            }
+            return .report
+        case .cannotComplete, .invalidEventSource, .missingMouseLocation,
+             .eventCreationFailure, .eventOperationTimeout,
+             .itemResponseTimeout, .ownerUnresponsive, .eventWindowMismatch,
+             .dropReverted, .moveTimedOut:
+            return .report
+        }
+    }
+
+    /// Applies the per-item and burst cooldowns to a reportable failure.
+    /// Exact boundary timestamps are allowed.
+    static nonisolated func automaticMoveFailurePresentationDecision(
+        now: Date,
+        lastForItem: Date?,
+        lastOverall: Date?,
+        itemCooldown: TimeInterval = automaticMoveFailureReportCooldown,
+        burstSpacing: TimeInterval = automaticMoveFailureReportSpacing
+    ) -> AutomaticMoveFailurePresentationDecision {
+        if let lastForItem {
+            let elapsed = now.timeIntervalSince(lastForItem)
+            if elapsed < itemCooldown {
+                return .suppressSameItem(elapsed: elapsed)
+            }
+        }
+        if let lastOverall {
+            let elapsed = now.timeIntervalSince(lastOverall)
+            if elapsed < burstSpacing {
+                return .suppressBurst(elapsed: elapsed)
+            }
+        }
+        return .present
+    }
+
+    /// Selects a sheet only when Settings is already visible; an automatic
+    /// background move never opens Settings over the user's current work.
+    static nonisolated func automaticMoveFailurePresentationRoute(
+        settingsWindowVisible: Bool
+    ) -> AutomaticMoveFailurePresentationRoute {
+        settingsWindowVisible ? .settingsSheet : .notification
+    }
+
+    /// Keeps persistence independent from presentation throttling: every
+    /// definitive failure is saved, while only `.present` reaches the user.
+    static nonisolated func automaticMoveFailureHandlingPlan(
+        disposition: AutomaticMoveFailureDisposition,
+        presentationDecision: AutomaticMoveFailurePresentationDecision
+    ) -> AutomaticMoveFailureHandlingPlan {
+        guard disposition == .report else {
+            return AutomaticMoveFailureHandlingPlan(
+                shouldPersist: false,
+                shouldPresent: false
+            )
+        }
+        let shouldPresent = if case .present = presentationDecision {
+            true
+        } else {
+            false
+        }
+        return AutomaticMoveFailureHandlingPlan(
+            shouldPersist: true,
+            shouldPresent: shouldPresent
+        )
+    }
+
+    /// Starts report generation outside a bulk move loop. The initial guard
+    /// runs in the caller's task so cancellation is not lost when the new task
+    /// is created.
+    func enqueueAutomaticMoveFailureReport(
+        of item: MenuBarItem,
+        to destination: MoveDestination?,
+        expectedSection: MenuBarSection.Name?,
+        error: any Error,
+        source: String
+    ) {
+        guard !Task.isCancelled,
+              Self.automaticMoveFailureDisposition(for: error) == .report
+        else {
+            return
+        }
+        Task { [weak self] in
+            await self?.reportAutomaticMoveFailure(
+                of: item,
+                to: destination,
+                expectedSection: expectedSection,
+                error: error,
+                source: source
+            )
+        }
+    }
+
+    /// Writes a report for a definitive automatic-move failure, then presents
+    /// it when the per-item and burst cooldowns allow.
+    func reportAutomaticMoveFailure(
+        of item: MenuBarItem,
+        to destination: MoveDestination?,
+        expectedSection: MenuBarSection.Name?,
+        error: any Error,
+        source: String
+    ) async {
+        guard !Task.isCancelled else { return }
+        guard let appState else {
+            return
+        }
+
+        let disposition = Self.automaticMoveFailureDisposition(for: error)
+        let key = MenuBarItemTag.canonicalPersistentIdentifier(item.uniqueIdentifier)
+        let now = Date()
+        let presentationDecision = Self.automaticMoveFailurePresentationDecision(
+            now: now,
+            lastForItem: automaticMoveFailureReports[key],
+            lastOverall: lastAutomaticMoveFailureReport
+        )
+        let handlingPlan = Self.automaticMoveFailureHandlingPlan(
+            disposition: disposition,
+            presentationDecision: presentationDecision
+        )
+        guard handlingPlan.shouldPersist else { return }
+
+        // Reserve an allowed presentation before report generation yields the
+        // main actor, so two simultaneous failures cannot both pass the burst
+        // gate. Persistence remains allowed for the suppressed one.
+        if handlingPlan.shouldPresent {
+            automaticMoveFailureReports[key] = now
+            lastAutomaticMoveFailureReport = now
+        }
+
+        let report = await MoveFailureDiagnosticReport.generate(
+            for: .init(
+                item: item,
+                destination: destination,
+                expectedSection: expectedSection,
+                error: error,
+                note: "Automatic move requested by \(source)."
+            ),
+            appState: appState
+        )
+        var savedURL: URL?
+        do {
+            savedURL = try report.writeToAutomaticReports()
+        } catch {
+            MenuBarItemManager.diagLog.error(
+                "Could not save the diagnostic report for \(item.logString): \(error)"
+            )
+        }
+
+        switch presentationDecision {
+        case .present:
+            break
+        case let .suppressSameItem(elapsed):
+            MenuBarItemManager.diagLog.debug(
+                "Saved but did not present another failed \(source) move of \(item.logString); that item was presented \(Int(max(0, elapsed))) s ago; report=\(savedURL?.lastPathComponent ?? "not saved")"
+            )
+            return
+        case let .suppressBurst(elapsed):
+            MenuBarItemManager.diagLog.debug(
+                "Saved but did not present the failed \(source) move of \(item.logString); another failure was presented \(Int(max(0, elapsed))) s ago; report=\(savedURL?.lastPathComponent ?? "not saved")"
+            )
+            return
+        }
+
+        let title = String(localized: "Couldn't move \(item.displayName) right now.")
+        let description = (error as? LocalizedError)?.errorDescription
+            ?? String(describing: error)
+        MenuBarItemManager.diagLog.info(
+            "Presenting the failed \(source) move of \(item.logString): \(description); report=\(savedURL?.lastPathComponent ?? "not saved")"
+        )
+
+        let settingsWindow = NSApp.window(withIdentifier: IceWindowIdentifier.settings.rawValue)
+        switch Self.automaticMoveFailurePresentationRoute(
+            settingsWindowVisible: settingsWindow?.isVisible == true
+        ) {
+        case .settingsSheet:
+            let alert = NSAlert()
+            alert.alertStyle = .warning
+            alert.messageText = title
+            var lines = [description]
+            if let suggestion = (error as? LocalizedError)?.recoverySuggestion {
+                lines.append(suggestion)
+            }
+            alert.informativeText = lines.joined(separator: "\n\n")
+            report.run(alert, in: settingsWindow)
+
+        case .notification:
+            let location = savedURL.map { url in
+                let folder = url.deletingLastPathComponent().path
+                    .replacingOccurrences(of: NSHomeDirectory(), with: "~")
+                return String(localized: "A diagnostic report was saved to \(folder).")
+            } ?? ""
+            appState.userNotificationManager.requestAuthorization()
+            appState.userNotificationManager.addRequest(
+                with: .moveFailed,
+                title: title,
+                body: [description, location].filter { !$0.isEmpty }.joined(separator: ". "),
+                userInfo: savedURL.map { ["reportPath": $0.path] } ?? [:]
+            )
+        }
+    }
+}

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -406,6 +406,13 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.error(
                     "Notch overflow rebalance: failed to eject \(item.logString): \(error)"
                 )
+                await reportAutomaticMoveFailure(
+                    of: item,
+                    to: .leftOfItem(controlItems.hidden),
+                    expectedSection: .hidden,
+                    error: error,
+                    source: "notch overflow management"
+                )
             }
         }
         if didFailAcceptedMove {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager.swift
@@ -196,6 +196,14 @@ final class MenuBarItemManager {
     /// The single record of which items have been failing, and how.
     let failureLedger = MenuBarItemFailureLedger()
 
+    /// When each item's failed automatic move was last presented to the user.
+    /// Reports are still written while this presentation cooldown is active.
+    var automaticMoveFailureReports = [String: Date]()
+
+    /// When any automatic move failure was last presented, to space bursts
+    /// involving several items from one layout pass.
+    var lastAutomaticMoveFailureReport: Date?
+
     /// The record of which saved identifiers no longer match anything.
     let staleIdentifierLedger = StaleIdentifierLedger()
 

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -3857,6 +3857,9 @@
         }
       }
     },
+    "A diagnostic report was saved to %@." : {
+
+    },
     "A new update is available" : {
       "comment" : "Title of a notification when a new update is available.",
       "localizations" : {

--- a/Thaw/UserNotifications/UserNotificationIdentifier.swift
+++ b/Thaw/UserNotifications/UserNotificationIdentifier.swift
@@ -11,4 +11,6 @@ enum UserNotificationIdentifier: String {
     case updateCheck = "UpdateCheck"
     case triggerFired = "TriggerFired"
     case hotkeyToggleFeedback = "HotkeyToggleFeedback"
+    /// An automatic menu bar move failed and saved a diagnostic report.
+    case moveFailed = "MoveFailed"
 }

--- a/Thaw/UserNotifications/UserNotificationManager.swift
+++ b/Thaw/UserNotifications/UserNotificationManager.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import AppKit
 import UserNotifications
 
 /// Manager for user notifications.
@@ -38,10 +39,16 @@ final class UserNotificationManager: NSObject {
     }
 
     /// Schedules the delivery of a local notification.
-    func addRequest(with identifier: UserNotificationIdentifier, title: String, body: String) {
+    func addRequest(
+        with identifier: UserNotificationIdentifier,
+        title: String,
+        body: String,
+        userInfo: [AnyHashable: Any] = [:]
+    ) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
+        content.userInfo = userInfo
 
         let request = UNNotificationRequest(
             identifier: identifier.rawValue,
@@ -55,6 +62,26 @@ final class UserNotificationManager: NSObject {
     /// Removes the notifications from Notification Center that match the given identifiers.
     func removeDeliveredNotifications(with identifiers: [UserNotificationIdentifier]) {
         notificationCenter.removeDeliveredNotifications(withIdentifiers: identifiers.map(\.rawValue))
+    }
+}
+
+extension UserNotificationManager {
+    /// What opening a failed-move notification should do.
+    nonisolated enum MoveFailureOpenAction: Equatable {
+        case revealReport(URL)
+        case openSettings
+    }
+
+    /// Resolves notification payload state without invoking AppKit, so a
+    /// pruned or malformed report path safely falls back to Settings.
+    static nonisolated func moveFailureOpenAction(
+        reportPath: String?,
+        reportExists: Bool
+    ) -> MoveFailureOpenAction {
+        guard let reportPath, !reportPath.isEmpty, reportExists else {
+            return .openSettings
+        }
+        return .revealReport(URL(fileURLWithPath: reportPath))
     }
 }
 
@@ -90,6 +117,21 @@ extension UserNotificationManager: @MainActor UNUserNotificationCenterDelegate {
         case .hotkeyToggleFeedback:
             // Pure feedback banner; tapping it carries no action.
             break
+        case .moveFailed:
+            guard response.actionIdentifier == UNNotificationDefaultActionIdentifier else {
+                break
+            }
+            let reportPath = response.notification.request.content.userInfo["reportPath"] as? String
+            let reportExists = reportPath.map(FileManager.default.fileExists(atPath:)) ?? false
+            switch Self.moveFailureOpenAction(
+                reportPath: reportPath,
+                reportExists: reportExists
+            ) {
+            case let .revealReport(url):
+                NSWorkspace.shared.activateFileViewerSelecting([url])
+            case .openSettings:
+                appState.openWindow(.settings)
+            }
         case nil:
             break
         }

--- a/ThawTests/MenuBar/Items/AutomaticMoveFailureReportingTests.swift
+++ b/ThawTests/MenuBar/Items/AutomaticMoveFailureReportingTests.swift
@@ -1,0 +1,186 @@
+//
+//  AutomaticMoveFailureReportingTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Foundation
+import Testing
+@testable import Thaw
+
+@Suite("Automatic move failure reporting")
+struct AutomaticMoveFailureReportingTests {
+    private let item = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "com.example.status", title: "Status"),
+        windowID: 42
+    )
+
+    @Test("Transient move outcomes are deferrals")
+    func transientOutcomesAreDeferred() {
+        let errors: [any Error] = [
+            CancellationError(),
+            MenuBarItemManager.EventError.missingItemBounds(item),
+            MenuBarItemManager.EventError.missingDestinationBounds(item),
+            MenuBarItemManager.EventError.menuTrackingActive(item),
+            MenuBarItemManager.EventError.staleDestination(item),
+            MenuBarItemManager.EventError.moveSuperseded(item),
+            MenuBarItemManager.EventError.moveEngineBusy(item),
+            MenuBarItemManager.EventError.unsafeMovePath(item),
+        ]
+
+        for error in errors {
+            #expect(MenuBarItemManager.automaticMoveFailureDisposition(for: error) == .deferred)
+        }
+    }
+
+    @Test("An unresolved Control Center placeholder is a deferral")
+    func unresolvedPlaceholderIsDeferred() {
+        let unresolved = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .controlCenter, title: "Item-0"),
+            windowID: 43,
+            sourcePID: nil
+        )
+
+        #expect(
+            MenuBarItemManager.automaticMoveFailureDisposition(
+                for: MenuBarItemManager.EventError.itemNotMovable(unresolved)
+            ) == .deferred
+        )
+    }
+
+    @Test("Terminal event outcomes are reportable")
+    func terminalOutcomesAreReportable() {
+        let errors: [any Error] = [
+            MenuBarItemManager.EventError.cannotComplete,
+            MenuBarItemManager.EventError.invalidEventSource,
+            MenuBarItemManager.EventError.missingMouseLocation,
+            MenuBarItemManager.EventError.eventCreationFailure(item),
+            MenuBarItemManager.EventError.eventOperationTimeout(item),
+            MenuBarItemManager.EventError.itemResponseTimeout(item),
+            MenuBarItemManager.EventError.ownerUnresponsive(item),
+            MenuBarItemManager.EventError.eventWindowMismatch(item),
+            MenuBarItemManager.EventError.dropReverted(item),
+            MenuBarItemManager.EventError.moveTimedOut(item),
+            NSError(domain: "AutomaticMoveFailureReportingTests", code: 1),
+        ]
+
+        for error in errors {
+            #expect(MenuBarItemManager.automaticMoveFailureDisposition(for: error) == .report)
+        }
+    }
+
+    @Test("A static immovability refusal is reportable")
+    func staticImmovabilityIsReportable() {
+        let prohibited = MenuBarItem.fixture(tag: .clock, windowID: 44)
+
+        #expect(
+            MenuBarItemManager.automaticMoveFailureDisposition(
+                for: MenuBarItemManager.EventError.itemNotMovable(prohibited)
+            ) == .report
+        )
+    }
+
+    @Test("The same-item cooldown suppresses before but not at its boundary")
+    func itemCooldownBoundary() {
+        let now = Date(timeIntervalSince1970: 1000)
+
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationDecision(
+                now: now,
+                lastForItem: now.addingTimeInterval(-599),
+                lastOverall: nil
+            ) == .suppressSameItem(elapsed: 599)
+        )
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationDecision(
+                now: now,
+                lastForItem: now.addingTimeInterval(-600),
+                lastOverall: nil
+            ) == .present
+        )
+    }
+
+    @Test("The burst cooldown suppresses before but not at its boundary")
+    func burstCooldownBoundary() {
+        let now = Date(timeIntervalSince1970: 1000)
+
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationDecision(
+                now: now,
+                lastForItem: nil,
+                lastOverall: now.addingTimeInterval(-29)
+            ) == .suppressBurst(elapsed: 29)
+        )
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationDecision(
+                now: now,
+                lastForItem: nil,
+                lastOverall: now.addingTimeInterval(-30)
+            ) == .present
+        )
+    }
+
+    @Test("A rate-limited failure is still persisted")
+    func rateLimitedFailureStillPersists() {
+        let plan = MenuBarItemManager.automaticMoveFailureHandlingPlan(
+            disposition: .report,
+            presentationDecision: .suppressBurst(elapsed: 1)
+        )
+
+        #expect(plan.shouldPersist)
+        #expect(!plan.shouldPresent)
+    }
+
+    @Test("A deferral is neither persisted nor presented")
+    func deferralDoesNothing() {
+        let plan = MenuBarItemManager.automaticMoveFailureHandlingPlan(
+            disposition: .deferred,
+            presentationDecision: .present
+        )
+
+        #expect(!plan.shouldPersist)
+        #expect(!plan.shouldPresent)
+    }
+
+    @Test("Visible Settings uses a sheet; background work uses a notification")
+    func presentationRoute() {
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationRoute(settingsWindowVisible: true)
+                == .settingsSheet
+        )
+        #expect(
+            MenuBarItemManager.automaticMoveFailurePresentationRoute(settingsWindowVisible: false)
+                == .notification
+        )
+    }
+
+    @Test("A live report path is revealed from its notification")
+    func liveNotificationReportIsRevealed() {
+        let path = "/tmp/Thaw-move-diagnostic.txt"
+
+        #expect(
+            UserNotificationManager.moveFailureOpenAction(
+                reportPath: path,
+                reportExists: true
+            ) == .revealReport(URL(fileURLWithPath: path))
+        )
+    }
+
+    @Test("A missing or pruned notification report falls back to Settings")
+    func missingNotificationReportOpensSettings() {
+        #expect(
+            UserNotificationManager.moveFailureOpenAction(
+                reportPath: nil,
+                reportExists: false
+            ) == .openSettings
+        )
+        #expect(
+            UserNotificationManager.moveFailureOpenAction(
+                reportPath: "/tmp/pruned-report.txt",
+                reportExists: false
+            ) == .openSettings
+        )
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveFailureDiagnosticReportTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureDiagnosticReportTests.swift
@@ -82,4 +82,51 @@ struct MoveFailureDiagnosticReportTests {
 
         #expect(try String(contentsOf: url, encoding: .utf8) == report.text)
     }
+
+    @Test("Automatic reports do not overwrite a same-second report")
+    func automaticReportNamesDoNotCollide() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let report = MoveFailureDiagnosticReport(
+            text: "failure\n",
+            suggestedFileName: "\(Constants.displayName)-move-diagnostic-2026-08-30-120000.txt"
+        )
+
+        let first = try report.writeToAutomaticReports(in: directory)
+        let second = try report.writeToAutomaticReports(in: directory)
+
+        #expect(first != second)
+        #expect(first.lastPathComponent == report.suggestedFileName)
+        #expect(second.lastPathComponent.hasSuffix("-2.txt"))
+        #expect(try String(contentsOf: first, encoding: .utf8) == report.text)
+        #expect(try String(contentsOf: second, encoding: .utf8) == report.text)
+    }
+
+    @Test("Pruning keeps only the newest automatic reports")
+    func automaticReportPruning() throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+
+        let prefix = "\(Constants.displayName)-move-diagnostic-"
+        let reportNames = (0 ..< 4).map { "\(prefix)\($0).txt" }
+        for (index, name) in reportNames.enumerated() {
+            let url = directory.appendingPathComponent(name)
+            try "report \(index)".write(to: url, atomically: true, encoding: .utf8)
+            try fileManager.setAttributes(
+                [.modificationDate: Date(timeIntervalSince1970: TimeInterval(index))],
+                ofItemAtPath: url.path
+            )
+        }
+        let unrelated = directory.appendingPathComponent("notes.txt")
+        try "keep".write(to: unrelated, atomically: true, encoding: .utf8)
+
+        MoveFailureDiagnosticReport.pruneAutomaticReports(in: directory, keeping: 2)
+
+        let remaining = try fileManager.contentsOfDirectory(atPath: directory.path)
+        #expect(Set(remaining) == Set([reportNames[2], reportNames[3], unrelated.lastPathComponent]))
+    }
 }

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -93,6 +93,7 @@ $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Event
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+$(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+MoveFailureReporting.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+TemporaryShow.swift
 $(SRCROOT)/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift


### PR DESCRIPTION
# Summary

Persists a redacted diagnostic report whenever an automatic menu-bar move reaches a definitive failure, retains the newest 20 reports, and surfaces the result through a Settings sheet or notification. Presentation cooldowns prevent alert storms without discarding diagnostic evidence, while cancelled, stale, transient, and unsafe-plan deferrals remain silent.

Automatic reporting covers system-item and Thaw-icon placement, newly discovered and pending-item relocation, control-divider ordering, saved-layout/profile application, and notch-overflow rebalancing. A notification opens its still-live report in Finder and falls back to Layout settings if the bounded retention policy has already removed that file.

**Scope:** This PR changes 12 files with 776 insertions and 20 deletions. It adds the reporting coordinator, persistence/retention policy, notification routing, automatic-mover integrations, localization entries, and focused Swift Testing coverage. It does not change move transport, retry policy, cache publication, or Layout Bar presentation. This may be suitable for 2.2.

Dependency: #1003 must be merged first or used as this PR's base. Functional dependencies: #994 supplies the redacted report and save-sheet foundation, #997 supplies definitive move outcomes, and #1002 supplies coordinated automatic-move call sites.

## Linked issue (required)

Closes: N/A

Related: #905, #923, #927

## PR Type

- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- A definitive automatic move failure always generates and persists a redacted diagnostic report, even when an alert or notification is suppressed by a presentation cooldown.
- Cancelled, superseded, stale, transient, input-busy, and unsafe-plan outcomes are classified as deferrals and generate neither a report nor user-facing UI.
- Reports use collision-safe names, retain the newest 20 files, and never remove unrelated files from the diagnostics directory.
- When Settings is visible, the existing move-failure sheet offers the report for saving elsewhere.
- Background failures post a notification naming the affected item; opening it reveals the report in Finder or falls back to Layout settings when the file no longer exists.
- Per-item and global presentation cooldowns prevent one reverting episode or a bulk pass from producing an alert storm without suppressing diagnostic evidence.
- Automatic section placement, pending restoration, divider ordering, saved-layout/profile application, and notch-overflow rebalancing all route terminal failures through the same policy.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath /tmp/ThawFinalStackBuild -clonedSourcePackagesDirPath /tmp/ThawBuildData/SourcePackages -disableAutomaticPackageResolution -onlyUsePackageVersionsFromResolvedFile CODE_SIGNING_ALLOWED=NO -only-testing:ThawTests/AutomaticMoveFailureReportingTests -only-testing:ThawTests/MoveFailureDiagnosticReportTests`

The final rebased stack built successfully, and all 19 focused reporting tests passed. The isolated change also passed a complete run of 2,668 tests across 335 suites before final integration with #1002's outcome return. Strict SwiftLint reported 0 violations across all touched Swift files; localization JSON validation, the generated SwiftLint input-list comparison, attribution scan, SwiftFormat lint of the combined file, and `git diff --check` were clean.

## Known limitations / follow-ups

- Only the automatic movers currently present on `development` are included. Any separate feature branch that introduces another automatic mover should integrate with the shared reporting entry point when it is merged.
- Automated redaction is best effort. The report and save presentation continue to ask users to review the file before sharing it.
- Presentation is deliberately rate-limited, but every definitive failure still writes a report; repeated failures can therefore replace older reports under the newest-20 retention limit.
- This stacked PR should remain based on #1003 until that dependency merges. It can then be rebased onto `development`.

## Other information

No manual notification or save-sheet run was performed for this isolated PR. Verification used the focused reporting suites, a complete test run, the generic macOS build, formatting, lint, localization validation, generated-file comparison, and diff checks.

The commit includes the required DCO sign-off. No dependency or lockfile changes are included.

## Related PRs

This draft is part of a 12-PR series improving Layout Bar stability, menu-bar movement reliability, and failure diagnostics. Each PR has a non-overlapping diff; the branches are stacked and should merge in order.

1. #993 — Redact sensitive diagnostic report values
2. #994 — Add redacted move diagnostic reports
3. #995 — Bound persisted item identity seeds
4. #996 — Reconcile hosted item identities safely
5. #997 — Make move outcomes explicit and attributable
6. #998 — Serialize and preflight menu bar moves
7. #999 — Keep menu bar move transport on safe paths
8. #1000 — Bound and verify move attempts
9. #1001 — Make layout cache refreshes transactional
10. #1002 — Coordinate automatic move batches
11. #1003 — Stabilize editor transitions
12. #1004 — Report failed automatic moves

**This PR:** 12 of 12  
**Git base:** #1003  
**Functional dependencies:** #994, #997, and #1002.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automatic diagnostic reports for menu bar item move failures.
  - Reports are saved locally with non-conflicting filenames, retaining the 20 most recent reports.
  - Added user notifications with options to reveal reports in Finder or open Settings.
  - Added failure details in a Settings warning sheet when Settings is already open.

- **Bug Fixes**
  - Improved failure reporting across menu bar layout, overflow, and ordering operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->