### PR TITLE
feat(triggers): add image comparison modes and preview

### DIFF
--- a/Thaw/Settings/Models/MenuBarItemTrigger.swift
+++ b/Thaw/Settings/Models/MenuBarItemTrigger.swift
@@ -135,6 +135,35 @@ enum ScheduleWeekday: Int, Codable, Hashable, CaseIterable, Identifiable {
 
 // MARK: - TriggerCondition
 
+/// How strictly an image-comparison condition compares the current icon to
+/// its captured reference.
+enum ImageComparisonMode: String, Codable, Hashable, CaseIterable, Identifiable {
+    /// Ignores small perceptual-hash differences caused by rendering noise.
+    case fuzzy
+
+    /// Treats any pixel-content difference as an icon change.
+    case exact
+
+    var id: String {
+        rawValue
+    }
+
+    var displayString: String {
+        switch self {
+        case .fuzzy: "Fuzzy"
+        case .exact: "Exact"
+        }
+    }
+}
+
+/// The hashes used at runtime plus a compact PNG used only to preview the
+/// captured reference in settings.
+struct ImageComparisonReference: Codable, Hashable {
+    let perceptualHash: UInt64
+    let exactHash: UInt64
+    let imageData: Data?
+}
+
 /// A condition that decides whether a ``MenuBarItemTrigger`` is currently
 /// satisfied, evaluated against a ``SystemState`` snapshot.
 ///
@@ -186,8 +215,16 @@ enum TriggerCondition: Codable, Hashable {
     /// Script
     case scriptResult(path: String, expectedOutput: String)
 
-    /// Image comparison
-    case imageChanged(itemIdentifier: String, referenceHash: UInt64?)
+    /// Image comparison. The optional trailing values keep triggers saved by
+    /// the original prototype decodable; their absence means fuzzy matching
+    /// and no stored preview image.
+    case imageChanged(
+        itemIdentifier: String,
+        referenceHash: UInt64?,
+        referenceExactHash: UInt64? = nil,
+        comparisonMode: ImageComparisonMode? = nil,
+        referenceImageData: Data? = nil
+    )
 
     /// Satisfied while a watched item is blinking for attention.
     ///
@@ -269,9 +306,15 @@ enum TriggerCondition: Codable, Hashable {
             }
             return outcome.matchedExpectedOutputs.contains(expectedOutput) ||
                 outcome.output.localizedCaseInsensitiveContains(expectedOutput)
-        case let .imageChanged(itemIdentifier, referenceHash):
-            guard let referenceHash, let current = state.imageHashes[itemIdentifier] else { return false }
-            return ImageHashing.hammingDistance(current, referenceHash) > ImageHashing.changeThreshold
+        case let .imageChanged(itemIdentifier, referenceHash, referenceExactHash, comparisonMode, _):
+            switch comparisonMode ?? .fuzzy {
+            case .fuzzy:
+                guard let referenceHash, let current = state.imageHashes[itemIdentifier] else { return false }
+                return ImageHashing.hammingDistance(current, referenceHash) > ImageHashing.changeThreshold
+            case .exact:
+                guard let referenceExactHash, let current = state.exactImageHashes[itemIdentifier] else { return false }
+                return current != referenceExactHash
+            }
         case let .itemSeekingAttention(itemIdentifier):
             return state.itemsSeekingAttention.contains(itemIdentifier)
         }
@@ -333,7 +376,7 @@ enum TriggerCondition: Codable, Hashable {
         case let .scriptResult(path, expectedOutput):
             let name = path.isEmpty ? "a script" : ((path as NSString).lastPathComponent)
             return expectedOutput.isEmpty ? "\(name) exits 0" : "\(name) outputs “\(expectedOutput)”"
-        case let .imageChanged(_, referenceHash):
+        case let .imageChanged(_, referenceHash, _, _, _):
             return referenceHash == nil ? "An icon changed (capture a reference)" : "A watched icon changed"
         case .itemSeekingAttention:
             return "An icon is asking for attention"
@@ -677,10 +720,29 @@ extension TriggerCondition {
         return nil
     }
 
-    /// The watched item and reference hash, for the image-comparison condition.
-    var imageValue: (itemIdentifier: String, referenceHash: UInt64?)? {
-        if case let .imageChanged(itemIdentifier, referenceHash) = self {
-            return (itemIdentifier, referenceHash)
+    /// The persisted values for the image-comparison condition. Legacy
+    /// conditions with no mode are normalized to fuzzy behavior here.
+    var imageValue: (
+        itemIdentifier: String,
+        referenceHash: UInt64?,
+        referenceExactHash: UInt64?,
+        comparisonMode: ImageComparisonMode,
+        referenceImageData: Data?
+    )? {
+        if case let .imageChanged(
+            itemIdentifier,
+            referenceHash,
+            referenceExactHash,
+            comparisonMode,
+            referenceImageData
+        ) = self {
+            return (
+                itemIdentifier,
+                referenceHash,
+                referenceExactHash,
+                comparisonMode ?? .fuzzy,
+                referenceImageData
+            )
         }
         return nil
     }
@@ -688,7 +750,7 @@ extension TriggerCondition {
     /// The item this condition watches, for either icon-watching kind.
     var watchedItemIdentifier: String? {
         switch self {
-        case let .imageChanged(itemIdentifier, _): itemIdentifier
+        case let .imageChanged(itemIdentifier, _, _, _, _): itemIdentifier
         case let .itemSeekingAttention(itemIdentifier): itemIdentifier
         default: nil
         }
@@ -758,14 +820,22 @@ extension TriggerCondition {
             old.scriptValue.map { TriggerCondition.scriptResult(path: $0.path, expectedOutput: $0.expectedOutput) }
                 ?? .scriptResult(path: "", expectedOutput: "")
         case .imageChanged:
-            // Carry the watched item from either icon-watching kind. The
-            // reference hash only survives when there was one, so switching
-            // from the attention kind lands on "no reference yet" rather
-            // than an inherited comparison the user never captured.
-            .imageChanged(
-                itemIdentifier: old.watchedItemIdentifier ?? "",
-                referenceHash: old.imageValue?.referenceHash
-            )
+            if let image = old.imageValue {
+                .imageChanged(
+                    itemIdentifier: image.itemIdentifier,
+                    referenceHash: image.referenceHash,
+                    referenceExactHash: image.referenceExactHash,
+                    comparisonMode: image.comparisonMode,
+                    referenceImageData: image.referenceImageData
+                )
+            } else {
+                // Carry the watched item when switching from the attention
+                // condition, but start without an image comparison reference.
+                .imageChanged(
+                    itemIdentifier: old.watchedItemIdentifier ?? "",
+                    referenceHash: nil
+                )
+            }
         case .itemSeekingAttention:
             // Preserve the watched item when switching between the two
             // icon-watching kinds; the reference hash has no meaning here.
@@ -842,16 +912,40 @@ extension TriggerCondition {
     }
 
     /// Returns a copy of the image condition with the watched item replaced
-    /// (clearing the reference hash, since it no longer applies).
+    /// (clearing the reference, since it no longer applies).
     func withImageItem(_ itemIdentifier: String) -> TriggerCondition {
-        guard case .imageChanged = self else { return self }
-        return .imageChanged(itemIdentifier: itemIdentifier, referenceHash: nil)
+        guard case let .imageChanged(_, _, _, comparisonMode, _) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: nil,
+            referenceExactHash: nil,
+            comparisonMode: comparisonMode,
+            referenceImageData: nil
+        )
     }
 
-    /// Returns a copy of the image condition with the reference hash replaced.
-    func withImageReferenceHash(_ referenceHash: UInt64) -> TriggerCondition {
-        guard case let .imageChanged(itemIdentifier, _) = self else { return self }
-        return .imageChanged(itemIdentifier: itemIdentifier, referenceHash: referenceHash)
+    /// Returns a copy of the image condition with its captured reference.
+    func withImageReference(_ reference: ImageComparisonReference) -> TriggerCondition {
+        guard case let .imageChanged(itemIdentifier, _, _, comparisonMode, _) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: reference.perceptualHash,
+            referenceExactHash: reference.exactHash,
+            comparisonMode: comparisonMode,
+            referenceImageData: reference.imageData
+        )
+    }
+
+    /// Returns a copy using the requested comparison strictness.
+    func withImageComparisonMode(_ comparisonMode: ImageComparisonMode) -> TriggerCondition {
+        guard case let .imageChanged(itemIdentifier, referenceHash, referenceExactHash, _, referenceImageData) = self else { return self }
+        return .imageChanged(
+            itemIdentifier: itemIdentifier,
+            referenceHash: referenceHash,
+            referenceExactHash: referenceExactHash,
+            comparisonMode: comparisonMode,
+            referenceImageData: referenceImageData
+        )
     }
 
     /// Returns a copy with the Energy Mode predicate replaced.

--- a/Thaw/Settings/Models/MenuBarItemTrigger.swift
+++ b/Thaw/Settings/Models/MenuBarItemTrigger.swift
@@ -150,8 +150,8 @@ enum ImageComparisonMode: String, Codable, Hashable, CaseIterable, Identifiable 
 
     var displayString: String {
         switch self {
-        case .fuzzy: "Fuzzy"
-        case .exact: "Exact"
+        case .fuzzy: String(localized: "Fuzzy")
+        case .exact: String(localized: "Exact")
         }
     }
 }

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager+Live.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager+Live.swift
@@ -709,16 +709,20 @@ extension MenuBarItemTriggersManager {
         var ids = Set<String>()
         for trigger in triggers where trigger.isEnabled {
             for condition in trigger.allConditions {
-                if case let .imageChanged(itemIdentifier, _) = condition, !itemIdentifier.isEmpty {
+                if case let .imageChanged(itemIdentifier, _, _, _, _) = condition, !itemIdentifier.isEmpty {
                     ids.insert(itemIdentifier)
                 }
             }
         }
 
         let removed = Set(imageHashes.keys).subtracting(ids)
-        let removedAny = !removed.isEmpty
+        let removedExact = Set(exactImageHashes.keys).subtracting(ids)
+        let removedAny = !removed.isEmpty || !removedExact.isEmpty
         for id in removed {
             imageHashes[id] = nil
+        }
+        for id in removedExact {
+            exactImageHashes[id] = nil
         }
 
         guard !ids.isEmpty else {
@@ -734,15 +738,19 @@ extension MenuBarItemTriggersManager {
 
             var changed = removedAny
             for id in ids {
-                guard let hash = await self.currentImageHash(forItemIdentifier: id) else {
-                    if self.imageHashes[id] != nil {
+                guard let fingerprints = await self.currentImageFingerprints(forItemIdentifier: id) else {
+                    if self.imageHashes[id] != nil || self.exactImageHashes[id] != nil {
                         self.imageHashes[id] = nil
+                        self.exactImageHashes[id] = nil
                         changed = true
                     }
                     continue
                 }
-                if self.imageHashes[id] != hash {
-                    self.imageHashes[id] = hash
+                if self.imageHashes[id] != fingerprints.perceptual
+                    || self.exactImageHashes[id] != fingerprints.exact
+                {
+                    self.imageHashes[id] = fingerprints.perceptual
+                    self.exactImageHashes[id] = fingerprints.exact
                     changed = true
                 }
             }
@@ -758,8 +766,22 @@ extension MenuBarItemTriggersManager {
         }
     }
 
-    /// Captures the watched item's window and returns its perceptual hash.
-    func currentImageHash(forItemIdentifier id: String) async -> UInt64? {
+    /// Captures the watched item's window and returns both comparison hashes.
+    private func currentImageFingerprints(
+        forItemIdentifier id: String
+    ) async -> (perceptual: UInt64, exact: UInt64)? {
+        guard
+            let image = await currentImage(forItemIdentifier: id),
+            let perceptual = ImageHashing.averageHash(image),
+            let exact = ImageHashing.exactHash(image)
+        else {
+            return nil
+        }
+        return (perceptual, exact)
+    }
+
+    /// Captures the watched item's current window image.
+    private func currentImage(forItemIdentifier id: String) async -> CGImage? {
         guard
             let appState,
             let item = appState.itemManager.itemCache.managedItems.first(where: { $0.tag.tagIdentifier == id })
@@ -767,15 +789,27 @@ extension MenuBarItemTriggersManager {
             return nil
         }
 
-        let image = await ScreenCapture.captureWindowAsync(with: item.windowID)
+        return await ScreenCapture.captureWindowAsync(with: item.windowID)
             ?? ScreenCapture.captureWindow(with: item.windowID)
-        guard let image else { return nil }
-        return ImageHashing.averageHash(image)
     }
 
-    /// Captures a reference hash for the given item now (used by the editor's
-    /// "Capture reference" button).
-    func captureReferenceHash(forItemIdentifier id: String) async -> UInt64? {
-        await currentImageHash(forItemIdentifier: id)
+    /// Captures both the runtime hash and a compact settings preview.
+    func captureImageReference(forItemIdentifier id: String) async -> ImageComparisonReference? {
+        guard
+            let image = await currentImage(forItemIdentifier: id),
+            let perceptualHash = ImageHashing.averageHash(image),
+            let exactHash = ImageHashing.exactHash(image)
+        else {
+            return nil
+        }
+        let imageData = NSBitmapImageRep(cgImage: image).representation(
+            using: .png,
+            properties: [:]
+        )
+        return ImageComparisonReference(
+            perceptualHash: perceptualHash,
+            exactHash: exactHash,
+            imageData: imageData
+        )
     }
 }

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
@@ -181,9 +181,6 @@ final class MenuBarItemTriggersManager {
     /// Exact pixel hashes captured in the same pass as ``imageHashes``.
     var exactImageHashes = [String: UInt64]()
 
-    /// Exact pixel hashes captured in the same pass as ``imageHashes``.
-    private var exactImageHashes = [String: UInt64]()
-
     /// Guards against overlapping image-capture passes.
     var isRefreshingImages = false
     var imagesNeedRefresh = false
@@ -231,7 +228,6 @@ final class MenuBarItemTriggersManager {
         state.imageHashes = imageHashes
         state.exactImageHashes = exactImageHashes
         state.itemsSeekingAttention = itemsSeekingAttention
-        state.exactImageHashes = exactImageHashes
         return state
     }
 

--- a/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
+++ b/Thaw/Settings/Models/MenuBarItemTriggersManager.swift
@@ -178,6 +178,12 @@ final class MenuBarItemTriggersManager {
     /// conditions, keyed by tag identifier, injected into the system state.
     var imageHashes = [String: UInt64]()
 
+    /// Exact pixel hashes captured in the same pass as ``imageHashes``.
+    var exactImageHashes = [String: UInt64]()
+
+    /// Exact pixel hashes captured in the same pass as ``imageHashes``.
+    private var exactImageHashes = [String: UInt64]()
+
     /// Guards against overlapping image-capture passes.
     var isRefreshingImages = false
     var imagesNeedRefresh = false
@@ -223,7 +229,9 @@ final class MenuBarItemTriggersManager {
         var state = systemMonitor.state
         state.scriptOutcomes = scriptOutcomes
         state.imageHashes = imageHashes
+        state.exactImageHashes = exactImageHashes
         state.itemsSeekingAttention = itemsSeekingAttention
+        state.exactImageHashes = exactImageHashes
         return state
     }
 

--- a/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
@@ -217,7 +217,7 @@ struct TriggersSettingsPane: View {
                             dragProvider(for: trigger.id)
                         },
                         currentCoordinate: { manager.systemMonitor.currentCoordinate },
-                        captureReference: { await manager.captureReferenceHash(forItemIdentifier: $0) },
+                        captureReference: { await manager.captureImageReference(forItemIdentifier: $0) },
                         focusedField: $focusedField,
                         onDelete: { manager.remove(id: trigger.id) }
                     )
@@ -614,7 +614,7 @@ private struct TriggerRow: View {
     let onToggleCollapsedExpansion: () -> Void
     let dragProvider: () -> NSItemProvider
     let currentCoordinate: () -> (latitude: Double, longitude: Double)?
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
     var focusedField: FocusState<String?>.Binding
     let onDelete: () -> Void
 
@@ -1467,7 +1467,7 @@ private struct ConditionEditorView: View {
     let refreshBluetoothOptions: () -> Void
     let itemOptions: [TriggerItemOption]
     let currentCoordinate: () -> (latitude: Double, longitude: Double)?
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
     var focusedField: FocusState<String?>.Binding
     let focusID: String
 
@@ -1921,7 +1921,7 @@ private struct AttentionConditionEditor: View {
 private struct ImageConditionEditor: View {
     @Binding var condition: TriggerCondition
     let itemOptions: [TriggerItemOption]
-    let captureReference: (String) async -> UInt64?
+    let captureReference: (String) async -> ImageComparisonReference?
 
     @State private var isCapturing = false
 
@@ -1930,8 +1930,22 @@ private struct ImageConditionEditor: View {
     }
 
     private var hasReference: Bool {
-        guard case let .imageChanged(_, referenceHash) = condition else { return false }
-        return referenceHash != nil
+        condition.imageValue?.referenceHash != nil
+    }
+
+    private var exactReferenceNeedsRecapture: Bool {
+        comparisonMode == .exact
+            && hasReference
+            && condition.imageValue?.referenceExactHash == nil
+    }
+
+    private var referenceImage: NSImage? {
+        guard let data = condition.imageValue?.referenceImageData else { return nil }
+        return NSImage(data: data)
+    }
+
+    private var comparisonMode: ImageComparisonMode {
+        condition.imageValue?.comparisonMode ?? .fuzzy
     }
 
     var body: some View {
@@ -1943,16 +1957,20 @@ private struct ImageConditionEditor: View {
             )
             .disabled(isCapturing)
 
+            IcePicker("Comparison", selection: comparisonModeBinding) {
+                ForEach(ImageComparisonMode.allCases) { mode in
+                    Text(mode.displayString).tag(mode)
+                }
+            }
+
             HStack(spacing: 12) {
                 Button(isCapturing ? "Capturing…" : "Capture Reference") { capture() }
                     .disabled(isCapturing || watchedID.isEmpty)
                 Spacer()
-                Text(hasReference ? "Reference captured" : "No reference yet")
-                    .font(.caption)
-                    .foregroundStyle(hasReference ? .green : .secondary)
+                referenceStatus
             }
 
-            Text("Captures the icon now as a reference, then reveals the item when the icon later changes from it. Requires screen recording permission.")
+            Text(comparisonHelp)
                 .font(.caption)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
@@ -1963,15 +1981,61 @@ private struct ImageConditionEditor: View {
         Binding(get: { watchedID }, set: { condition = condition.withImageItem($0) })
     }
 
+    private var comparisonModeBinding: Binding<ImageComparisonMode> {
+        Binding(
+            get: { comparisonMode },
+            set: { condition = condition.withImageComparisonMode($0) }
+        )
+    }
+
+    @ViewBuilder
+    private var referenceStatus: some View {
+        if let referenceImage {
+            HStack(spacing: 8) {
+                Text("Reference")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                Image(nsImage: referenceImage)
+                    .resizable()
+                    .interpolation(.high)
+                    .scaledToFit()
+                    .frame(width: 32, height: 22)
+                    .padding(4)
+                    .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+                    .accessibilityLabel("Captured reference icon")
+            }
+        } else {
+            Text(referenceStatusText)
+                .font(.caption)
+                .foregroundStyle(hasReference && !exactReferenceNeedsRecapture ? .green : .secondary)
+        }
+    }
+
+    private var referenceStatusText: String {
+        if exactReferenceNeedsRecapture {
+            return "Recapture required for Exact"
+        }
+        return hasReference ? "Reference captured — recapture to add preview" : "No reference yet"
+    }
+
+    private var comparisonHelp: String {
+        switch comparisonMode {
+        case .fuzzy:
+            "Fuzzy ignores small rendering differences and reveals when the icon meaningfully changes from the reference. Requires screen recording permission."
+        case .exact:
+            "Exact reveals on any pixel-content difference from the reference. Requires screen recording permission."
+        }
+    }
+
     private func capture() {
         let id = watchedID
         guard !id.isEmpty else { return }
         isCapturing = true
         Task { @MainActor in
-            let hash = await captureReference(id)
+            let reference = await captureReference(id)
             isCapturing = false
-            if let hash, watchedID == id {
-                condition = condition.withImageReferenceHash(hash)
+            if let reference, watchedID == id {
+                condition = condition.withImageReference(reference)
             }
         }
     }

--- a/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/TriggersSettingsPane.swift
@@ -886,16 +886,21 @@ private struct TriggerRow: View {
             Divider()
 
             ForEach(Array(trigger.additionalItems.indices), id: \.self) { index in
+                // Index identity shifts on removal, so SwiftUI can evaluate a
+                // row whose index no longer exists. Every access tolerates a
+                // stale index instead of trapping.
+                let currentItem = trigger.additionalItems.indices.contains(index)
+                    ? trigger.additionalItems[index]
+                    : TriggerTargetItem()
                 HStack(spacing: 8) {
                     IcePicker("Also move", selection: additionalItemBinding(index)) {
-                        let currentItem = trigger.additionalItems[index]
                         let current = currentItem.identifier
                         let resolvedItem = itemOption(
                             matching: current,
                             baseIdentifier: currentItem.baseIdentifier
                         )
                         if !current.isEmpty, resolvedItem == nil {
-                            Text("\(trigger.additionalItems[index].displayName) (not present)").tag(current)
+                            Text("\(currentItem.displayName) (not present)").tag(current)
                         } else if let resolvedItem, resolvedItem.id != current {
                             Text(resolvedItem.name).tag(current)
                         }
@@ -907,6 +912,7 @@ private struct TriggerRow: View {
                         }
                     }
                     Button(role: .destructive) {
+                        guard trigger.additionalItems.indices.contains(index) else { return }
                         trigger.additionalItems.remove(at: index)
                     } label: {
                         Image(systemName: "minus.circle")
@@ -2013,17 +2019,19 @@ private struct ImageConditionEditor: View {
 
     private var referenceStatusText: String {
         if exactReferenceNeedsRecapture {
-            return "Recapture required for Exact"
+            return String(localized: "Recapture required for Exact")
         }
-        return hasReference ? "Reference captured — recapture to add preview" : "No reference yet"
+        return hasReference
+            ? String(localized: "Reference captured — recapture to add preview")
+            : String(localized: "No reference yet")
     }
 
     private var comparisonHelp: String {
         switch comparisonMode {
         case .fuzzy:
-            "Fuzzy ignores small rendering differences and reveals when the icon meaningfully changes from the reference. Requires screen recording permission."
+            String(localized: "Fuzzy ignores small rendering differences and reveals when the icon meaningfully changes from the reference. Requires screen recording permission.")
         case .exact:
-            "Exact reveals on any pixel-content difference from the reference. Requires screen recording permission."
+            String(localized: "Exact reveals on any pixel-content difference from the reference. Requires screen recording permission.")
         }
     }
 

--- a/Thaw/Utilities/ImageHashing.swift
+++ b/Thaw/Utilities/ImageHashing.swift
@@ -62,6 +62,62 @@ enum ImageHashing {
         return hash
     }
 
+    /// Computes a stable hash of the image's exact, normalized RGBA pixels.
+    /// Unlike ``averageHash``, a one-pixel difference changes this value,
+    /// which is appropriate for the opt-in exact comparison mode.
+    static func exactHash(_ image: CGImage) -> UInt64? {
+        let width = image.width
+        let height = image.height
+        guard
+            width > 0,
+            height > 0,
+            width <= Int.max / 4
+        else {
+            return nil
+        }
+
+        let bytesPerRow = width * 4
+        guard height <= Int.max / bytesPerRow else { return nil }
+
+        var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
+        let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
+            | CGImageAlphaInfo.premultipliedLast.rawValue
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: bitmapInfo
+        ) else {
+            return nil
+        }
+        context.interpolationQuality = .none
+        context.setBlendMode(.copy)
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // FNV-1a is small, deterministic across launches, and sufficient for
+        // change detection. This is not used as a security primitive.
+        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
+        let prime: UInt64 = 0x0000_0100_0000_01B3
+
+        func combine(_ byte: UInt8) {
+            hash ^= UInt64(byte)
+            hash &*= prime
+        }
+
+        for value in [UInt64(width), UInt64(height)] {
+            for shift in stride(from: 0, to: 64, by: 8) {
+                combine(UInt8(truncatingIfNeeded: value >> UInt64(shift)))
+            }
+        }
+        for byte in pixels {
+            combine(byte)
+        }
+        return hash
+    }
+
     /// The number of differing bits between two hashes (0...64).
     static func hammingDistance(_ lhs: UInt64, _ rhs: UInt64) -> Int {
         (lhs ^ rhs).nonzeroBitCount

--- a/Thaw/Utilities/ImageHashing.swift
+++ b/Thaw/Utilities/ImageHashing.swift
@@ -82,20 +82,30 @@ enum ImageHashing {
         var pixels = [UInt8](repeating: 0, count: bytesPerRow * height)
         let bitmapInfo = CGBitmapInfo.byteOrder32Big.rawValue
             | CGImageAlphaInfo.premultipliedLast.rawValue
-        guard let context = CGContext(
-            data: &pixels,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: CGColorSpaceCreateDeviceRGB(),
-            bitmapInfo: bitmapInfo
-        ) else {
+        // The buffer is bound for the whole lifetime of the context, not just
+        // for the initializer call: `draw` writes through it afterwards. An
+        // inout-to-pointer conversion is only valid for the duration of the
+        // call it is passed to, so the pointer has to stay in scope instead.
+        let rendered = pixels.withUnsafeMutableBytes { buffer -> Bool in
+            guard let context = CGContext(
+                data: buffer.baseAddress,
+                width: width,
+                height: height,
+                bitsPerComponent: 8,
+                bytesPerRow: bytesPerRow,
+                space: CGColorSpaceCreateDeviceRGB(),
+                bitmapInfo: bitmapInfo
+            ) else {
+                return false
+            }
+            context.interpolationQuality = .none
+            context.setBlendMode(.copy)
+            context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+            return true
+        }
+        guard rendered else {
             return nil
         }
-        context.interpolationQuality = .none
-        context.setBlendMode(.copy)
-        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
 
         // FNV-1a is small, deterministic across launches, and sufficient for
         // change detection. This is not used as a security primitive.

--- a/Thaw/Utilities/SystemState.swift
+++ b/Thaw/Utilities/SystemState.swift
@@ -97,6 +97,9 @@ struct SystemState: Equatable {
     /// conditions, keyed by item tag identifier. Populated by the manager.
     var imageHashes: [String: UInt64]
 
+    /// Exact pixel hashes captured in the same pass as ``imageHashes``.
+    var exactImageHashes: [String: UInt64]
+
     /// Identifiers of items currently blinking for attention.
     var itemsSeekingAttention: Set<String>
 
@@ -121,6 +124,7 @@ struct SystemState: Equatable {
         isMicrophoneInUse: Bool = false,
         scriptOutcomes: [String: ScriptOutcome] = [:],
         imageHashes: [String: UInt64] = [:],
+        exactImageHashes: [String: UInt64] = [:],
         itemsSeekingAttention: Set<String> = []
     ) {
         self.power = power
@@ -143,6 +147,7 @@ struct SystemState: Equatable {
         self.isMicrophoneInUse = isMicrophoneInUse
         self.scriptOutcomes = scriptOutcomes
         self.imageHashes = imageHashes
+        self.exactImageHashes = exactImageHashes
         self.itemsSeekingAttention = itemsSeekingAttention
     }
 }

--- a/ThawTests/MenuBarItemTriggerTests.swift
+++ b/ThawTests/MenuBarItemTriggerTests.swift
@@ -720,9 +720,10 @@ struct MenuBarItemTriggerTests {
         #expect(ImageHashing.hammingDistance(.max, 0) == 64)
     }
 
-    @Test func averageHashIsDeterministic() {
+    @Test func averageHashIsDeterministic() throws {
         let image = makeImage(whiteColumns: 8)
-        #expect(ImageHashing.averageHash(image) == ImageHashing.averageHash(image))
+        let first = try #require(ImageHashing.averageHash(image))
+        #expect(ImageHashing.averageHash(image) == first)
     }
 
     @Test func averageHashDetectsLargeChange() throws {
@@ -731,13 +732,13 @@ struct MenuBarItemTriggerTests {
         #expect(ImageHashing.hammingDistance(mostlyBlack, mostlyWhite) > ImageHashing.changeThreshold)
     }
 
-    @Test func exactHashIsDeterministicAndPixelSensitive() {
-        let first = makeImage(whiteColumns: 8)
-        let same = makeImage(whiteColumns: 8)
-        let changed = makeImage(whiteColumns: 9)
+    @Test func exactHashIsDeterministicAndPixelSensitive() throws {
+        let first = try #require(ImageHashing.exactHash(makeImage(whiteColumns: 8)))
+        let same = try #require(ImageHashing.exactHash(makeImage(whiteColumns: 8)))
+        let changed = try #require(ImageHashing.exactHash(makeImage(whiteColumns: 9)))
 
-        #expect(ImageHashing.exactHash(first) == ImageHashing.exactHash(same))
-        #expect(ImageHashing.exactHash(first) != ImageHashing.exactHash(changed))
+        #expect(first == same)
+        #expect(first != changed)
     }
 
     @Test func imageChangedCondition() {

--- a/ThawTests/MenuBarItemTriggerTests.swift
+++ b/ThawTests/MenuBarItemTriggerTests.swift
@@ -731,6 +731,15 @@ struct MenuBarItemTriggerTests {
         #expect(ImageHashing.hammingDistance(mostlyBlack, mostlyWhite) > ImageHashing.changeThreshold)
     }
 
+    @Test func exactHashIsDeterministicAndPixelSensitive() {
+        let first = makeImage(whiteColumns: 8)
+        let same = makeImage(whiteColumns: 8)
+        let changed = makeImage(whiteColumns: 9)
+
+        #expect(ImageHashing.exactHash(first) == ImageHashing.exactHash(same))
+        #expect(ImageHashing.exactHash(first) != ImageHashing.exactHash(changed))
+    }
+
     @Test func imageChangedCondition() {
         let id = "com.apple.controlcenter:Battery"
         let reference: UInt64 = 0x0000_0000_0000_0000
@@ -747,6 +756,40 @@ struct MenuBarItemTriggerTests {
         // No reference captured -> never satisfied.
         let noRef = TriggerCondition.imageChanged(itemIdentifier: id, referenceHash: nil)
         #expect(!noRef.isSatisfied(state: changed))
+    }
+
+    @Test func exactAndFuzzyImageComparisonDifferOnSmallChanges() {
+        let id = "com.example:Status"
+        var current = state()
+        current.imageHashes = [id: 1] // One perceptual bit differs.
+        current.exactImageHashes = [id: 101]
+
+        let fuzzy = TriggerCondition.imageChanged(
+            itemIdentifier: id,
+            referenceHash: 0,
+            referenceExactHash: 100,
+            comparisonMode: .fuzzy
+        )
+        let exact = TriggerCondition.imageChanged(
+            itemIdentifier: id,
+            referenceHash: 0,
+            referenceExactHash: 100,
+            comparisonMode: .exact
+        )
+
+        #expect(!fuzzy.isSatisfied(state: current))
+        #expect(exact.isSatisfied(state: current))
+    }
+
+    @Test func exactComparisonRequiresAnExactReference() {
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: 0,
+            comparisonMode: .exact
+        )
+        var current = state()
+        current.exactImageHashes = ["item": 1]
+        #expect(!condition.isSatisfied(state: current))
     }
 
     @Test func imageChangedCodableRoundTrip() throws {
@@ -766,6 +809,54 @@ struct MenuBarItemTriggerTests {
         let decoded = try JSONDecoder().decode(TriggerCondition.self, from: data)
 
         #expect(decoded == condition)
+    }
+
+    @Test func imageComparisonSettingsCodableRoundTrip() throws {
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: 7,
+            referenceExactHash: 11,
+            comparisonMode: .exact,
+            referenceImageData: Data([1, 2, 3])
+        )
+
+        let data = try JSONEncoder().encode(condition)
+        #expect(try JSONDecoder().decode(TriggerCondition.self, from: data) == condition)
+    }
+
+    @Test func legacyImageComparisonDefaultsToFuzzyWithoutPreview() throws {
+        let data = Data(#"{"imageChanged":{"itemIdentifier":"item","referenceHash":7}}"#.utf8)
+        let decoded = try JSONDecoder().decode(TriggerCondition.self, from: data)
+
+        #expect(decoded.imageValue?.comparisonMode == .fuzzy)
+        #expect(decoded.imageValue?.referenceHash == 7)
+        #expect(decoded.imageValue?.referenceExactHash == nil)
+        #expect(decoded.imageValue?.referenceImageData == nil)
+    }
+
+    @Test func capturedReferenceAndModeArePreserved() {
+        let reference = ImageComparisonReference(
+            perceptualHash: 7,
+            exactHash: 11,
+            imageData: Data([1, 2, 3])
+        )
+        let condition = TriggerCondition.imageChanged(
+            itemIdentifier: "item",
+            referenceHash: nil,
+            comparisonMode: .exact
+        )
+        let captured = condition.withImageReference(reference)
+
+        #expect(captured.imageValue?.comparisonMode == .exact)
+        #expect(captured.imageValue?.referenceHash == 7)
+        #expect(captured.imageValue?.referenceExactHash == 11)
+        #expect(captured.imageValue?.referenceImageData == Data([1, 2, 3]))
+
+        let changedItem = captured.withImageItem("other")
+        #expect(changedItem.imageValue?.comparisonMode == .exact)
+        #expect(changedItem.imageValue?.referenceHash == nil)
+        #expect(changedItem.imageValue?.referenceExactHash == nil)
+        #expect(changedItem.imageValue?.referenceImageData == nil)
     }
 
     // MARK: - Kind / editor mapping

--- a/ThawTests/Settings/Models/TriggerConditionSurfaceTests.swift
+++ b/ThawTests/Settings/Models/TriggerConditionSurfaceTests.swift
@@ -334,12 +334,15 @@ struct TriggerConditionSurfaceTests {
         #expect(rewatched.imageValue?.itemIdentifier == "new")
         #expect(rewatched.imageValue?.referenceHash == nil)
 
-        let recaptured = base.withImageReferenceHash(123)
+        let recaptured = base.withImageReference(
+            ImageComparisonReference(perceptualHash: 123, exactHash: 0, imageData: nil)
+        )
         #expect(recaptured.imageValue?.itemIdentifier == "old")
         #expect(recaptured.imageValue?.referenceHash == 123)
 
+        let reference = ImageComparisonReference(perceptualHash: 1, exactHash: 0, imageData: nil)
         #expect(TriggerCondition.charging.withImageItem("new") == .charging)
-        #expect(TriggerCondition.charging.withImageReferenceHash(1) == .charging)
+        #expect(TriggerCondition.charging.withImageReference(reference) == .charging)
     }
 
     @Test("A location edit replaces only the fields it is given")


### PR DESCRIPTION
# Summary

Improves the image-change trigger so users can choose how icon changes are compared and can see the captured reference image in the trigger editor.

This change:

- adds **Fuzzy** comparison for meaningful visual changes while ignoring small rendering differences
- adds **Exact** comparison for any normalized pixel-content difference
- stores perceptual and exact hashes together with an optional compact reference preview
- shows the captured icon in the settings UI and explains when an older reference must be recaptured
- keeps existing saved image-change conditions compatible by treating them as Fuzzy
- adds Swift Testing coverage for hashing, comparison modes, capture updates, and Codable migration

## Dependency and release sequencing

Depends on #977.

This PR is based on the trigger implementation carried by #977 and should land with or after #977, not before it. It is intended for v2.2 or v2.3, not v2.1.

Until #977 lands in `development`, GitHub may include parts of that trigger stack in this PR's comparison.

## Related work

[48b1af69](https://github.com/thaw-app/Thaw/commit/48b1af69ec1bbcbda904fb1752e8eefe5cf53775) introduced revealing an item when its icon asks for attention and deliberately distinguished that signal from arbitrary image changes. This PR complements that behavior by improving the broader image-change condition with configurable exact/fuzzy comparison and reference previews.

## Linked issue (required)

Closes: N/A

## PR Type

- [ ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [x] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [x] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

When configuring an image-change condition, users can capture a reference icon, preview it, and choose Fuzzy or Exact comparison. Fuzzy mode ignores minor rendering noise; Exact mode reacts to any normalized pixel-content change. Existing references continue to use Fuzzy mode, while selecting Exact for an older reference prompts the user to recapture it.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected. (The app build passes; final UI behavior verification is still outstanding.)
- [x] I've run SwiftFormat lint on the touched Swift files to keep the code style consistent.
- [x] I've run the smallest relevant test commands (listed below).
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [x] This PR does not change dependencies or lockfiles.

Test commands run:

- `xcodebuild build -project Thaw.xcodeproj -scheme Thaw -destination 'generic/platform=macOS' ...` — passed
- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -only-testing:ThawTests/MenuBarItemTriggerTests -destination 'platform=macOS' ...` — the focused suite could not execute because the dependency base currently has unrelated compile errors in `MenuBarAppearanceSpaceOverrideTests.swift`
- SwiftFormat lint on all touched Swift files — passed

## Known limitations / follow-ups

- Capturing and monitoring menu bar icon images requires Screen Recording permission.
- References saved before this change do not contain an exact hash or preview; they continue to work in Fuzzy mode and must be recaptured for Exact mode or a preview.
- This PR remains a draft pending final UI verification.

## Other information

Exact comparison hashes normalized RGBA pixels and is intended only for change detection, not as a security primitive.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790709485&installation_model_id=431242&pr_number=1006&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1006&signature=9712b6895fa11426c587c0b8fdeef155ae554e5155abe281542d83d1cfe5e1e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added exact image matching alongside fuzzy image comparison for triggers.
  * Added a comparison-mode selector and reference image preview when configuring image conditions.
  * Added guidance when an exact reference needs to be recaptured.
* **Bug Fixes**
  * Improved trigger editing reliability when managing advanced “Also move” items.
  * Preserved compatibility with previously saved image-trigger settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->