### PR TITLE
feat(triggers): protect Battery and add image-change comparison modes

### DIFF
--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift
@@ -274,17 +274,40 @@ extension MenuBarItemManager {
         return candidates.count == 1 ? candidates[0] : nil
     }
 
-    enum TriggerMoveResult {
+    enum TriggerMoveResult: Equatable {
         /// A synthetic move was performed and verified.
         case moved
         /// The item was already in the requested section.
         case alreadyInSection
         /// The item or its controls are unavailable right now.
         case unavailable
+        /// The move would hide a system item whose visibility is governed by
+        /// macOS, so no synthetic input was posted.
+        case protectedSystemItem
         /// A bulk layout operation is in flight; retry after it settles.
         case deferred
         /// The move was attempted but did not complete.
         case failed
+    }
+
+    enum TriggerMovePreflight: Equatable {
+        case allowed
+        case protectedSystemItem
+    }
+
+    /// Pure, final safety check for trigger-driven section moves. Keeping this
+    /// next to the event-posting entry point means a stale queue or imported
+    /// trigger cannot bypass planner and picker validation.
+    static nonisolated func triggerMovePreflight(
+        for tag: MenuBarItemTag,
+        to section: MenuBarSection.Name
+    ) -> TriggerMovePreflight {
+        if section != .visible,
+           tag.triggerTargetPolicy == .systemVisibilityPreferenceSensitive
+        {
+            return .protectedSystemItem
+        }
+        return .allowed
     }
 
     /// Moves the menu bar item identified by the given stable tag identifier
@@ -339,6 +362,12 @@ extension MenuBarItemManager {
                 "moveItem(trigger): no item matches identifier \(tagIdentifier). Available non-control items: \(availableItems)"
             )
             return .unavailable
+        }
+        guard Self.triggerMovePreflight(for: target.tag, to: section) == .allowed else {
+            MenuBarItemManager.diagLog.warning(
+                "moveItem(trigger): refusing to hide \(target.logString); macOS governs its menu bar visibility preference"
+            )
+            return .protectedSystemItem
         }
         guard target.isMovable else {
             MenuBarItemManager.diagLog.debug("moveItem(trigger): \(target.logString) is not movable")

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Triggers.swift
@@ -17,7 +17,6 @@ import Foundation
 /// here is instance-drift tolerant, because an item's `:N` suffix can change
 /// while a trigger owns it.
 extension MenuBarItemManager {
-
     /// Updates the set of items whose temporary placement is currently owned
     /// by conditional triggers.
     ///
@@ -116,7 +115,7 @@ extension MenuBarItemManager {
     static nonisolated func triggerReleaseIdentifiersRequiringRestoration(
         _ releasedIdentifiers: Set<String>,
         savedSectionOrder: [String: [String]],
-        knownBaseIdentifiers: Set<String> = []
+        knownBaseIdentifiers _: Set<String> = []
     ) -> Set<String> {
         Set(releasedIdentifiers.filter {
             // Upstream's `savedPositionByBaseID` does its own canonical

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag+TriggerIdentity.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag+TriggerIdentity.swift
@@ -15,6 +15,62 @@ import Foundation
 /// same-titled sibling comes or goes). ``tagIdentifier`` cannot serve that
 /// role because it folds the instance index into the string.
 nonisolated extension MenuBarItemTag {
+    /// Whether conditional placement can safely own this item.
+    ///
+    /// Some Apple menu extras interpret a synthetic Command-drag into an
+    /// off-screen section as removal from the menu bar. For those items, the
+    /// drag changes a macOS preference instead of merely changing Thaw's
+    /// section membership. Keeping this policy on the tag makes the picker,
+    /// planner, and final move preflight share one classification authority.
+    enum TriggerTargetPolicy: Equatable {
+        case supported
+        case systemVisibilityPreferenceSensitive
+
+        var supportsConditionalPlacement: Bool {
+            self == .supported
+        }
+    }
+
+    /// Items that must not be conditionally moved between Thaw sections on
+    /// the synthetic-drag backend. Match by namespace and title so live
+    /// instance-index changes do not bypass the protection.
+    private static let preferenceSensitiveTriggerTargets: [MenuBarItemTag] = [
+        .battery,
+    ]
+
+    /// The conditional-placement policy for this live tag.
+    var triggerTargetPolicy: TriggerTargetPolicy {
+        Self.preferenceSensitiveTriggerTargets.contains {
+            $0.namespace == namespace && $0.title == title
+        } ? .systemVisibilityPreferenceSensitive : .supported
+    }
+
+    /// Resolves the policy for a persisted trigger target. The captured base
+    /// is authoritative when present; the legacy identifier fallback strips
+    /// an instance suffix only against the small set of known protected bases,
+    /// so a third-party title ending in `:1` cannot be misclassified.
+    static func triggerTargetPolicy(
+        for identifier: String,
+        capturedBaseIdentifier: String? = nil
+    ) -> TriggerTargetPolicy {
+        let protectedBases = Set(preferenceSensitiveTriggerTargets.map(\.stableIdentifierBase))
+        if let capturedBaseIdentifier,
+           protectedBases.contains(capturedBaseIdentifier)
+        {
+            return .systemVisibilityPreferenceSensitive
+        }
+        if protectedBases.contains(identifier) {
+            return .systemVisibilityPreferenceSensitive
+        }
+        if let resolvedBase = resolvedBaseIdentifier(
+            for: identifier,
+            knownBaseIdentifiers: protectedBases
+        ), protectedBases.contains(resolvedBase) {
+            return .systemVisibilityPreferenceSensitive
+        }
+        return .supported
+    }
+
     /// The exact namespace-and-title identity for this live tag. Unlike the
     /// persisted string form, it is never ambiguous when a title ends in a
     /// colon followed by a number.

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemTag.swift
@@ -341,6 +341,10 @@ nonisolated extension MenuBarItemTag {
     /// The tag for the system "Clock" item.
     static let clock = MenuBarItemTag(namespace: .controlCenter, title: "Clock")
 
+    /// The built-in Battery module governed by macOS's
+    /// "Show in Menu Bar" preference.
+    static let battery = MenuBarItemTag(namespace: .controlCenter, title: "Battery")
+
     /// The tag for the system "Control Center" item.
     static let controlCenter = MenuBarItemTag(namespace: .controlCenter, title: "BentoBox-0")
 

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -136,6 +136,9 @@
     "%@ (not running)" : {
 
     },
+    "%@ (protected)" : {
+
+    },
     "%@ %@ %@" : {
       "localizations" : {
         "en" : {
@@ -46759,6 +46762,9 @@
       }
     },
     "This condition is turned off in Developer settings, so the trigger won't run." : {
+
+    },
+    "This system item cannot be a trigger target because automatically hiding it can turn off its macOS Show in Menu Bar setting. Choose another target; Battery and power conditions remain available. If Battery is already missing, re-enable Show in Menu Bar for Battery in System Settings." : {
 
     },
     "This trigger controls %@'s section. Your saved layout no longer applies to it." : {

--- a/Thaw/Settings/Models/MenuBarItemTrigger.swift
+++ b/Thaw/Settings/Models/MenuBarItemTrigger.swift
@@ -135,6 +135,36 @@ enum ScheduleWeekday: Int, Codable, Hashable, CaseIterable, Identifiable {
 
 // MARK: - TriggerCondition
 
+/// How strictly an image-comparison condition compares the current icon to
+/// its captured reference.
+enum ImageComparisonMode: String, Codable, Hashable, CaseIterable, Identifiable {
+    /// Ignores small perceptual-hash differences caused by rendering noise.
+    case fuzzy
+
+    /// Treats any pixel-content difference as an icon change.
+    case exact
+
+    var id: String {
+        rawValue
+    }
+
+    var displayString: String {
+        switch self {
+        case .fuzzy: "Fuzzy"
+        case .exact: "Exact"
+        }
+    }
+
+}
+
+/// The hashes used at runtime plus a compact PNG used only to preview the
+/// captured reference in settings.
+struct ImageComparisonReference: Codable, Hashable {
+    let perceptualHash: UInt64
+    let exactHash: UInt64
+    let imageData: Data?
+}
+
 /// A condition that decides whether a ``MenuBarItemTrigger`` is currently
 /// satisfied, evaluated against a ``SystemState`` snapshot.
 ///
@@ -186,8 +216,16 @@ enum TriggerCondition: Codable, Hashable {
     /// Script
     case scriptResult(path: String, expectedOutput: String)
 
-    /// Image comparison
-    case imageChanged(itemIdentifier: String, referenceHash: UInt64?)
+    /// Image comparison. The optional trailing values keep triggers saved by
+    /// the original prototype decodable; their absence means fuzzy matching
+    /// and no stored preview image.
+    case imageChanged(
+        itemIdentifier: String,
+        referenceHash: UInt64?,
+        referenceExactHash: UInt64? = nil,
+        comparisonMode: ImageComparisonMode? = nil,
+        referenceImageData: Data? = nil
+    )
 
     /// Satisfied while a watched item is blinking for attention.
     ///
@@ -269,9 +307,15 @@ enum TriggerCondition: Codable, Hashable {
             }
             return outcome.matchedExpectedOutputs.contains(expectedOutput) ||
                 outcome.output.localizedCaseInsensitiveContains(expectedOutput)
-        case let .imageChanged(itemIdentifier, referenceHash):
-            guard let referenceHash, let current = state.imageHashes[itemIdentifier] else { return false }
-            return ImageHashing.hammingDistance(current, referenceHash) > ImageHashing.changeThreshold
+        case let .imageChanged(itemIdentifier, referenceHash, referenceExactHash, comparisonMode, _):
+            switch comparisonMode ?? .fuzzy {
+            case .fuzzy:
+                guard let referenceHash, let current = state.imageHashes[itemIdentifier] else { return false }
+                return ImageHashing.hammingDistance(current, referenceHash) > ImageHashing.changeThreshold
+            case .exact:
+                guard let referenceExactHash, let current = state.exactImageHashes[itemIdentifier] else { return false }
+                return current != referenceExactHash
+            }
         case let .itemSeekingAttention(itemIdentifier):
             return state.itemsSeekingAttention.contains(itemIdentifier)
         }
@@ -333,7 +377,7 @@ enum TriggerCondition: Codable, Hashable {
         case let .scriptResult(path, expectedOutput):
             let name = path.isEmpty ? "a script" : ((path as NSString).lastPathComponent)
             return expectedOutput.isEmpty ? "\(name) exits 0" : "\(name) outputs “\(expectedOutput)”"
-        case let .imageChanged(_, referenceHash):
+        case let .imageChanged(_, referenceHash, _, _, _):
             return referenceHash == nil ? "An icon changed (capture a reference)" : "A watched icon changed"
         case .itemSeekingAttention:
             return "An icon is asking for attention"
@@ -677,10 +721,18 @@ extension TriggerCondition {
         }
     }
 
-    /// The watched item and reference hash, for the image-comparison condition.
-    var imageValue: (itemIdentifier: String, referenceHash: UInt64?)? {
+    /// The persisted values for the image-comparison condition. Legacy
+    /// conditions with no mode are normalized to fuzzy behavior here.
+    var imageValue: (
+        itemIdentifier: String,
+        referenceHash: UInt64?,
+        referenceExactHash: UInt64?,
+        comparisonMode: ImageComparisonMode,
+        referenceImageData: Data?
+    )? {
         switch self {
-        case let .imageChanged(itemIdentifier, referenceHash): (itemIdentifier, referenceHash)
+        case let .imageChanged(itemIdentifier, referenceHash, referenceExactHash, comparisonMode, referenceImageData):
+            (itemIdentifier, referenceHash, referenceExactHash, comparisonMode ?? .fuzzy, referenceImageData)
         default: nil
         }
     }
@@ -688,7 +740,7 @@ extension TriggerCondition {
     /// The item this condition watches, for either icon-watching kind.
     var watchedItemIdentifier: String? {
         switch self {
-        case let .imageChanged(itemIdentifier, _): itemIdentifier
+        case let .imageChanged(itemIdentifier, _, _, _, _): itemIdentifier
         case let .itemSeekingAttention(itemIdentifier): itemIdentifier
         default: nil
         }
@@ -758,14 +810,22 @@ extension TriggerCondition {
             old.scriptValue.map { TriggerCondition.scriptResult(path: $0.path, expectedOutput: $0.expectedOutput) }
                 ?? .scriptResult(path: "", expectedOutput: "")
         case .imageChanged:
-            // Carry the watched item from either icon-watching kind. The
-            // reference hash only survives when there was one, so switching
-            // from the attention kind lands on "no reference yet" rather
-            // than an inherited comparison the user never captured.
-            .imageChanged(
-                itemIdentifier: old.watchedItemIdentifier ?? "",
-                referenceHash: old.imageValue?.referenceHash
-            )
+            if let image = old.imageValue {
+                .imageChanged(
+                    itemIdentifier: image.itemIdentifier,
+                    referenceHash: image.referenceHash,
+                    referenceExactHash: image.referenceExactHash,
+                    comparisonMode: image.comparisonMode,
+                    referenceImageData: image.referenceImageData
+                )
+            } else {
+                // Carry the watched item when switching from the attention
+                // condition, but start without an image comparison reference.
+                .imageChanged(
+                    itemIdentifier: old.watchedItemIdentifier ?? "",
+                    referenceHash: nil
+                )
+            }
         case .itemSeekingAttention:
             // Preserve the watched item when switching between the two
             // icon-watching kinds; the reference hash has no meaning here.
@@ -842,16 +902,40 @@ extension TriggerCondition {
     }
 
     /// Returns a copy of the image condition with the watched item replaced
-    /// (clearing the reference hash, since it no longer applies).
+    /// (clearing the reference, since it no longer applies).
     func withImageItem(_ itemIdentifier: String) -> TriggerCondition {
-        guard case .imageChanged = self else { return self }
-        return .imageChanged(itemIdentifier: itemIdentifier, referenceHash: nil)
+        guard case let .imageChanged(_, _, _, comparisonMode, _) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: nil,
+            referenceExactHash: nil,
+            comparisonMode: comparisonMode,
+            referenceImageData: nil
+        )
     }
 
-    /// Returns a copy of the image condition with the reference hash replaced.
-    func withImageReferenceHash(_ referenceHash: UInt64) -> TriggerCondition {
-        guard case let .imageChanged(itemIdentifier, _) = self else { return self }
-        return .imageChanged(itemIdentifier: itemIdentifier, referenceHash: referenceHash)
+    /// Returns a copy of the image condition with its captured reference.
+    func withImageReference(_ reference: ImageComparisonReference) -> TriggerCondition {
+        guard case let .imageChanged(itemIdentifier, _, _, comparisonMode, _) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: reference.perceptualHash,
+            referenceExactHash: reference.exactHash,
+            comparisonMode: comparisonMode,
+            referenceImageData: reference.imageData
+        )
+    }
+
+    /// Returns a copy using the requested comparison strictness.
+    func withImageComparisonMode(_ comparisonMode: ImageComparisonMode) -> TriggerCondition {
+        guard case let .imageChanged(itemIdentifier, referenceHash, referenceExactHash, _, referenceImageData) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: referenceHash,
+            referenceExactHash: referenceExactHash,
+            comparisonMode: comparisonMode,
+            referenceImageData: referenceImageData
+        )
     }
 
     /// Returns a copy with the Energy Mode predicate replaced.

--- a/Thaw/Settings/Models/MenuBarItemTrigger.swift
+++ b/Thaw/Settings/Models/MenuBarItemTrigger.swift
@@ -154,7 +154,6 @@ enum ImageComparisonMode: String, Codable, Hashable, CaseIterable, Identifiable 
         case .exact: "Exact"
         }
     }
-
 }
 
 /// The hashes used at runtime plus a compact PNG used only to preview the

--- a/Thaw/Settings/Models/MenuBarItemTrigger.swift
+++ b/Thaw/Settings/Models/MenuBarItemTrigger.swift
@@ -1072,6 +1072,19 @@ struct MenuBarItemTrigger: Codable, Hashable, Identifiable {
         ] + additionalItems.filter { !$0.identifier.isEmpty }
     }
 
+    /// Whether any target is protected from conditional placement because a
+    /// synthetic hide can mutate its macOS visibility preference. A trigger
+    /// is rejected as a unit: partially moving a multi-item trigger would make
+    /// its displayed state and ownership claims untrue.
+    var hasPreferenceSensitiveTarget: Bool {
+        allTargetItems.contains { target in
+            MenuBarItemTag.triggerTargetPolicy(
+                for: target.identifier,
+                capturedBaseIdentifier: target.baseIdentifier
+            ) == .systemVisibilityPreferenceSensitive
+        }
+    }
+
     /// All conditions, primary first.
     var allConditions: [TriggerCondition] {
         [condition] + additionalConditions

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
@@ -1463,9 +1463,8 @@ final class MenuBarItemTriggersManager {
             return nil
         }
 
-        let image = await ScreenCapture.captureWindowAsync(with: item.windowID)
+        return await ScreenCapture.captureWindowAsync(with: item.windowID)
             ?? ScreenCapture.captureWindow(with: item.windowID)
-        return image
     }
 
     /// Captures both the runtime hash and a compact settings preview.

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
@@ -33,12 +33,15 @@ enum MenuBarItemTriggerRuntimeStatus: Equatable {
     case deferred
     /// The target item or required controls are unavailable.
     case unavailable
+    /// A selected system item cannot be hidden without changing its macOS
+    /// visibility preference, so the trigger is intentionally suspended.
+    case protectedSystemItem
     /// The trigger move was attempted but failed.
     case failed
 
     var isTerminalForDisplay: Bool {
         switch self {
-        case .overridden, .deferred, .unavailable, .failed:
+        case .overridden, .deferred, .unavailable, .protectedSystemItem, .failed:
             true
         case .off, .inactive, .settling, .moving, .active, .idle, .pending:
             false
@@ -202,6 +205,7 @@ final class MenuBarItemTriggersManager {
         var actions = [UUID: TriggerPriorityAction]()
         var overriddenBy = [UUID: [String]]()
         var unavailableTriggerIDs = Set<UUID>()
+        var protectedTriggerIDs = Set<UUID>()
 
         mutating func setAction(reveal: Bool, identifiers: [String], for triggerID: UUID) {
             let dedupedIdentifiers = Array(OrderedSet(identifiers))
@@ -248,7 +252,7 @@ final class MenuBarItemTriggersManager {
         // position before the first live evaluation establishes the action.
         let configuredTargetIdentifiers = Set(
             triggers
-                .filter { $0.isEnabled && isAvailable($0) }
+                .filter { $0.isEnabled && isAvailable($0) && !$0.hasPreferenceSensitiveTarget }
                 .flatMap(\.allItemIdentifiers)
         )
         appState.itemManager.setTriggerControlledItemIdentifiers(configuredTargetIdentifiers)
@@ -363,6 +367,7 @@ final class MenuBarItemTriggersManager {
     /// Returns the current runtime status for a trigger.
     func runtimeStatus(for trigger: MenuBarItemTrigger) -> MenuBarItemTriggerRuntimeStatus {
         guard trigger.isEnabled else { return .off }
+        guard !trigger.hasPreferenceSensitiveTarget else { return .protectedSystemItem }
         guard isAvailable(trigger) else { return .inactive }
 
         if pendingApplyTasks[trigger.id] != nil {
@@ -525,6 +530,8 @@ final class MenuBarItemTriggersManager {
                 clearApplyState(for: trigger.id)
                 if let names = plan.overriddenBy[trigger.id] {
                     setRuntimeStatus(.overridden(by: names), for: trigger.id)
+                } else if plan.protectedTriggerIDs.contains(trigger.id) {
+                    setRuntimeStatus(.protectedSystemItem, for: trigger.id)
                 } else if plan.unavailableTriggerIDs.contains(trigger.id) {
                     setRuntimeStatus(.unavailable, for: trigger.id)
                 } else {
@@ -601,6 +608,7 @@ final class MenuBarItemTriggersManager {
         )
         var identifiers = Set<String>()
         for trigger in triggers where trigger.isEnabled && isAvailable(trigger) {
+            guard !trigger.hasPreferenceSensitiveTarget else { continue }
             for target in trigger.allTargetItems where !target.identifier.isEmpty {
                 if let resolved = Self.resolvedPresentIdentifier(
                     for: target.identifier,
@@ -657,7 +665,10 @@ final class MenuBarItemTriggersManager {
             uniquingKeysWith: { first, _ in first }
         )
         return triggers.first { trigger in
-            guard trigger.isEnabled, isAvailable(trigger) else { return false }
+            guard trigger.isEnabled,
+                  isAvailable(trigger),
+                  !trigger.hasPreferenceSensitiveTarget
+            else { return false }
             return trigger.allTargetItems.contains { target in
                 guard !target.identifier.isEmpty else { return false }
                 return Self.resolvedPresentIdentifier(
@@ -675,7 +686,10 @@ final class MenuBarItemTriggersManager {
         guard !baseIdentifier.isEmpty else { return nil }
         let knownBases: Set<String> = [baseIdentifier]
         return triggers.first { trigger in
-            guard trigger.isEnabled, isAvailable(trigger) else { return false }
+            guard trigger.isEnabled,
+                  isAvailable(trigger),
+                  !trigger.hasPreferenceSensitiveTarget
+            else { return false }
             return trigger.allTargetItems.contains { target in
                 target.identifier == baseIdentifier
                     || target.baseIdentifier == baseIdentifier
@@ -699,6 +713,10 @@ final class MenuBarItemTriggersManager {
 
         for trigger in triggers where trigger.isEnabled {
             guard !trigger.allItemIdentifiers.isEmpty, isAvailable(trigger) else { continue }
+            guard !trigger.hasPreferenceSensitiveTarget else {
+                plan.protectedTriggerIDs.insert(trigger.id)
+                continue
+            }
 
             var presentTargets = [String]()
             for target in trigger.allTargetItems where !target.identifier.isEmpty {
@@ -838,6 +856,8 @@ final class MenuBarItemTriggersManager {
                         "Trigger \(trigger.displayName) pending apply expired after "
                             + "\(self.formattedElapsed(since: scheduledAt)); overridden by \(names.joined(separator: ", "))"
                     )
+                } else if plan.protectedTriggerIDs.contains(triggerID) {
+                    self.setRuntimeStatus(.protectedSystemItem, for: triggerID)
                 } else {
                     self.setRuntimeStatus(plan.unavailableTriggerIDs.contains(triggerID) ? .unavailable : .idle, for: triggerID)
                 }
@@ -1057,6 +1077,13 @@ final class MenuBarItemTriggersManager {
                     self.setRuntimeStatus(.unavailable, for: trigger.id)
                     self.finishPendingMove(for: trigger, action: action, applied: false, retry: false)
                     return
+                case .protectedSystemItem:
+                    self.diagLog.warning(
+                        "Trigger \(trigger.displayName) refused a protected system-item move for \(identifier)"
+                    )
+                    self.setRuntimeStatus(.protectedSystemItem, for: trigger.id)
+                    self.finishPendingMove(for: trigger, action: action, applied: false, retry: false)
+                    return
                 }
             }
             self.diagLog.debug(
@@ -1219,6 +1246,28 @@ final class MenuBarItemTriggersManager {
 
     // MARK: - Scripts
 
+    /// Script inputs that can affect an enabled trigger. Protected triggers
+    /// are suspended as a unit, so their scripts must not keep running in the
+    /// background—especially because a user script may have side effects.
+    static func runnableScriptExpectedOutputs(
+        in triggers: [MenuBarItemTrigger]
+    ) -> [String: Set<String>] {
+        var expectedOutputsByPath = [String: Set<String>]()
+        for trigger in triggers
+            where trigger.isEnabled && !trigger.hasPreferenceSensitiveTarget
+        {
+            for condition in trigger.allConditions {
+                if case let .scriptResult(path, expectedOutput) = condition {
+                    let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if !trimmed.isEmpty {
+                        expectedOutputsByPath[trimmed, default: []].insert(expectedOutput)
+                    }
+                }
+            }
+        }
+        return expectedOutputsByPath
+    }
+
     /// Runs every distinct script referenced by an enabled script-result
     /// condition (when the feature is on), updating cached outcomes and
     /// re-evaluating when any result changes.
@@ -1230,18 +1279,7 @@ final class MenuBarItemTriggersManager {
         }
         scriptsNeedRefresh = false
 
-        // Collect distinct, non-empty script paths in use by enabled triggers.
-        var expectedOutputsByPath = [String: Set<String>]()
-        for trigger in triggers where trigger.isEnabled {
-            for condition in trigger.allConditions {
-                if case let .scriptResult(path, expectedOutput) = condition {
-                    let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty {
-                        expectedOutputsByPath[trimmed, default: []].insert(expectedOutput)
-                    }
-                }
-            }
-        }
+        let expectedOutputsByPath = Self.runnableScriptExpectedOutputs(in: triggers)
         let paths = Set(expectedOutputsByPath.keys)
 
         // Drop cached outcomes for paths no longer referenced.
@@ -1289,6 +1327,27 @@ final class MenuBarItemTriggersManager {
 
     // MARK: - Image comparison
 
+    /// Image inputs that can affect an enabled trigger. Battery remains a
+    /// valid observation source for a supported target; this only suppresses
+    /// polling when the trigger's moved target itself is protected.
+    static func runnableImageObservationIdentifiers(
+        in triggers: [MenuBarItemTrigger]
+    ) -> Set<String> {
+        var ids = Set<String>()
+        for trigger in triggers
+            where trigger.isEnabled && !trigger.hasPreferenceSensitiveTarget
+        {
+            for condition in trigger.allConditions {
+                if case let .imageChanged(itemIdentifier, _) = condition,
+                   !itemIdentifier.isEmpty
+                {
+                    ids.insert(itemIdentifier)
+                }
+            }
+        }
+        return ids
+    }
+
     /// Captures the current perceptual hash for every watched item used by an
     /// enabled image-comparison condition (when the feature is on), updating
     /// the cache and re-evaluating when any hash changes.
@@ -1324,14 +1383,7 @@ final class MenuBarItemTriggersManager {
         }
         imagesNeedRefresh = false
 
-        var ids = Set<String>()
-        for trigger in triggers where trigger.isEnabled {
-            for condition in trigger.allConditions {
-                if case let .imageChanged(itemIdentifier, _) = condition, !itemIdentifier.isEmpty {
-                    ids.insert(itemIdentifier)
-                }
-            }
-        }
+        let ids = Self.runnableImageObservationIdentifiers(in: triggers)
 
         let removed = Set(imageHashes.keys).subtracting(ids)
         let removedAny = !removed.isEmpty

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
@@ -181,6 +181,9 @@ final class MenuBarItemTriggersManager {
     /// conditions, keyed by tag identifier, injected into the system state.
     private var imageHashes = [String: UInt64]()
 
+    /// Exact pixel hashes captured in the same pass as ``imageHashes``.
+    private var exactImageHashes = [String: UInt64]()
+
     /// Guards against overlapping image-capture passes.
     private var isRefreshingImages = false
     private var imagesNeedRefresh = false
@@ -225,6 +228,7 @@ final class MenuBarItemTriggersManager {
         state.scriptOutcomes = scriptOutcomes
         state.imageHashes = imageHashes
         state.itemsSeekingAttention = itemsSeekingAttention
+        state.exactImageHashes = exactImageHashes
         return state
     }
 
@@ -1338,7 +1342,7 @@ final class MenuBarItemTriggersManager {
             where trigger.isEnabled && !trigger.hasPreferenceSensitiveTarget
         {
             for condition in trigger.allConditions {
-                if case let .imageChanged(itemIdentifier, _) = condition,
+                if case let .imageChanged(itemIdentifier, _, _, _, _) = condition,
                    !itemIdentifier.isEmpty
                 {
                     ids.insert(itemIdentifier)
@@ -1386,9 +1390,13 @@ final class MenuBarItemTriggersManager {
         let ids = Self.runnableImageObservationIdentifiers(in: triggers)
 
         let removed = Set(imageHashes.keys).subtracting(ids)
-        let removedAny = !removed.isEmpty
+        let removedExact = Set(exactImageHashes.keys).subtracting(ids)
+        let removedAny = !removed.isEmpty || !removedExact.isEmpty
         for id in removed {
             imageHashes[id] = nil
+        }
+        for id in removedExact {
+            exactImageHashes[id] = nil
         }
 
         guard !ids.isEmpty else {
@@ -1404,15 +1412,19 @@ final class MenuBarItemTriggersManager {
 
             var changed = removedAny
             for id in ids {
-                guard let hash = await self.currentImageHash(forItemIdentifier: id) else {
-                    if self.imageHashes[id] != nil {
+                guard let fingerprints = await self.currentImageFingerprints(forItemIdentifier: id) else {
+                    if self.imageHashes[id] != nil || self.exactImageHashes[id] != nil {
                         self.imageHashes[id] = nil
+                        self.exactImageHashes[id] = nil
                         changed = true
                     }
                     continue
                 }
-                if self.imageHashes[id] != hash {
-                    self.imageHashes[id] = hash
+                if self.imageHashes[id] != fingerprints.perceptual
+                    || self.exactImageHashes[id] != fingerprints.exact
+                {
+                    self.imageHashes[id] = fingerprints.perceptual
+                    self.exactImageHashes[id] = fingerprints.exact
                     changed = true
                 }
             }
@@ -1428,8 +1440,22 @@ final class MenuBarItemTriggersManager {
         }
     }
 
-    /// Captures the watched item's window and returns its perceptual hash.
-    private func currentImageHash(forItemIdentifier id: String) async -> UInt64? {
+    /// Captures the watched item's window and returns both comparison hashes.
+    private func currentImageFingerprints(
+        forItemIdentifier id: String
+    ) async -> (perceptual: UInt64, exact: UInt64)? {
+        guard
+            let image = await currentImage(forItemIdentifier: id),
+            let perceptual = ImageHashing.averageHash(image),
+            let exact = ImageHashing.exactHash(image)
+        else {
+            return nil
+        }
+        return (perceptual, exact)
+    }
+
+    /// Captures the watched item's current window image.
+    private func currentImage(forItemIdentifier id: String) async -> CGImage? {
         guard
             let appState,
             let item = appState.itemManager.itemCache.managedItems.first(where: { $0.tag.tagIdentifier == id })
@@ -1439,14 +1465,27 @@ final class MenuBarItemTriggersManager {
 
         let image = await ScreenCapture.captureWindowAsync(with: item.windowID)
             ?? ScreenCapture.captureWindow(with: item.windowID)
-        guard let image else { return nil }
-        return ImageHashing.averageHash(image)
+        return image
     }
 
-    /// Captures a reference hash for the given item now (used by the editor's
-    /// "Capture reference" button).
-    func captureReferenceHash(forItemIdentifier id: String) async -> UInt64? {
-        await currentImageHash(forItemIdentifier: id)
+    /// Captures both the runtime hash and a compact settings preview.
+    func captureImageReference(forItemIdentifier id: String) async -> ImageComparisonReference? {
+        guard
+            let image = await currentImage(forItemIdentifier: id),
+            let perceptualHash = ImageHashing.averageHash(image),
+            let exactHash = ImageHashing.exactHash(image)
+        else {
+            return nil
+        }
+        let imageData = NSBitmapImageRep(cgImage: image).representation(
+            using: .png,
+            properties: [:]
+        )
+        return ImageComparisonReference(
+            perceptualHash: perceptualHash,
+            exactHash: exactHash,
+            imageData: imageData
+        )
     }
 
     // MARK: - Persistence

--- a/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
@@ -238,7 +238,7 @@ struct TriggersSettingsPane: View {
                             dragProvider(for: trigger.id)
                         },
                         currentCoordinate: { manager.systemMonitor.currentCoordinate },
-                        captureReference: { await manager.captureReferenceHash(forItemIdentifier: $0) },
+                        captureReference: { await manager.captureImageReference(forItemIdentifier: $0) },
                         focusedField: $focusedField,
                         onDelete: { manager.remove(id: trigger.id) }
                     )
@@ -638,7 +638,7 @@ private struct TriggerRow: View {
     let onToggleCollapsedExpansion: () -> Void
     let dragProvider: () -> NSItemProvider
     let currentCoordinate: () -> (latitude: Double, longitude: Double)?
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
     var focusedField: FocusState<String?>.Binding
     let onDelete: () -> Void
 
@@ -1523,7 +1523,7 @@ private struct ConditionEditorView: View {
     let refreshBluetoothOptions: () -> Void
     let itemOptions: [TriggerItemOption]
     let currentCoordinate: () -> (latitude: Double, longitude: Double)?
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
     var focusedField: FocusState<String?>.Binding
     let focusID: String
 
@@ -1957,7 +1957,7 @@ private struct AttentionConditionEditor: View {
 private struct ImageConditionEditor: View {
     @Binding var condition: TriggerCondition
     let itemOptions: [TriggerItemOption]
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
 
     @State private var isCapturing = false
 
@@ -1966,8 +1966,22 @@ private struct ImageConditionEditor: View {
     }
 
     private var hasReference: Bool {
-        guard case let .imageChanged(_, referenceHash) = condition else { return false }
-        return referenceHash != nil
+        condition.imageValue?.referenceHash != nil
+    }
+
+    private var exactReferenceNeedsRecapture: Bool {
+        comparisonMode == .exact
+            && hasReference
+            && condition.imageValue?.referenceExactHash == nil
+    }
+
+    private var referenceImage: NSImage? {
+        guard let data = condition.imageValue?.referenceImageData else { return nil }
+        return NSImage(data: data)
+    }
+
+    private var comparisonMode: ImageComparisonMode {
+        condition.imageValue?.comparisonMode ?? .fuzzy
     }
 
     var body: some View {
@@ -1984,16 +1998,20 @@ private struct ImageConditionEditor: View {
             }
             .disabled(isCapturing)
 
+            IcePicker("Comparison", selection: comparisonModeBinding) {
+                ForEach(ImageComparisonMode.allCases) { mode in
+                    Text(mode.displayString).tag(mode)
+                }
+            }
+
             HStack(spacing: 12) {
                 Button(isCapturing ? "Capturing…" : "Capture Reference") { capture() }
                     .disabled(isCapturing || watchedID.isEmpty)
                 Spacer()
-                Text(hasReference ? "Reference captured" : "No reference yet")
-                    .font(.caption)
-                    .foregroundStyle(hasReference ? .green : .secondary)
+                referenceStatus
             }
 
-            Text("Captures the icon now as a reference, then reveals the item when the icon later changes from it. Requires screen recording permission.")
+            Text(comparisonHelp)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -2004,15 +2022,61 @@ private struct ImageConditionEditor: View {
         Binding(get: { watchedID }, set: { condition = condition.withImageItem($0) })
     }
 
+    private var comparisonModeBinding: Binding<ImageComparisonMode> {
+        Binding(
+            get: { comparisonMode },
+            set: { condition = condition.withImageComparisonMode($0) }
+        )
+    }
+
+    @ViewBuilder
+    private var referenceStatus: some View {
+        if let referenceImage {
+            HStack(spacing: 8) {
+                Text("Reference")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Image(nsImage: referenceImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 32, height: 22)
+                    .padding(4)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                    .accessibilityLabel("Captured reference icon")
+            }
+        } else {
+            Text(referenceStatusText)
+                .font(.caption)
+                .foregroundStyle(hasReference && !exactReferenceNeedsRecapture ? .green : .secondary)
+        }
+    }
+
+    private var referenceStatusText: String {
+        if exactReferenceNeedsRecapture {
+            return "Recapture required for Exact"
+        }
+        return hasReference ? "Reference captured — recapture to add preview" : "No reference yet"
+    }
+
+    private var comparisonHelp: String {
+        switch comparisonMode {
+        case .fuzzy:
+            "Fuzzy ignores small rendering differences and reveals when the icon meaningfully changes from the reference. Requires screen recording permission."
+        case .exact:
+            "Exact reveals on any pixel-content difference from the reference. Requires screen recording permission."
+        }
+    }
+
     private func capture() {
         let id = watchedID
         guard !id.isEmpty else { return }
         isCapturing = true
         Task { @MainActor in
-            let hash = await captureReference(id)
+            let reference = await captureReference(id)
             isCapturing = false
-            if let hash, watchedID == id {
-                condition = condition.withImageReferenceHash(hash)
+            if let reference, watchedID == id {
+                condition = condition.withImageReference(reference)
             }
         }
     }

--- a/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
@@ -21,6 +21,16 @@ struct TriggerItemOption: Hashable {
     let id: String
     let name: String
     let baseIdentifier: String
+
+    /// Whether this item can be moved by a conditional trigger. The broader
+    /// option list remains available to image-comparison conditions, which
+    /// only observe an icon and therefore do not risk changing its placement.
+    var supportsConditionalPlacement: Bool {
+        MenuBarItemTag.triggerTargetPolicy(
+            for: id,
+            capturedBaseIdentifier: baseIdentifier
+        ).supportsConditionalPlacement
+    }
 }
 
 /// A paired Bluetooth device offered in the device-condition picker.
@@ -99,6 +109,7 @@ private extension MenuBarItemTriggerRuntimeStatus {
         case .overridden: "Overridden"
         case .deferred: "Deferred"
         case .unavailable: "Unavailable"
+        case .protectedSystemItem: "Protected"
         case .failed: "Failed"
         }
     }
@@ -111,7 +122,7 @@ private extension MenuBarItemTriggerRuntimeStatus {
         case .moving: .blue
         case .active: .green
         case .idle: .secondary
-        case .overridden, .deferred, .unavailable: .orange
+        case .overridden, .deferred, .unavailable, .protectedSystemItem: .orange
         case .failed: .red
         }
     }
@@ -142,6 +153,8 @@ private extension MenuBarItemTriggerRuntimeStatus {
             "The move was deferred because another layout operation is in progress."
         case .unavailable:
             "The target item or required menu bar controls are not available."
+        case .protectedSystemItem:
+            "This trigger targets a system item that Thaw cannot safely hide without changing its macOS Show in Menu Bar setting."
         case .failed:
             "The item move was attempted but failed."
         }
@@ -177,6 +190,13 @@ struct TriggersSettingsPane: View {
         flags = manager.featureFlags
     }
 
+    /// Placement choices are narrower than observation choices: protected
+    /// system items remain usable by image-comparison conditions but cannot
+    /// become the item a trigger moves.
+    private var targetItemOptions: [TriggerItemOption] {
+        itemOptions.filter(\.supportsConditionalPlacement)
+    }
+
     var body: some View {
         IceForm {
             introSection
@@ -193,6 +213,7 @@ struct TriggersSettingsPane: View {
                     TriggerRow(
                         trigger: triggerBinding(for: trigger.id),
                         itemOptions: itemOptions,
+                        targetItemOptions: targetItemOptions,
                         appOptions: appOptions,
                         bluetoothOptions: bluetoothOptions,
                         refreshBluetoothOptions: refreshBluetoothOptions,
@@ -283,13 +304,13 @@ struct TriggersSettingsPane: View {
 
     /// Item identifiers targeted by more than one enabled trigger.
     private func conflictingTriggerIDs() -> Set<UUID> {
-        let presentIdentifiers = Set(itemOptions.map(\.id))
+        let presentIdentifiers = Set(targetItemOptions.map(\.id))
         let presentIdentifierBases = Dictionary(
-            itemOptions.map { ($0.id, $0.baseIdentifier) },
+            targetItemOptions.map { ($0.id, $0.baseIdentifier) },
             uniquingKeysWith: { first, _ in first }
         )
         var ownersByIdentifier = [String: Set<UUID>]()
-        for trigger in manager.triggers where trigger.isEnabled {
+        for trigger in manager.triggers where trigger.isEnabled && !trigger.hasPreferenceSensitiveTarget {
             var resolvedTargets = Set<String>()
             for target in trigger.allTargetItems {
                 let resolved = MenuBarItemTriggersManager.resolvedPresentIdentifier(
@@ -508,7 +529,7 @@ struct TriggersSettingsPane: View {
     }
 
     private func addTrigger() {
-        let firstItem = itemOptions.first
+        let firstItem = targetItemOptions.first
         let trigger = MenuBarItemTrigger(
             itemIdentifier: firstItem?.id ?? "",
             itemDisplayName: firstItem?.name ?? "",
@@ -591,7 +612,10 @@ private struct TriggerPriorityDropDelegate: DropDelegate {
 /// An inline editor for a single ``MenuBarItemTrigger``.
 private struct TriggerRow: View {
     @Binding var trigger: MenuBarItemTrigger
+    /// All observable items, including protected system modules.
     let itemOptions: [TriggerItemOption]
+    /// Items that can safely be moved between sections by a trigger.
+    let targetItemOptions: [TriggerItemOption]
     let appOptions: [TriggerAppOption]
     let bluetoothOptions: [TriggerBluetoothOption]
     let refreshBluetoothOptions: () -> Void
@@ -633,11 +657,11 @@ private struct TriggerRow: View {
         matching identifier: String,
         baseIdentifier: String?
     ) -> TriggerItemOption? {
-        if let exact = itemOptions.first(where: { $0.id == identifier }) {
+        if let exact = targetItemOptions.first(where: { $0.id == identifier }) {
             return exact
         }
         guard let baseIdentifier else { return nil }
-        let matches = itemOptions.filter { $0.baseIdentifier == baseIdentifier }
+        let matches = targetItemOptions.filter { $0.baseIdentifier == baseIdentifier }
         return matches.count == 1 ? matches[0] : nil
     }
 
@@ -660,6 +684,13 @@ private struct TriggerRow: View {
 
     private var isSelectedItemMissing: Bool {
         !trigger.itemIdentifier.isEmpty && selectedItemOption == nil
+    }
+
+    private var isSelectedItemProtected: Bool {
+        MenuBarItemTag.triggerTargetPolicy(
+            for: trigger.itemIdentifier,
+            capturedBaseIdentifier: trigger.itemBaseIdentifier
+        ) == .systemVisibilityPreferenceSensitive
     }
 
     private var overriddenNames: [String] {
@@ -702,6 +733,9 @@ private struct TriggerRow: View {
                 if !isCollapsed {
                     Divider()
                     itemPicker
+                    if trigger.hasPreferenceSensitiveTarget {
+                        protectedSystemItemWarning
+                    }
                     conditionsSection
                     if trigger.isEnabled, !conditionActive {
                         inactiveConditionWarning
@@ -709,7 +743,10 @@ private struct TriggerRow: View {
                     if hasConflict {
                         conflictWarning
                     }
-                    if trigger.isEnabled, conditionActive {
+                    if trigger.isEnabled,
+                       conditionActive,
+                       !trigger.hasPreferenceSensitiveTarget
+                    {
                         savedLayoutOverrideNote
                     }
                     if !overriddenNames.isEmpty {
@@ -894,7 +931,13 @@ private struct TriggerRow: View {
                             matching: current,
                             baseIdentifier: currentItem.baseIdentifier
                         )
-                        if !current.isEmpty, resolvedItem == nil {
+                        let isProtected = MenuBarItemTag.triggerTargetPolicy(
+                            for: current,
+                            capturedBaseIdentifier: currentItem.baseIdentifier
+                        ) == .systemVisibilityPreferenceSensitive
+                        if !current.isEmpty, isProtected {
+                            Text("\(trigger.additionalItems[index].displayName) (protected)").tag(current)
+                        } else if !current.isEmpty, resolvedItem == nil {
                             Text("\(trigger.additionalItems[index].displayName) (not present)").tag(current)
                         } else if let resolvedItem, resolvedItem.id != current {
                             Text(resolvedItem.name).tag(current)
@@ -902,7 +945,7 @@ private struct TriggerRow: View {
                         if current.isEmpty {
                             Text("Choose an item…").tag("")
                         }
-                        ForEach(itemOptions, id: \.id) { option in
+                        ForEach(targetItemOptions, id: \.id) { option in
                             Text(option.name).tag(option.id)
                         }
                     }
@@ -947,8 +990,8 @@ private struct TriggerRow: View {
             set: { newValue in
                 guard index < trigger.additionalItems.count else { return }
                 guard newValue != trigger.additionalItems[index].identifier else { return }
-                let name = itemOptions.first(where: { $0.id == newValue })?.name ?? ""
-                let baseIdentifier = itemOptions.first(where: { $0.id == newValue })?.baseIdentifier
+                let name = targetItemOptions.first(where: { $0.id == newValue })?.name ?? ""
+                let baseIdentifier = targetItemOptions.first(where: { $0.id == newValue })?.baseIdentifier
                 trigger.additionalItems[index] = TriggerTargetItem(
                     identifier: newValue,
                     displayName: name,
@@ -989,14 +1032,27 @@ private struct TriggerRow: View {
 
     private var itemPicker: some View {
         IcePicker("Menu bar item", selection: itemBinding) {
-            if isSelectedItemMissing {
+            if isSelectedItemProtected {
+                Text("\(selectedItemName) (protected)").tag(trigger.itemIdentifier)
+            } else if isSelectedItemMissing {
                 Text("\(selectedItemName) (not present)").tag(trigger.itemIdentifier)
             } else if let selectedItemOption, selectedItemOption.id != trigger.itemIdentifier {
                 Text(selectedItemOption.name).tag(trigger.itemIdentifier)
             }
-            ForEach(itemOptions, id: \.id) { option in
+            ForEach(targetItemOptions, id: \.id) { option in
                 Text(option.name).tag(option.id)
             }
+        }
+    }
+
+    private var protectedSystemItemWarning: some View {
+        Label {
+            Text("This system item cannot be a trigger target because automatically hiding it can turn off its macOS Show in Menu Bar setting. Choose another target; Battery and power conditions remain available. If Battery is already missing, re-enable Show in Menu Bar for Battery in System Settings.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } icon: {
+            Image(systemName: "shield.lefthalf.filled")
+                .foregroundStyle(.orange)
         }
     }
 
@@ -1389,7 +1445,7 @@ private struct TriggerRow: View {
             set: { newValue in
                 guard newValue != trigger.itemIdentifier else { return }
                 trigger.itemIdentifier = newValue
-                if let match = itemOptions.first(where: { $0.id == newValue }) {
+                if let match = targetItemOptions.first(where: { $0.id == newValue }) {
                     trigger.itemDisplayName = match.name
                     trigger.itemBaseIdentifier = match.baseIdentifier
                 } else {

--- a/Thaw/Utilities/ImageHashing.swift
+++ b/Thaw/Utilities/ImageHashing.swift
@@ -62,6 +62,62 @@ enum ImageHashing {
         return hash
     }
 
+    /// Computes a stable hash of the image's exact, normalized RGBA pixels.
+    /// Unlike ``averageHash``, a one-pixel difference changes this value,
+    /// which is appropriate for the opt-in exact comparison mode.
+    static func exactHash(_ image: CGImage) -> UInt64? {
+        let width = image.width
+        let height = image.height
+        guard
+            width > 0,
+            height > 0,
+            width <= Int.max / 4
+        else {
+            return nil
+        }
+
+        let bytesPerRow = width * 4
+        guard height <= Int.max / bytesPerRow else { return nil }
+
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
+            | CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ) else {
+            return nil
+        }
+        context.interpolationQuality = .none
+        context.setBlendMode(.copy)
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // FNV-1a is small, deterministic across launches, and sufficient for
+        // change detection. This is not used as a security primitive.
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        let prime: UInt64 = 0x0000_0100_0000_01B3
+
+        func combine(_ byte: UInt8) {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+
+        for value in [UInt64(width), UInt64(height)] {
+            for shift in stride(from: 0, to: 64, by: 8) {
+                combine(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
+            }
+        }
+        for byte in pixels {
+            combine(byte)
+        }
+        return hash
+    }
+
     /// The number of differing bits between two hashes (0...64).
     static func hammingDistance(_ lhs: UInt64, _ rhs: UInt64) -> Int {
         (lhs ^ rhs).nonzeroBitCount

--- a/Thaw/Utilities/ImageHashing.swift
+++ b/Thaw/Utilities/ImageHashing.swift
@@ -99,7 +99,7 @@ enum ImageHashing {
 
         // FNV-1a is small, deterministic across launches, and sufficient for
         // change detection. This is not used as a security primitive.
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
         let prime: UInt64 = 0x0000_0100_0000_01B3
 
         func combine(_ byte: UInt8) {

--- a/Thaw/Utilities/SystemStateMonitor.swift
+++ b/Thaw/Utilities/SystemStateMonitor.swift
@@ -110,6 +110,10 @@ struct SystemState: Equatable {
     /// Identifiers of items currently blinking for attention.
     var itemsSeekingAttention: Set<String>
 
+    /// Exact pixel hashes of watched items, populated alongside
+    /// ``imageHashes`` for exact image-comparison conditions.
+    var exactImageHashes: [String: UInt64]
+
     init(
         power: PowerState = PowerState(batteryPercentage: nil, isOnACPower: true, isCharging: false),
         frontmostAppBundleID: String? = nil,
@@ -131,7 +135,8 @@ struct SystemState: Equatable {
         isMicrophoneInUse: Bool = false,
         scriptOutcomes: [String: ScriptOutcome] = [:],
         imageHashes: [String: UInt64] = [:],
-        itemsSeekingAttention: Set<String> = []
+        itemsSeekingAttention: Set<String> = [],
+        exactImageHashes: [String: UInt64] = [:]
     ) {
         self.power = power
         self.frontmostAppBundleID = frontmostAppBundleID
@@ -154,6 +159,7 @@ struct SystemState: Equatable {
         self.scriptOutcomes = scriptOutcomes
         self.imageHashes = imageHashes
         self.itemsSeekingAttention = itemsSeekingAttention
+        self.exactImageHashes = exactImageHashes
     }
 }
 

--- a/ThawTests/MenuBarItemTriggerTests.swift
+++ b/ThawTests/MenuBarItemTriggerTests.swift
@@ -806,7 +806,7 @@ struct MenuBarItemTriggerTests {
         #expect(ImageHashing.hammingDistance(mostlyBlack, mostlyWhite) > ImageHashing.changeThreshold)
     }
 
-    @Test func exactHashIsDeterministicAndPixelSensitive() throws {
+    @Test func exactHashIsDeterministicAndPixelSensitive() {
         let first = makeImage(whiteColumns: 8)
         let same = makeImage(whiteColumns: 8)
         let changed = makeImage(whiteColumns: 9)

--- a/ThawTests/MenuBarItemTriggerTests.swift
+++ b/ThawTests/MenuBarItemTriggerTests.swift
@@ -132,6 +132,39 @@ struct MenuBarItemTriggerTests {
         #expect(TriggerCondition.charging.isSatisfied(state: state(charging: true)))
     }
 
+    @Test func builtInBatteryIsProtectedFromConditionalPlacement() {
+        let battery = MenuBarItemTag(
+            namespace: .controlCenter,
+            title: "Battery",
+            instanceIndex: 2
+        )
+        #expect(battery.triggerTargetPolicy == .systemVisibilityPreferenceSensitive)
+        #expect(
+            MenuBarItemTag.triggerTargetPolicy(for: "com.apple.controlcenter:Battery:2")
+                == .systemVisibilityPreferenceSensitive
+        )
+        #expect(MenuBarItemTag.triggerTargetPolicy(for: "com.example.app:Battery") == .supported)
+        #expect(MenuBarItemTag.triggerTargetPolicy(for: "com.apple.controlcenter:BatteryStatus") == .supported)
+
+        #expect(MenuBarItemManager.triggerMovePreflight(for: battery, to: .visible) == .allowed)
+        #expect(MenuBarItemManager.triggerMovePreflight(for: battery, to: .hidden) == .protectedSystemItem)
+        #expect(MenuBarItemManager.triggerMovePreflight(for: battery, to: .alwaysHidden) == .protectedSystemItem)
+
+        let observedBattery = TriggerItemOption(
+            id: battery.tagIdentifier,
+            name: "Battery",
+            baseIdentifier: battery.stableIdentifierBase
+        )
+        #expect(!observedBattery.supportsConditionalPlacement)
+        #expect(
+            TriggerItemOption(
+                id: "com.example.app:Battery",
+                name: "Battery",
+                baseIdentifier: "com.example.app:Battery"
+            ).supportsConditionalPlacement
+        )
+    }
+
     // MARK: - Applications
 
     @Test func frontmostApp() {
@@ -489,14 +522,14 @@ struct MenuBarItemTriggerTests {
         manager.triggers = [
             MenuBarItemTrigger(
                 isEnabled: true,
-                itemIdentifier: "com.apple.controlcenter:Battery",
+                itemIdentifier: "com.example.Status",
                 condition: .batteryBelow(percentage: 69)
             ),
         ]
 
-        let owner = manager.controllingTrigger(forBaseIdentifier: "com.apple.controlcenter:Battery")
+        let owner = manager.controllingTrigger(forBaseIdentifier: "com.example.Status")
 
-        #expect(owner?.itemIdentifier == "com.apple.controlcenter:Battery")
+        #expect(owner?.itemIdentifier == "com.example.Status")
         #expect(manager.controllingTrigger(forBaseIdentifier: "com.example.Other") == nil)
         #expect(manager.controllingTrigger(forBaseIdentifier: "") == nil)
     }
@@ -509,12 +542,12 @@ struct MenuBarItemTriggerTests {
         manager.triggers = [
             MenuBarItemTrigger(
                 isEnabled: false,
-                itemIdentifier: "com.apple.controlcenter:Battery",
+                itemIdentifier: "com.example.Status",
                 condition: .batteryBelow(percentage: 69)
             ),
         ]
 
-        #expect(manager.controllingTrigger(forBaseIdentifier: "com.apple.controlcenter:Battery") == nil)
+        #expect(manager.controllingTrigger(forBaseIdentifier: "com.example.Status") == nil)
     }
 
     /// A stored target carrying a stale instance suffix still resolves to the
@@ -524,12 +557,12 @@ struct MenuBarItemTriggerTests {
         manager.triggers = [
             MenuBarItemTrigger(
                 isEnabled: true,
-                itemIdentifier: "com.apple.controlcenter:Battery:2",
+                itemIdentifier: "com.example.Status:2",
                 condition: .onBatteryPower
             ),
         ]
 
-        #expect(manager.controllingTrigger(forBaseIdentifier: "com.apple.controlcenter:Battery") != nil)
+        #expect(manager.controllingTrigger(forBaseIdentifier: "com.example.Status") != nil)
     }
 
     /// Two enabled triggers on one item resolve to the higher-priority one,
@@ -540,20 +573,66 @@ struct MenuBarItemTriggerTests {
             MenuBarItemTrigger(
                 name: "First",
                 isEnabled: true,
-                itemIdentifier: "com.apple.controlcenter:Battery",
+                itemIdentifier: "com.example.Status",
                 condition: .onBatteryPower
             ),
             MenuBarItemTrigger(
                 name: "Second",
                 isEnabled: true,
-                itemIdentifier: "com.apple.controlcenter:Battery",
+                itemIdentifier: "com.example.Status",
                 condition: .onACPower
             ),
         ]
 
         #expect(
-            manager.controllingTrigger(forBaseIdentifier: "com.apple.controlcenter:Battery")?.displayName
+            manager.controllingTrigger(forBaseIdentifier: "com.example.Status")?.displayName
                 == "First"
+        )
+    }
+
+    @Test func protectedBatteryTriggerDoesNotClaimLayoutOwnership() {
+        let manager = makeManager()
+        manager.triggers = [
+            MenuBarItemTrigger(
+                itemIdentifier: "com.apple.controlcenter:Battery:2",
+                itemBaseIdentifier: "com.apple.controlcenter:Battery",
+                condition: .onBatteryPower
+            ),
+        ]
+
+        #expect(!manager.isControlledByTrigger(baseIdentifier: "com.apple.controlcenter:Battery"))
+        #expect(manager.controllingTrigger(forBaseIdentifier: "com.apple.controlcenter:Battery") == nil)
+        #expect(manager.runtimeStatus(for: manager.triggers[0]) == .protectedSystemItem)
+    }
+
+    @Test func protectedTriggerConditionSourcesAreNotPolled() {
+        let protected = MenuBarItemTrigger(
+            itemIdentifier: "com.apple.controlcenter:Battery",
+            itemBaseIdentifier: "com.apple.controlcenter:Battery",
+            condition: .scriptResult(path: "/protected-only", expectedOutput: "protected"),
+            additionalConditions: [
+                .imageChanged(itemIdentifier: "protected-image", referenceHash: nil),
+                .scriptResult(path: "/shared", expectedOutput: "protected"),
+                .imageChanged(itemIdentifier: "shared-image", referenceHash: nil),
+            ]
+        )
+        let supported = MenuBarItemTrigger(
+            itemIdentifier: "com.example.Status",
+            condition: .scriptResult(path: "/shared", expectedOutput: "supported"),
+            additionalConditions: [
+                .imageChanged(itemIdentifier: "shared-image", referenceHash: nil),
+            ]
+        )
+
+        #expect(
+            MenuBarItemTriggersManager.runnableScriptExpectedOutputs(
+                in: [protected, supported]
+            ) == ["/shared": ["supported"]]
+        )
+        #expect(
+            MenuBarItemTriggersManager.runnableImageObservationIdentifiers(
+                in: [protected, supported]
+            ) == ["shared-image"]
         )
     }
 
@@ -964,12 +1043,11 @@ struct MenuBarItemTriggerTests {
         #expect(plan.actions[lower.id] == nil)
     }
 
-    /// Battery hides like any other target. An earlier revision exempted the
-    /// Control Center Battery control from the hide branch, on the theory
-    /// that concealing it would turn off the system's own Show in Menu Bar
-    /// setting; that does not happen, and the exemption made a trigger
-    /// silently ignore the "Otherwise hide in" section the user picked.
-    @Test func priorityPlanHidesControlCenterBatteryWhenConditionClears() {
+    /// The built-in Battery item is governed by macOS's Show in Menu Bar
+    /// preference. A conditional off-screen drag can turn that preference off,
+    /// so the entire trigger is suspended before it claims ownership or plans
+    /// either branch.
+    @Test func priorityPlanProtectsControlCenterBatteryInBothBranches() {
         let manager = makeManager()
         let trigger = MenuBarItemTrigger(
             itemIdentifier: "com.apple.controlcenter:Battery",
@@ -985,13 +1063,8 @@ struct MenuBarItemTriggerTests {
                 "com.apple.controlcenter:Battery": "com.apple.controlcenter:Battery",
             ]
         )
-        #expect(
-            hiddenPlan.actions[trigger.id]
-                == MenuBarItemTriggersManager.TriggerPriorityAction(
-                    reveal: false,
-                    identifiers: ["com.apple.controlcenter:Battery"]
-                )
-        )
+        #expect(hiddenPlan.actions[trigger.id] == nil)
+        #expect(hiddenPlan.protectedTriggerIDs.contains(trigger.id))
         #expect(!hiddenPlan.unavailableTriggerIDs.contains(trigger.id))
 
         let revealPlan = manager.priorityPlan(
@@ -1001,13 +1074,37 @@ struct MenuBarItemTriggerTests {
                 "com.apple.controlcenter:Battery": "com.apple.controlcenter:Battery",
             ]
         )
-        #expect(
-            revealPlan.actions[trigger.id]
-                == MenuBarItemTriggersManager.TriggerPriorityAction(
-                    reveal: true,
-                    identifiers: ["com.apple.controlcenter:Battery"]
-                )
+        #expect(revealPlan.actions[trigger.id] == nil)
+        #expect(revealPlan.protectedTriggerIDs.contains(trigger.id))
+    }
+
+    @Test func priorityPlanRejectsMultiItemTriggerContainingProtectedBattery() {
+        let manager = makeManager()
+        let trigger = MenuBarItemTrigger(
+            itemIdentifier: "com.example.Safe",
+            itemBaseIdentifier: "com.example.Safe",
+            additionalItems: [
+                TriggerTargetItem(
+                    identifier: "com.apple.controlcenter:Battery:1",
+                    displayName: "Battery",
+                    baseIdentifier: "com.apple.controlcenter:Battery"
+                ),
+            ],
+            condition: .onACPower
         )
+        manager.triggers = [trigger]
+
+        let plan = manager.priorityPlan(
+            for: state(onAC: true),
+            presentIdentifiers: ["com.example.Safe", "com.apple.controlcenter:Battery:1"],
+            presentIdentifierBases: [
+                "com.example.Safe": "com.example.Safe",
+                "com.apple.controlcenter:Battery:1": "com.apple.controlcenter:Battery",
+            ]
+        )
+
+        #expect(plan.actions[trigger.id] == nil)
+        #expect(plan.protectedTriggerIDs.contains(trigger.id))
     }
 
     @Test func priorityPlanReacquiresUnambiguousSuffixDriftFromLiveTagBases() {
@@ -1254,13 +1351,8 @@ struct MenuBarItemTriggerTests {
         )
 
         #expect(repaired.itemBaseIdentifier == "com.apple.controlcenter:Battery")
-        #expect(
-            plan.actions[repaired.id]
-                == MenuBarItemTriggersManager.TriggerPriorityAction(
-                    reveal: true,
-                    identifiers: ["com.apple.controlcenter:Battery:1"]
-                )
-        )
+        #expect(plan.actions[repaired.id] == nil)
+        #expect(plan.protectedTriggerIDs.contains(repaired.id))
         #expect(!plan.unavailableTriggerIDs.contains(repaired.id))
     }
 

--- a/ThawTests/MenuBarItemTriggerTests.swift
+++ b/ThawTests/MenuBarItemTriggerTests.swift
@@ -806,6 +806,15 @@ struct MenuBarItemTriggerTests {
         #expect(ImageHashing.hammingDistance(mostlyBlack, mostlyWhite) > ImageHashing.changeThreshold)
     }
 
+    @Test func exactHashIsDeterministicAndPixelSensitive() throws {
+        let first = makeImage(whiteColumns: 8)
+        let same = makeImage(whiteColumns: 8)
+        let changed = makeImage(whiteColumns: 9)
+
+        #expect(ImageHashing.exactHash(first) == ImageHashing.exactHash(same))
+        #expect(ImageHashing.exactHash(first) != ImageHashing.exactHash(changed))
+    }
+
     @Test func imageChangedCondition() {
         let id = "com.apple.controlcenter:Battery"
         let reference: UInt64 = 0x0000_0000_0000_0000
@@ -822,6 +831,40 @@ struct MenuBarItemTriggerTests {
         // No reference captured -> never satisfied.
         let noRef = TriggerCondition.imageChanged(itemIdentifier: id, referenceHash: nil)
         #expect(!noRef.isSatisfied(state: changed))
+    }
+
+    @Test func exactAndFuzzyImageComparisonDifferOnSmallChanges() {
+        let id = "com.example:Status"
+        var current = state()
+        current.imageHashes = [id: 1] // One perceptual bit differs.
+        current.exactImageHashes = [id: 101]
+
+        let fuzzy = TriggerCondition.imageChanged(
+            itemIdentifier: id,
+            referenceHash: 0,
+            referenceExactHash: 100,
+            comparisonMode: .fuzzy
+        )
+        let exact = TriggerCondition.imageChanged(
+            itemIdentifier: id,
+            referenceHash: 0,
+            referenceExactHash: 100,
+            comparisonMode: .exact
+        )
+
+        #expect(!fuzzy.isSatisfied(state: current))
+        #expect(exact.isSatisfied(state: current))
+    }
+
+    @Test func exactComparisonRequiresAnExactReference() {
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: 0,
+            comparisonMode: .exact
+        )
+        var current = state()
+        current.exactImageHashes = ["item": 1]
+        #expect(!condition.isSatisfied(state: current))
     }
 
     @Test func imageChangedCodableRoundTrip() throws {
@@ -841,6 +884,54 @@ struct MenuBarItemTriggerTests {
         let decoded = try JSONDecoder().decode(TriggerCondition.self, from: data)
 
         #expect(decoded == condition)
+    }
+
+    @Test func imageComparisonSettingsCodableRoundTrip() throws {
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: 7,
+            referenceExactHash: 11,
+            comparisonMode: .exact,
+            referenceImageData: Data([1, 2, 3])
+        )
+
+        let data = try JSONEncoder().encode(condition)
+        #expect(try JSONDecoder().decode(TriggerCondition.self, from: data) == condition)
+    }
+
+    @Test func legacyImageComparisonDefaultsToFuzzyWithoutPreview() throws {
+        let data = Data(#"{"imageChanged":{"itemIdentifier":"item","referenceHash":7}}"#.utf8)
+        let decoded = try JSONDecoder().decode(TriggerCondition.self, from: data)
+
+        #expect(decoded.imageValue?.comparisonMode == .fuzzy)
+        #expect(decoded.imageValue?.referenceHash == 7)
+        #expect(decoded.imageValue?.referenceExactHash == nil)
+        #expect(decoded.imageValue?.referenceImageData == nil)
+    }
+
+    @Test func capturedReferenceAndModeArePreserved() {
+        let reference = ImageComparisonReference(
+            perceptualHash: 7,
+            exactHash: 11,
+            imageData: Data([1, 2, 3])
+        )
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: nil,
+            comparisonMode: .exact
+        )
+        let captured = condition.withImageReference(reference)
+
+        #expect(captured.imageValue?.comparisonMode == .exact)
+        #expect(captured.imageValue?.referenceHash == 7)
+        #expect(captured.imageValue?.referenceExactHash == 11)
+        #expect(captured.imageValue?.referenceImageData == Data([1, 2, 3]))
+
+        let changedItem = captured.withImageItem("other")
+        #expect(changedItem.imageValue?.comparisonMode == .exact)
+        #expect(changedItem.imageValue?.referenceHash == nil)
+        #expect(changedItem.imageValue?.referenceExactHash == nil)
+        #expect(changedItem.imageValue?.referenceImageData == nil)
     }
 
     // MARK: - Kind / editor mapping


### PR DESCRIPTION
# Summary

This follow-up to #965 protects the built-in Battery item from conditional off-screen placement and expands image-change triggers with configurable comparison modes and a captured-reference preview.

Closes: N/A

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- The built-in Control Center Battery item is excluded from trigger targets that would hide it and potentially change macOS's Show in Menu Bar preference.
- Triggers containing a protected Battery target are suspended as a unit, do not claim layout ownership, and do not poll their condition sources unnecessarily.
- Image-change conditions can use fuzzy perceptual matching or exact pixel matching.
- Settings can capture, preview, and replace an image reference while preserving compatibility with existing saved fuzzy comparisons.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [ ] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -destination 'generic/platform=macOS' -derivedDataPath /private/tmp/ThawTriggerFollowupBuild CODE_SIGNING_ALLOWED=NO` — passed.
- `swiftformat --lint` on all touched Swift files — passed.
- The focused `MenuBarItemTriggerTests` command compiled the app and touched test file, but the test target is currently blocked before execution by existing compile errors in `MenuBarAppearanceSpaceOverrideTests` on `release/v2.1.0`.

## Known limitations / follow-ups

- Manual testing of Battery protection and live image-reference capture is still required before marking this PR ready for review.
- This targets `release/v2.1.0` because it directly follows the trigger feature merged in #965.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790708461&installation_model_id=431242&pr_number=1005&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1005&signature=9dc8ea911bb71992d99515074056efb3f180160ad4acc726e8e89ef1110ef270"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->