### PR TITLE
feat(appearance): Thaw Bar appearance settings and multi-display icon tint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,8 @@ plans/
 # Local badge mockups
 .tmp-badge-preview/
 default.profraw
+
+# Local Debug codesign (self-signed cert copy + DerivedData)
+.local-codesign/
+Thaw-local/
+**/Thaw-local/

--- a/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV1.swift
+++ b/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV1.swift
@@ -82,6 +82,10 @@ extension MenuBarAppearanceConfigurationV2 {
             configuration.lightModeConfiguration = partialConfiguration
             configuration.darkModeConfiguration = partialConfiguration
             configuration.staticConfiguration = partialConfiguration
+            let thawBarPartial = ThawBarAppearancePartialConfiguration.migrating(from: partialConfiguration)
+            configuration.thawBarLightModeConfiguration = thawBarPartial
+            configuration.thawBarDarkModeConfiguration = thawBarPartial
+            configuration.thawBarStaticConfiguration = thawBarPartial
             configuration.shapeKind = oldConfiguration.shapeKind
             configuration.fullShapeInfo = oldConfiguration.fullShapeInfo
             configuration.splitShapeInfo = oldConfiguration.splitShapeInfo

--- a/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV2.swift
+++ b/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV2.swift
@@ -12,6 +12,12 @@ nonisolated struct MenuBarAppearanceConfigurationV2: Hashable {
     var lightModeConfiguration: MenuBarAppearancePartialConfiguration
     var darkModeConfiguration: MenuBarAppearancePartialConfiguration
     var staticConfiguration: MenuBarAppearancePartialConfiguration
+    /// Thaw Bar appearance for light mode when ``isDynamic`` is on.
+    var thawBarLightModeConfiguration: ThawBarAppearancePartialConfiguration
+    /// Thaw Bar appearance for dark mode when ``isDynamic`` is on.
+    var thawBarDarkModeConfiguration: ThawBarAppearancePartialConfiguration
+    /// Thaw Bar appearance when ``isDynamic`` is off.
+    var thawBarStaticConfiguration: ThawBarAppearancePartialConfiguration
     var shapeKind: MenuBarShapeKind
     var fullShapeInfo: MenuBarFullShapeInfo
     var splitShapeInfo: MenuBarSplitShapeInfo
@@ -42,6 +48,19 @@ nonisolated struct MenuBarAppearanceConfigurationV2: Hashable {
             staticConfiguration
         }
     }
+
+    /// The Thaw Bar partial that applies under the current system appearance.
+    @MainActor
+    var currentThawBar: ThawBarAppearancePartialConfiguration {
+        if isDynamic {
+            switch SystemAppearance.current {
+            case .light: thawBarLightModeConfiguration
+            case .dark: thawBarDarkModeConfiguration
+            }
+        } else {
+            thawBarStaticConfiguration
+        }
+    }
 }
 
 // MARK: Default Configuration
@@ -51,6 +70,9 @@ nonisolated extension MenuBarAppearanceConfigurationV2 {
         lightModeConfiguration: .defaultConfiguration,
         darkModeConfiguration: .defaultConfiguration,
         staticConfiguration: .defaultConfiguration,
+        thawBarLightModeConfiguration: .defaultConfiguration,
+        thawBarDarkModeConfiguration: .defaultConfiguration,
+        thawBarStaticConfiguration: .defaultConfiguration,
         shapeKind: .noShape,
         fullShapeInfo: .defaultValue,
         splitShapeInfo: .defaultValue,
@@ -68,6 +90,9 @@ nonisolated extension MenuBarAppearanceConfigurationV2: Codable {
         case lightModeConfiguration
         case darkModeConfiguration
         case staticConfiguration
+        case thawBarLightModeConfiguration
+        case thawBarDarkModeConfiguration
+        case thawBarStaticConfiguration
         case shapeKind
         case fullShapeInfo
         case splitShapeInfo
@@ -81,10 +106,27 @@ nonisolated extension MenuBarAppearanceConfigurationV2: Codable {
 
     init(from decoder: any Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
+        let light = try container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .lightModeConfiguration) ?? Self.defaultConfiguration.lightModeConfiguration
+        let dark = try container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .darkModeConfiguration) ?? Self.defaultConfiguration.darkModeConfiguration
+        let staticPartial = try container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .staticConfiguration) ?? Self.defaultConfiguration.staticConfiguration
+
+        // Pre-Thaw-Bar-appearance payloads have no thawBar* keys. Seed each
+        // slot from the matching menu bar partial so borders carry over and
+        // the historical black tint overlay is cleared (see migrating(from:)).
+        let thawBarLight = try container.decodeIfPresent(ThawBarAppearancePartialConfiguration.self, forKey: .thawBarLightModeConfiguration)
+            ?? .migrating(from: light)
+        let thawBarDark = try container.decodeIfPresent(ThawBarAppearancePartialConfiguration.self, forKey: .thawBarDarkModeConfiguration)
+            ?? .migrating(from: dark)
+        let thawBarStatic = try container.decodeIfPresent(ThawBarAppearancePartialConfiguration.self, forKey: .thawBarStaticConfiguration)
+            ?? .migrating(from: staticPartial)
+
         try self.init(
-            lightModeConfiguration: container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .lightModeConfiguration) ?? Self.defaultConfiguration.lightModeConfiguration,
-            darkModeConfiguration: container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .darkModeConfiguration) ?? Self.defaultConfiguration.darkModeConfiguration,
-            staticConfiguration: container.decodeIfPresent(MenuBarAppearancePartialConfiguration.self, forKey: .staticConfiguration) ?? Self.defaultConfiguration.staticConfiguration,
+            lightModeConfiguration: light,
+            darkModeConfiguration: dark,
+            staticConfiguration: staticPartial,
+            thawBarLightModeConfiguration: thawBarLight,
+            thawBarDarkModeConfiguration: thawBarDark,
+            thawBarStaticConfiguration: thawBarStatic,
             shapeKind: container.decodeIfPresent(MenuBarShapeKind.self, forKey: .shapeKind) ?? Self.defaultConfiguration.shapeKind,
             fullShapeInfo: container.decodeIfPresent(MenuBarFullShapeInfo.self, forKey: .fullShapeInfo) ?? Self.defaultConfiguration.fullShapeInfo,
             splitShapeInfo: container.decodeIfPresent(MenuBarSplitShapeInfo.self, forKey: .splitShapeInfo) ?? Self.defaultConfiguration.splitShapeInfo,
@@ -102,6 +144,9 @@ nonisolated extension MenuBarAppearanceConfigurationV2: Codable {
         try container.encode(lightModeConfiguration, forKey: .lightModeConfiguration)
         try container.encode(darkModeConfiguration, forKey: .darkModeConfiguration)
         try container.encode(staticConfiguration, forKey: .staticConfiguration)
+        try container.encode(thawBarLightModeConfiguration, forKey: .thawBarLightModeConfiguration)
+        try container.encode(thawBarDarkModeConfiguration, forKey: .thawBarDarkModeConfiguration)
+        try container.encode(thawBarStaticConfiguration, forKey: .thawBarStaticConfiguration)
         try container.encode(shapeKind, forKey: .shapeKind)
         try container.encode(fullShapeInfo, forKey: .fullShapeInfo)
         try container.encode(splitShapeInfo, forKey: .splitShapeInfo)

--- a/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
+++ b/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
@@ -1,0 +1,398 @@
+//
+//  ThawBarAppearanceConfiguration.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+// MARK: - ThawBarBackgroundKind
+
+/// How the Thaw Bar fills its panel background.
+///
+/// Independent of ``MenuBarBackgroundKind``: the menu bar paints into an
+/// overlay behind system items, while the Thaw Bar owns a freestanding panel
+/// and therefore needs its own fill model (including an adaptive sample of
+/// the live menu bar / wallpaper).
+nonisolated enum ThawBarBackgroundKind: Int, CaseIterable, Hashable, Identifiable {
+    /// System clear liquid glass — the same family of material as the menu bar,
+    /// so the panel tracks wallpaper tone instead of painting a flat sample.
+    case adaptive = 0
+    /// A solid color fill.
+    case solid = 1
+    /// A gradient fill.
+    case gradient = 2
+    /// System liquid glass with a configurable Regular / Clear style.
+    case glass = 3
+    /// No fill; only tint, border, and shadow (if enabled) remain visible.
+    case none = 4
+    /// Flat average of the menu bar / wallpaper strip. Looks darker than the
+    /// real menu bar because it has no translucency; kept for users who want
+    /// an opaque matched swatch.
+    case sampled = 5
+
+    var id: Int { rawValue }
+
+    var localized: LocalizedStringKey {
+        switch self {
+        case .adaptive: "Match Menu Bar"
+        case .solid: "Solid"
+        case .gradient: "Gradient"
+        case .glass: "Glass"
+        case .none: "None"
+        case .sampled: "Sampled Color"
+        }
+    }
+
+    /// Whether this kind always draws through SwiftUI liquid glass.
+    /// Match Menu Bar opts in separately via ``ThawBarAppearancePartialConfiguration/adaptiveGlassAmount``.
+    var usesLiquidGlass: Bool {
+        switch self {
+        case .glass: true
+        case .adaptive, .solid, .gradient, .none, .sampled: false
+        }
+    }
+}
+
+nonisolated extension ThawBarBackgroundKind: Codable {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Int.self)
+        guard let value = ThawBarBackgroundKind(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ThawBarBackgroundKind: \(rawValue)"
+            )
+        }
+        self = value
+    }
+}
+
+// MARK: - ThawBarCornerStyle
+
+/// Corner treatment for the Thaw Bar panel, independent of the menu bar shape.
+nonisolated enum ThawBarCornerStyle: Int, CaseIterable, Hashable, Identifiable {
+    /// Capsule ends (fully rounded).
+    case rounded = 0
+    /// Squared ends with a small continuous radius.
+    case square = 1
+
+    var id: Int { rawValue }
+
+    var localized: LocalizedStringKey {
+        switch self {
+        case .rounded: "Rounded"
+        case .square: "Square"
+        }
+    }
+
+    /// Whether this style uses the pill (fully rounded) clip path.
+    var isFullyRounded: Bool {
+        switch self {
+        case .rounded: true
+        case .square: false
+        }
+    }
+}
+
+nonisolated extension ThawBarCornerStyle: Codable {
+    init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(Int.self)
+        guard let value = ThawBarCornerStyle(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ThawBarCornerStyle: \(rawValue)"
+            )
+        }
+        self = value
+    }
+}
+
+// MARK: - ThawBarAppearancePartialConfiguration
+
+/// Appearance knobs that apply to the Thaw Bar for one appearance mode
+/// (static, light, or dark).
+nonisolated struct ThawBarAppearancePartialConfiguration: Hashable {
+    var backgroundKind: ThawBarBackgroundKind
+    var backgroundColor: CGColor
+    var backgroundGradient: IceGradient
+    /// Opacity applied to solid, gradient, and sampled fills (`0...1`).
+    var backgroundOpacity: Double
+    var backgroundGlassStyle: MenuBarGlassStyle
+
+    /// Brightness offset for Match Menu Bar fills (`-1...1`, `0` = as sampled).
+    /// Positive values mix toward white; negative values mix toward black.
+    var adaptiveBrightness: Double
+    /// Liquid-glass blend for Match Menu Bar (`0...1`, `0` = opaque sample only).
+    var adaptiveGlassAmount: Double
+
+    var tintKind: MenuBarTintKind
+    var tintColor: CGColor
+    var tintGradient: IceGradient
+    /// Opacity applied to solid and gradient tints (`0...1`).
+    var tintOpacity: Double
+
+    var cornerStyle: ThawBarCornerStyle
+
+    var hasBorder: Bool
+    var borderColor: CGColor
+    var borderWidth: Double
+    /// When the corners are square, skip the top edge of the border so the
+    /// stroke is not clipped by the display's rounded corners (#325).
+    var omitTopBorderWhenSquare: Bool
+
+    /// Whether the panel window draws its native drop shadow.
+    var hasShadow: Bool
+}
+
+// MARK: Default
+
+nonisolated extension ThawBarAppearancePartialConfiguration {
+    /// Defaults chosen so a fresh install matches the system menu bar tone
+    /// via clear liquid glass (same material family as the menu bar).
+    static let defaultConfiguration = ThawBarAppearancePartialConfiguration(
+        backgroundKind: .adaptive,
+        backgroundColor: .black,
+        backgroundGradient: .defaultMenuBarTint,
+        backgroundOpacity: 1,
+        backgroundGlassStyle: .clear,
+        adaptiveBrightness: 0,
+        adaptiveGlassAmount: 0,
+        tintKind: .noTint,
+        tintColor: .black,
+        tintGradient: .defaultMenuBarTint,
+        tintOpacity: 0.2,
+        cornerStyle: .rounded,
+        hasBorder: false,
+        borderColor: .black,
+        borderWidth: 1,
+        omitTopBorderWhenSquare: true,
+        hasShadow: true
+    )
+
+    /// Builds a Thaw Bar partial from a pre-split menu bar partial that still
+    /// carried `borderOnThawBar` / shared tint. Match-menu-bar glass + migrated
+    /// border; tint defaults to none so upgrading clears the historical black
+    /// overlay that made the bar look darker than the menu bar.
+    static func migrating(from menuBarPartial: MenuBarAppearancePartialConfiguration) -> ThawBarAppearancePartialConfiguration {
+        ThawBarAppearancePartialConfiguration(
+            backgroundKind: .adaptive,
+            backgroundColor: menuBarPartial.backgroundColor,
+            backgroundGradient: menuBarPartial.backgroundGradient,
+            backgroundOpacity: 1,
+            backgroundGlassStyle: .clear,
+            adaptiveBrightness: 0,
+            adaptiveGlassAmount: 0,
+            tintKind: .noTint,
+            tintColor: menuBarPartial.tintColor,
+            tintGradient: menuBarPartial.tintGradient,
+            tintOpacity: menuBarPartial.tintOpacity,
+            cornerStyle: .rounded,
+            hasBorder: menuBarPartial.borderOnThawBar,
+            borderColor: menuBarPartial.borderColor,
+            borderWidth: menuBarPartial.borderWidth,
+            omitTopBorderWhenSquare: true,
+            hasShadow: true
+        )
+    }
+}
+
+// MARK: Codable
+
+nonisolated extension ThawBarAppearancePartialConfiguration: Codable {
+    private enum CodingKeys: CodingKey {
+        case backgroundKind
+        case backgroundColor
+        case backgroundGradient
+        case backgroundOpacity
+        case backgroundGlassStyle
+        case adaptiveBrightness
+        case adaptiveGlassAmount
+        case tintKind
+        case tintColor
+        case tintGradient
+        case tintOpacity
+        case cornerStyle
+        case hasBorder
+        case borderColor
+        case borderWidth
+        case omitTopBorderWhenSquare
+        case hasShadow
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let defaults = Self.defaultConfiguration
+        try self.init(
+            backgroundKind: container.decodeIfPresent(ThawBarBackgroundKind.self, forKey: .backgroundKind) ?? defaults.backgroundKind,
+            backgroundColor: container.decodeIfPresent(IceColor.self, forKey: .backgroundColor)?.cgColor ?? defaults.backgroundColor,
+            backgroundGradient: container.decodeIfPresent(IceGradient.self, forKey: .backgroundGradient) ?? defaults.backgroundGradient,
+            backgroundOpacity: container.decodeIfPresent(Double.self, forKey: .backgroundOpacity) ?? defaults.backgroundOpacity,
+            backgroundGlassStyle: container.decodeIfPresent(MenuBarGlassStyle.self, forKey: .backgroundGlassStyle) ?? defaults.backgroundGlassStyle,
+            adaptiveBrightness: container.decodeIfPresent(Double.self, forKey: .adaptiveBrightness) ?? defaults.adaptiveBrightness,
+            adaptiveGlassAmount: container.decodeIfPresent(Double.self, forKey: .adaptiveGlassAmount) ?? defaults.adaptiveGlassAmount,
+            tintKind: container.decodeIfPresent(MenuBarTintKind.self, forKey: .tintKind) ?? defaults.tintKind,
+            tintColor: container.decodeIfPresent(IceColor.self, forKey: .tintColor)?.cgColor ?? defaults.tintColor,
+            tintGradient: container.decodeIfPresent(IceGradient.self, forKey: .tintGradient) ?? defaults.tintGradient,
+            tintOpacity: container.decodeIfPresent(Double.self, forKey: .tintOpacity) ?? defaults.tintOpacity,
+            cornerStyle: container.decodeIfPresent(ThawBarCornerStyle.self, forKey: .cornerStyle) ?? defaults.cornerStyle,
+            hasBorder: container.decodeIfPresent(Bool.self, forKey: .hasBorder) ?? defaults.hasBorder,
+            borderColor: container.decodeIfPresent(IceColor.self, forKey: .borderColor)?.cgColor ?? defaults.borderColor,
+            borderWidth: container.decodeIfPresent(Double.self, forKey: .borderWidth) ?? defaults.borderWidth,
+            omitTopBorderWhenSquare: container.decodeIfPresent(Bool.self, forKey: .omitTopBorderWhenSquare) ?? defaults.omitTopBorderWhenSquare,
+            hasShadow: container.decodeIfPresent(Bool.self, forKey: .hasShadow) ?? defaults.hasShadow
+        )
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(backgroundKind, forKey: .backgroundKind)
+        try container.encode(IceColor(cgColor: backgroundColor), forKey: .backgroundColor)
+        try container.encode(backgroundGradient, forKey: .backgroundGradient)
+        try container.encode(backgroundOpacity, forKey: .backgroundOpacity)
+        try container.encode(backgroundGlassStyle, forKey: .backgroundGlassStyle)
+        try container.encode(adaptiveBrightness, forKey: .adaptiveBrightness)
+        try container.encode(adaptiveGlassAmount, forKey: .adaptiveGlassAmount)
+        try container.encode(tintKind, forKey: .tintKind)
+        try container.encode(IceColor(cgColor: tintColor), forKey: .tintColor)
+        try container.encode(tintGradient, forKey: .tintGradient)
+        try container.encode(tintOpacity, forKey: .tintOpacity)
+        try container.encode(cornerStyle, forKey: .cornerStyle)
+        try container.encode(hasBorder, forKey: .hasBorder)
+        try container.encode(IceColor(cgColor: borderColor), forKey: .borderColor)
+        try container.encode(borderWidth, forKey: .borderWidth)
+        try container.encode(omitTopBorderWhenSquare, forKey: .omitTopBorderWhenSquare)
+        try container.encode(hasShadow, forKey: .hasShadow)
+    }
+}
+
+// MARK: - Effective fill helpers
+
+nonisolated extension ThawBarAppearancePartialConfiguration {
+    /// Whether the top edge of the border should be omitted for the current
+    /// corner style and omit-top preference (#325).
+    var shouldOmitTopBorder: Bool {
+        hasBorder && !cornerStyle.isFullyRounded && omitTopBorderWhenSquare
+    }
+
+    /// Whether liquid glass should be applied for the current fill settings.
+    var appliesLiquidGlass: Bool {
+        switch backgroundKind {
+        case .glass:
+            true
+        case .adaptive:
+            adaptiveGlassAmount > 0
+        case .solid, .gradient, .none, .sampled:
+            false
+        }
+    }
+
+    /// Corner radius for the clip path given the bar's content height.
+    func cornerRadius(contentHeight: CGFloat) -> CGFloat {
+        switch cornerStyle {
+        case .rounded:
+            contentHeight / 2
+        case .square:
+            contentHeight / 4
+        }
+    }
+
+    /// Match Menu Bar fill opacity: higher glass amount lets more liquid glass show.
+    var adaptiveFillOpacity: Double {
+        max(0.12, 1 - adaptiveGlassAmount * 0.88)
+    }
+
+    /// Sampled color with ``adaptiveBrightness`` applied (Match Menu Bar).
+    func brightnessAdjustedSample(from color: CGColor) -> CGColor {
+        Self.adjustingBrightness(of: color, by: adaptiveBrightness) ?? color
+    }
+
+    /// Resolved fill color used for icon contrast when a concrete color is
+    /// available (sampled strip, solid, or a representative gradient stop).
+    func resolvedFillColor(sampled: CGColor?) -> CGColor? {
+        switch backgroundKind {
+        case .adaptive:
+            sampled.map { brightnessAdjustedSample(from: $0) }
+        case .glass, .none, .sampled:
+            sampled
+        case .solid:
+            backgroundColor
+        case .gradient:
+            // Avoid ``IceGradient/averageColor`` here: that API is `@MainActor`
+            // because it renders through AppKit. A middle stop is enough for
+            // icon contrast decisions from nonisolated configuration code.
+            representativeGradientColor ?? backgroundColor
+        }
+    }
+
+    /// A representative stop color from ``backgroundGradient`` for contrast.
+    private var representativeGradientColor: CGColor? {
+        guard !backgroundGradient.stops.isEmpty else { return nil }
+        let sorted = backgroundGradient.stops.sorted { $0.location < $1.location }
+        return sorted[sorted.count / 2].color
+    }
+
+    /// Whether icon glyphs should render dark on top of the resolved fill.
+    ///
+    /// Takes precomputed notch / brightness inputs so this stays usable from
+    /// `nonisolated` configuration code without touching `NSScreen`.
+    func prefersDarkForeground(
+        sampledColor: CGColor?,
+        sampledBrightness: CGFloat?,
+        screenHasNotch: Bool
+    ) -> Bool {
+        let threshold = screenHasNotch
+            ? Constants.notchedDisplayBrightnessThreshold
+            : Constants.menuBarBrightnessThreshold
+        if let fill = resolvedFillColor(sampled: sampledColor) {
+            let brightness = Self.relativeLuminance(of: fill) ?? sampledBrightness ?? 0
+            return brightness > threshold
+        }
+        return (sampledBrightness ?? 0) > threshold
+    }
+
+    /// Mixes `color` toward white (`amount > 0`) or black (`amount < 0`).
+    /// `amount` is clamped to `-1...1`; `0` returns the original color.
+    static func adjustingBrightness(of color: CGColor, by amount: Double) -> CGColor? {
+        let clamped = min(max(amount, -1), 1)
+        guard clamped != 0 else { return color }
+        guard
+            let rgb = color.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil),
+            let components = rgb.components,
+            components.count >= 3
+        else {
+            return nil
+        }
+        let alpha = components.count > 3 ? components[3] : 1
+        let r: CGFloat
+        let g: CGFloat
+        let b: CGFloat
+        if clamped > 0 {
+            let t = CGFloat(clamped)
+            r = components[0] + (1 - components[0]) * t
+            g = components[1] + (1 - components[1]) * t
+            b = components[2] + (1 - components[2]) * t
+        } else {
+            let t = CGFloat(1 + clamped)
+            r = components[0] * t
+            g = components[1] * t
+            b = components[2] * t
+        }
+        return CGColor(colorSpace: CGColorSpaceCreateDeviceRGB(), components: [r, g, b, alpha])
+    }
+
+    /// W3C relative luminance for an sRGB-ish color, computed without the
+    /// MainActor-bound ``CGColor/brightness`` helper.
+    private static func relativeLuminance(of color: CGColor) -> CGFloat? {
+        guard
+            let rgb = color.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil),
+            let components = rgb.components,
+            components.count >= 3
+        else {
+            return nil
+        }
+        return ((components[0] * 299) + (components[1] * 587) + (components[2] * 114)) / 1000
+    }
+}

--- a/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
+++ b/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
@@ -311,19 +311,26 @@ nonisolated extension ThawBarAppearancePartialConfiguration {
 
     /// Resolved fill color used for icon contrast when a concrete color is
     /// available (sampled strip, solid, or a representative gradient stop).
+    ///
+    /// Translucent fills are composited over ``sampled`` with the same opacity
+    /// ``ThawBarChrome`` paints, so glyph contrast tracks the visible panel
+    /// rather than the full-opacity source color.
     func resolvedFillColor(sampled: CGColor?) -> CGColor? {
         switch backgroundKind {
         case .adaptive:
-            sampled.map { brightnessAdjustedSample(from: $0) }
+            guard let sampled else { return nil }
+            let fill = brightnessAdjustedSample(from: sampled)
+            return Self.compositing(fill, over: sampled, opacity: adaptiveFillOpacity)
         case .glass, .none, .sampled:
-            sampled
+            return sampled
         case .solid:
-            backgroundColor
+            return Self.compositing(backgroundColor, over: sampled, opacity: backgroundOpacity)
         case .gradient:
             // Avoid ``IceGradient/averageColor`` here: that API is `@MainActor`
-            // because it renders through AppKit. A middle stop is enough for
-            // icon contrast decisions from nonisolated configuration code.
-            representativeGradientColor ?? backgroundColor
+            // because it renders through AppKit. A middle-stop blend is enough
+            // for icon contrast decisions from nonisolated configuration code.
+            let fill = representativeGradientColor ?? backgroundColor
+            return Self.compositing(fill, over: sampled, opacity: backgroundOpacity)
         }
     }
 
@@ -369,6 +376,15 @@ nonisolated extension ThawBarAppearancePartialConfiguration {
         let bl = ca[2] + (cb[2] - ca[2]) * clamped
         let alpha = aa + (ab - aa) * clamped
         return CGColor(colorSpace: CGColorSpaceCreateDeviceRGB(), components: [r, g, bl, alpha])
+    }
+
+    /// Paints `fill` at `opacity` over an opaque `underlay`, matching SwiftUI
+    /// `.opacity` compositing for contrast decisions.
+    private static func compositing(_ fill: CGColor, over underlay: CGColor?, opacity: Double) -> CGColor {
+        let clamped = min(max(opacity, 0), 1)
+        if clamped >= 1 { return fill }
+        guard let underlay else { return fill }
+        return blend(underlay, fill, t: clamped) ?? fill
     }
 
     /// Whether icon glyphs should render dark on top of the resolved fill.

--- a/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
+++ b/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
@@ -327,11 +327,48 @@ nonisolated extension ThawBarAppearancePartialConfiguration {
         }
     }
 
-    /// A representative stop color from ``backgroundGradient`` for contrast.
+    /// A representative color from ``backgroundGradient`` for contrast,
+    /// interpolated at location `0.5` when neighboring stops exist.
     private var representativeGradientColor: CGColor? {
         guard !backgroundGradient.stops.isEmpty else { return nil }
         let sorted = backgroundGradient.stops.sorted { $0.location < $1.location }
-        return sorted[sorted.count / 2].color
+        if sorted.count == 1 {
+            return sorted[0].color
+        }
+        if let exact = sorted.first(where: { abs($0.location - 0.5) < 0.000_1 }) {
+            return exact.color
+        }
+        guard
+            let lower = sorted.last(where: { $0.location <= 0.5 }),
+            let upper = sorted.first(where: { $0.location >= 0.5 })
+        else {
+            return sorted[sorted.count / 2].color
+        }
+        if lower.location == upper.location {
+            return lower.color
+        }
+        let t = (0.5 - lower.location) / (upper.location - lower.location)
+        return Self.blend(lower.color, upper.color, t: t) ?? lower.color
+    }
+
+    /// Linear blend of two device-RGB colors.
+    private static func blend(_ a: CGColor, _ b: CGColor, t: Double) -> CGColor? {
+        guard
+            let rgbA = a.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil),
+            let rgbB = b.converted(to: CGColorSpaceCreateDeviceRGB(), intent: .defaultIntent, options: nil),
+            let ca = rgbA.components, ca.count >= 3,
+            let cb = rgbB.components, cb.count >= 3
+        else {
+            return nil
+        }
+        let clamped = min(max(t, 0), 1)
+        let aa = ca.count > 3 ? ca[3] : 1
+        let ab = cb.count > 3 ? cb[3] : 1
+        let r = ca[0] + (cb[0] - ca[0]) * clamped
+        let g = ca[1] + (cb[1] - ca[1]) * clamped
+        let bl = ca[2] + (cb[2] - ca[2]) * clamped
+        let alpha = aa + (ab - aa) * clamped
+        return CGColor(colorSpace: CGColorSpaceCreateDeviceRGB(), components: [r, g, bl, alpha])
     }
 
     /// Whether icon glyphs should render dark on top of the resolved fill.

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
@@ -98,9 +98,13 @@ struct MenuBarAppearanceEditor: View {
                 }
             }
 
+            ThawBarAppearanceEditorSection(configuration: $appearanceManager.configuration)
+
             if appearanceManager.configuration.current.tintKind != .noTint
                 || appearanceManager.configuration.shapeKind != .noShape
                 || appearanceManager.configuration.current.backgroundKind != .none
+                || appearanceManager.configuration.currentThawBar.backgroundKind != .none
+                || appearanceManager.configuration.currentThawBar.tintKind != .noTint
             {
                 if appearanceManager.isReduceTransparencyEnabled {
                     reduceTransparencyWarning
@@ -466,21 +470,20 @@ private struct UnlabeledShapeEditor: View {
     }
 
     private var borderToggle: some View {
-        LabeledContent("Border") {
-            HStack {
-                Toggle("Menu Bar", isOn: $configuration.borderOnMenuBar)
-                    .disabled(shapeKind == .noShape)
-
-                Toggle("\(Constants.displayName) Bar", isOn: $configuration.borderOnThawBar)
+        Toggle("Border", isOn: $configuration.borderOnMenuBar)
+            .disabled(shapeKind == .noShape)
+            .annotation {
+                if shapeKind == .noShape {
+                    Text("Choose a shape kind to draw a border around the menu bar shape. The \(Constants.displayName) Bar has its own border setting below.")
+                } else {
+                    Text("Draws a border around the menu bar shape. The \(Constants.displayName) Bar has its own border setting in the \(Constants.displayName) Bar section.")
+                }
             }
-            .toggleStyle(.checkbox)
-            .frame(height: 24)
-        }
     }
 
     @ViewBuilder
     private var borderColor: some View {
-        if configuration.hasBorder {
+        if configuration.borderOnMenuBar {
             ColorPicker(
                 "Border Color",
                 selection: $configuration.borderColor,
@@ -491,7 +494,7 @@ private struct UnlabeledShapeEditor: View {
 
     @ViewBuilder
     private var borderWidth: some View {
-        if configuration.hasBorder {
+        if configuration.borderOnMenuBar {
             IcePicker(
                 "Border Width",
                 selection: $configuration.borderWidth

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
@@ -203,7 +203,6 @@ private final class MenuBarAppearanceEditorHostingController: NSHostingControlle
             return
         }
         let configuration = appState.appearanceManager.configuration
-        let thawBar = configuration.currentThawBar
         let baseHeight: CGFloat = configuration.isDynamic ? 980 : 780
         let shapeBonus: CGFloat = configuration.shapeKind == .noShape ? 0 : 105
         let headingBonus: CGFloat = 32
@@ -220,33 +219,42 @@ private final class MenuBarAppearanceEditorHostingController: NSHostingControlle
             return height
         }()
         let thawBarBonus: CGFloat = {
-            var height: CGFloat = 0
-            switch thawBar.backgroundKind {
-            case .adaptive:
-                height += 72 // brightness + glass
-            case .solid, .gradient, .sampled:
-                height += 36 // background opacity
-            case .glass:
-                height += 36 // glass style
-            case .none:
-                break
+            // Dynamic mode renders light and dark Thaw Bar editors together.
+            if configuration.isDynamic {
+                return thawBarEditorHeightBonus(for: configuration.thawBarLightModeConfiguration)
+                    + thawBarEditorHeightBonus(for: configuration.thawBarDarkModeConfiguration)
             }
-            if thawBar.tintKind != .noTint {
-                height += 36 // tint opacity
-            }
-            if thawBar.hasBorder {
-                height += 80 // border color + width
-                if !thawBar.cornerStyle.isFullyRounded {
-                    height += 48 // omit top border
-                }
-            }
-            return height
+            return thawBarEditorHeightBonus(for: configuration.currentThawBar)
         }()
         preferredContentSize = NSSize(
             width: 525,
             height: baseHeight + shapeBonus + headingBonus + tintOpacityBonus + backgroundBonus + thawBarBonus
         )
         view.setFrameSize(preferredContentSize)
+    }
+
+    private func thawBarEditorHeightBonus(for thawBar: ThawBarAppearancePartialConfiguration) -> CGFloat {
+        var height: CGFloat = 0
+        switch thawBar.backgroundKind {
+        case .adaptive:
+            height += 72 // brightness + glass
+        case .solid, .gradient, .sampled:
+            height += 36 // background opacity
+        case .glass:
+            height += 36 // glass style
+        case .none:
+            break
+        }
+        if thawBar.tintKind != .noTint {
+            height += 36 // tint opacity
+        }
+        if thawBar.hasBorder {
+            height += 80 // border color + width
+            if !thawBar.cornerStyle.isFullyRounded {
+                height += 48 // omit top border
+            }
+        }
+        return height
     }
 }
 

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
@@ -199,11 +199,12 @@ private final class MenuBarAppearanceEditorHostingController: NSHostingControlle
 
     func updatePreferredContentSize() {
         guard let appState else {
-            preferredContentSize = NSSize(width: 525, height: 745)
+            preferredContentSize = NSSize(width: 525, height: 980)
             return
         }
         let configuration = appState.appearanceManager.configuration
-        let baseHeight: CGFloat = configuration.isDynamic ? 755 : 555
+        let thawBar = configuration.currentThawBar
+        let baseHeight: CGFloat = configuration.isDynamic ? 980 : 780
         let shapeBonus: CGFloat = configuration.shapeKind == .noShape ? 0 : 105
         let headingBonus: CGFloat = 32
         let tintOpacityBonus: CGFloat = {
@@ -218,7 +219,33 @@ private final class MenuBarAppearanceEditorHostingController: NSHostingControlle
             }
             return height
         }()
-        preferredContentSize = NSSize(width: 525, height: baseHeight + shapeBonus + headingBonus + tintOpacityBonus + backgroundBonus)
+        let thawBarBonus: CGFloat = {
+            var height: CGFloat = 0
+            switch thawBar.backgroundKind {
+            case .adaptive:
+                height += 72 // brightness + glass
+            case .solid, .gradient, .sampled:
+                height += 36 // background opacity
+            case .glass:
+                height += 36 // glass style
+            case .none:
+                break
+            }
+            if thawBar.tintKind != .noTint {
+                height += 36 // tint opacity
+            }
+            if thawBar.hasBorder {
+                height += 80 // border color + width
+                if !thawBar.cornerStyle.isFullyRounded {
+                    height += 48 // omit top border
+                }
+            }
+            return height
+        }()
+        preferredContentSize = NSSize(
+            width: 525,
+            height: baseHeight + shapeBonus + headingBonus + tintOpacityBonus + backgroundBonus + thawBarBonus
+        )
         view.setFrameSize(preferredContentSize)
     }
 }

--- a/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/ThawBarAppearanceEditor.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/ThawBarAppearanceEditor.swift
@@ -1,0 +1,301 @@
+//
+//  ThawBarAppearanceEditor.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+// MARK: - Thaw Bar section host
+
+/// Appearance controls for the Thaw Bar panel (background, tint, corners,
+/// border, shadow), shown inside ``MenuBarAppearanceEditor``.
+struct ThawBarAppearanceEditorSection: View {
+    @Binding var configuration: MenuBarAppearanceConfigurationV2
+
+    var body: some View {
+        if configuration.isDynamic {
+            LabeledThawBarEditor(configuration: $configuration, appearance: .light)
+            LabeledThawBarEditor(configuration: $configuration, appearance: .dark)
+        } else {
+            IceSection("\(Constants.displayName) Bar") {
+                UnlabeledThawBarEditor(configuration: $configuration.thawBarStaticConfiguration)
+            }
+        }
+    }
+}
+
+// MARK: - Labeled (dynamic) editors
+
+private struct LabeledThawBarEditor: View {
+    @Binding var configuration: MenuBarAppearanceConfigurationV2
+    @State private var textFrame = CGRect.zero
+
+    let appearance: SystemAppearance
+
+    var body: some View {
+        IceSection(isBordered: false) {
+            labelStack
+        } content: {
+            UnlabeledThawBarEditor(configuration: binding)
+        }
+    }
+
+    private var labelStack: some View {
+        Text(
+            appearance == .light
+                ? "\(Constants.displayName) Bar - Light Appearance"
+                : "\(Constants.displayName) Bar - Dark Appearance"
+        )
+        .font(.headline)
+        .onFrameChange(update: $textFrame)
+        .frame(height: textFrame.height)
+    }
+
+    private var binding: Binding<ThawBarAppearancePartialConfiguration> {
+        switch appearance {
+        case .light: $configuration.thawBarLightModeConfiguration
+        case .dark: $configuration.thawBarDarkModeConfiguration
+        }
+    }
+}
+
+// MARK: - Unlabeled editor body
+
+private struct UnlabeledThawBarEditor: View {
+    @Binding var configuration: ThawBarAppearancePartialConfiguration
+
+    /// Tint kinds that apply to a freestanding panel. Glass tint is reserved
+    /// for the menu bar overlay; the Thaw Bar uses glass as a background kind.
+    private static let tintKinds: [MenuBarTintKind] = [
+        .noTint, .solid, .gradient, .adaptive,
+    ]
+
+    var body: some View {
+        backgroundPicker
+        if configuration.backgroundKind == .adaptive {
+            adaptiveBrightness
+            adaptiveGlass
+        }
+        if configuration.backgroundKind == .solid || configuration.backgroundKind == .gradient || configuration.backgroundKind == .sampled {
+            backgroundOpacity
+        }
+        if configuration.backgroundKind == .glass {
+            backgroundGlassStyle
+        }
+
+        tintPicker
+        if configuration.tintKind != .noTint {
+            tintOpacity
+        }
+
+        cornerStylePicker
+
+        Toggle("Shadow", isOn: $configuration.hasShadow)
+
+        Toggle("Border", isOn: $configuration.hasBorder)
+        if configuration.hasBorder {
+            borderColor
+            borderWidth
+            if !configuration.cornerStyle.isFullyRounded {
+                omitTopBorderToggle
+            }
+        }
+    }
+
+    // MARK: Background
+
+    private var backgroundPicker: some View {
+        LabeledContent("Background") {
+            HStack {
+                IcePicker("Background", selection: $configuration.backgroundKind) {
+                    ForEach(ThawBarBackgroundKind.allCases) { kind in
+                        Text(kind.localized).tag(kind)
+                    }
+                }
+                .labelsHidden()
+
+                switch configuration.backgroundKind {
+                case .none, .adaptive, .glass, .sampled:
+                    EmptyView()
+                case .solid:
+                    ColorPicker(
+                        "Background",
+                        selection: $configuration.backgroundColor,
+                        supportsOpacity: false
+                    )
+                    .labelsHidden()
+                case .gradient:
+                    IceGradientPicker(
+                        "Background",
+                        gradient: $configuration.backgroundGradient,
+                        supportsOpacity: false
+                    )
+                    .labelsHidden()
+                }
+            }
+            .frame(height: 24)
+        }
+        .annotation {
+            switch configuration.backgroundKind {
+            case .adaptive:
+                Text("Live-samples the menu bar and wallpaper. Use Brightness and Glass to fine-tune the match.")
+            case .solid:
+                Text("Fills the bar with a single color.")
+            case .gradient:
+                Text("Fills the bar with a gradient.")
+            case .glass:
+                Text("System liquid glass. Clear shows whatever is behind the bar; Regular is thicker.")
+            case .none:
+                Text("No fill. Tint, border, and shadow still apply if enabled.")
+            case .sampled:
+                Text("Same live sample as Match Menu Bar, with an opacity slider.")
+            }
+        }
+    }
+
+    private var adaptiveBrightness: some View {
+        LabeledContent("Brightness") {
+            IceSlider(
+                value: $configuration.adaptiveBrightness,
+                in: -1 ... 1,
+                step: 0.05,
+                showsValue: false
+            ) {
+                Text(configuration.adaptiveBrightness, format: .percent.precision(.fractionLength(0)))
+            }
+        }
+    }
+
+    private var adaptiveGlass: some View {
+        LabeledContent("Glass") {
+            IceSlider(
+                value: $configuration.adaptiveGlassAmount,
+                in: 0 ... 1,
+                step: 0.05,
+                showsValue: false
+            ) {
+                Text(configuration.adaptiveGlassAmount, format: .percent.precision(.fractionLength(0)))
+            }
+        }
+    }
+
+    private var backgroundOpacity: some View {
+        LabeledContent("Background Opacity") {
+            IceSlider(
+                value: $configuration.backgroundOpacity,
+                in: 0 ... 1,
+                step: 0.05,
+                showsValue: false
+            ) {
+                Text(configuration.backgroundOpacity, format: .percent.precision(.fractionLength(0)))
+            }
+        }
+    }
+
+    private var backgroundGlassStyle: some View {
+        LabeledContent("Glass Style") {
+            IcePicker("Glass Style", selection: $configuration.backgroundGlassStyle) {
+                ForEach(MenuBarGlassStyle.allCases, id: \.self) { style in
+                    Text(style.localized).tag(style)
+                }
+            }
+            .labelsHidden()
+        }
+    }
+
+    // MARK: Tint
+
+    private var tintPicker: some View {
+        LabeledContent("Tint") {
+            HStack {
+                IcePicker("Tint", selection: $configuration.tintKind) {
+                    ForEach(Self.tintKinds, id: \.self) { tintKind in
+                        Text(tintKind.localized).tag(tintKind)
+                    }
+                }
+                .labelsHidden()
+
+                switch configuration.tintKind {
+                case .noTint, .glass, .adaptive:
+                    EmptyView()
+                case .solid:
+                    ColorPicker(
+                        "Tint",
+                        selection: $configuration.tintColor,
+                        supportsOpacity: false
+                    )
+                    .labelsHidden()
+                case .gradient:
+                    IceGradientPicker(
+                        "Tint",
+                        gradient: $configuration.tintGradient,
+                        supportsOpacity: false
+                    )
+                    .labelsHidden()
+                }
+            }
+            .frame(height: 24)
+        }
+        .annotation("Optional overlay on top of the background. Leave as None to match the sampled menu bar color.")
+    }
+
+    private var tintOpacity: some View {
+        LabeledContent("Tint Opacity") {
+            IceSlider(
+                value: $configuration.tintOpacity,
+                in: 0 ... 1,
+                step: 0.05,
+                showsValue: false
+            ) {
+                Text(configuration.tintOpacity, format: .percent.precision(.fractionLength(0)))
+            }
+        }
+    }
+
+    // MARK: Corners & border
+
+    private var cornerStylePicker: some View {
+        LabeledContent("Corners") {
+            IcePicker("Corners", selection: $configuration.cornerStyle) {
+                ForEach(ThawBarCornerStyle.allCases) { style in
+                    Text(style.localized).tag(style)
+                }
+            }
+            .labelsHidden()
+        }
+        .annotation {
+            switch configuration.cornerStyle {
+            case .rounded:
+                Text("Fully rounded capsule ends.")
+            case .square:
+                Text("Squared ends. With a border, the top edge is omitted by default so it is not clipped by the display corners.")
+            }
+        }
+    }
+
+    private var borderColor: some View {
+        ColorPicker(
+            "Border Color",
+            selection: $configuration.borderColor,
+            supportsOpacity: true
+        )
+    }
+
+    private var borderWidth: some View {
+        IcePicker(
+            "Border Width",
+            selection: $configuration.borderWidth
+        ) {
+            Text(verbatim: "1").tag(1.0)
+            Text(verbatim: "2").tag(2.0)
+            Text(verbatim: "3").tag(3.0)
+        }
+    }
+
+    private var omitTopBorderToggle: some View {
+        Toggle("Omit top border edge", isOn: $configuration.omitTopBorderWhenSquare)
+            .annotation("Hides the top stroke so square corners are not clipped by the display's rounded corners.")
+    }
+}

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -34,11 +34,19 @@ final class IceBarPanel: NSPanel {
     /// change posts that notification, racing with the show).
     private var lastShowTimestamp: Date?
 
+    /// Display the Thaw Bar was last shown on. Cross-screen opens must drop
+    /// the previous screen's icon captures (light/dark tint is baked in).
+    private var lastShownDisplayID: CGDirectDisplayID?
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
     /// Background cache task started when the panel is shown.
     private var cacheTask: Task<Void, Never>?
+
+    /// Keeps ``hasShadow`` aligned with the Thaw Bar appearance setting while
+    /// the panel is visible.
+    private var thawBarShadowObservationTask: Task<Void, Never>?
 
     /// Creates a new Thaw Bar panel with Liquid Glass support.
     init() {
@@ -69,6 +77,21 @@ final class IceBarPanel: NSPanel {
         self.appState = appState
         configureCancellables()
         colorManager.performSetup(with: self)
+        startThawBarShadowObservation(with: appState)
+    }
+
+    /// Observes Thaw Bar shadow preference and applies it to the panel window.
+    private func startThawBarShadowObservation(with appState: AppState) {
+        thawBarShadowObservationTask?.cancel()
+        thawBarShadowObservationTask = Task { [weak self] in
+            let changes = Observations {
+                appState.appearanceManager.configuration.currentThawBar.hasShadow
+            }
+            for await hasShadow in changes {
+                guard let self else { return }
+                self.hasShadow = hasShadow
+            }
+        }
     }
 
     /// Configures the internal observers.
@@ -228,9 +251,26 @@ final class IceBarPanel: NSPanel {
         currentSection = section
         lastShowTimestamp = Date()
 
-        // Show the panel immediately with whatever cached data we have.
-        // The SwiftUI view observes itemManager and imageCache, so it
-        // will re-render automatically as the background updates land.
+        // Menu bar icon light/dark tint is baked into the captured bitmaps.
+        // Restore this display's warm snapshot when we have one; otherwise clear
+        // wrong-display icons so the panel can still appear instantly (Loading)
+        // while a background SkyLight recapture fills the correct tint.
+        let switchedDisplay = lastShownDisplayID.map { $0 != screen.displayID } ?? false
+        let needsBackgroundRecapture = appState.imageCache.prepareImagesForThawBar(
+            displayID: screen.displayID,
+            section: section
+        )
+        if switchedDisplay {
+            colorManager.invalidateColorInfo()
+            diagLog.notice(
+                "show: display \(self.lastShownDisplayID.map(String.init) ?? "nil") → \(screen.displayID); warmCache=\(!needsBackgroundRecapture)"
+            )
+        }
+        lastShownDisplayID = screen.displayID
+
+        // Show the panel immediately. Never defer orderFront: setting
+        // currentSection without a visible panel makes isHidden flip to false,
+        // so a second click would call hide() instead of show().
         contentView = IceBarHostingView(
             appState: appState,
             colorManager: colorManager,
@@ -242,35 +282,47 @@ final class IceBarPanel: NSPanel {
 
         // Color manager must be updated after updating the panel's origin,
         // but before it is shown.
-        //
-        // Color manager handles frame changes automatically, but does so on
-        // the main queue, so we need to update manually once before showing
-        // the panel to prevent the color from flashing.
         colorManager.updateAllProperties(with: frame, screen: screen)
+
+        hasShadow = appState.appearanceManager.configuration.currentThawBar.hasShadow
 
         orderFrontRegardless()
 
-        // Rehide temporarily shown items and refresh caches in the
-        // background. Ordering is preserved: rehide moves items back
-        // to their correct sections before the cache is rebuilt.
-        // The task is cancelled in close() to avoid holding appState.
+        // Refresh color + icons in the background. Same-display opens keep the
+        // settle delay for control-item positioning; cross-display / cold-cache
+        // opens recapture immediately so Loading is replaced ASAP.
+        let panelFrame = frame
+        let targetDisplayID = screen.displayID
         cacheTask?.cancel()
-        cacheTask = Task { [weak appState] in
+        cacheTask = Task { [weak appState, weak colorManager, switchedDisplay, needsBackgroundRecapture] in
             guard let appState else { return }
+
+            await colorManager?.refresh(with: panelFrame, screen: screen)
+
             await appState.itemManager.rehideTemporarilyShownItems(force: true)
             guard !Task.isCancelled else { return }
-            // Settle delay: when the IceBar just opened on a screen that
-            // was previously inactive, the menu bar has moved screens and
-            // NSStatusItem windows (control item chevrons) are still
-            // positioning. Without this delay, cacheItemsIfNeeded can
-            // recache with stale/zero control item bounds, causing
-            // findSection() to misclassify all items as .visible and
-            // leave the hidden section cache empty ("No items…").
-            try? await Task.sleep(for: .milliseconds(500))
+
+            if switchedDisplay || needsBackgroundRecapture {
+                // Menu bar is already on this screen when the user clicked its
+                // control item; only a short beat is needed before SkyLight.
+                try? await Task.sleep(for: .milliseconds(16))
+            } else {
+                // Settle delay: when the IceBar just opened on a screen that
+                // was previously inactive, the menu bar has moved screens and
+                // NSStatusItem windows (control item chevrons) are still
+                // positioning. Without this delay, cacheItemsIfNeeded can
+                // recache with stale/zero control item bounds, causing
+                // findSection() to misclassify all items as .visible and
+                // leave the hidden section cache empty ("No items…").
+                try? await Task.sleep(for: .milliseconds(500))
+            }
             guard !Task.isCancelled else { return }
             await appState.itemManager.cacheItemsIfNeeded()
             guard !Task.isCancelled else { return }
-            await appState.imageCache.updateCache()
+            await appState.imageCache.recaptureSection(
+                section,
+                preferredDisplayID: targetDisplayID
+            )
         }
     }
 
@@ -375,6 +427,10 @@ private struct IceBarContentView: View {
         appState.appearanceManager.configuration
     }
 
+    private var thawBarConfiguration: ThawBarAppearancePartialConfiguration {
+        configuration.currentThawBar
+    }
+
     private var displaySettings: DisplaySettingsManager {
         appState.settings.displaySettings
     }
@@ -397,7 +453,7 @@ private struct IceBarContentView: View {
     }
 
     private var verticalPadding: CGFloat {
-        screen.hasNotch && configuration.hasRoundedShape ? 2 : 0
+        screen.hasNotch && thawBarConfiguration.cornerStyle.isFullyRounded ? 2 : 0
     }
 
     private var contentHeight: CGFloat {
@@ -460,16 +516,13 @@ private struct IceBarContentView: View {
         }
     }
 
-    private var clipShape: some InsettableShape {
-        if configuration.hasRoundedShape {
-            RoundedRectangle(cornerRadius: contentHeight / 2, style: .circular)
-        } else {
-            RoundedRectangle(cornerRadius: contentHeight / 4, style: .continuous)
-        }
-    }
-
     var body: some View {
-        ZStack {
+        ThawBarChrome(
+            configuration: thawBarConfiguration,
+            colorInfo: colorManager.colorInfo,
+            contentHeight: contentHeight,
+            screen: screen
+        ) {
             Group {
                 if layout == .horizontal {
                     content.frame(height: contentHeight)
@@ -479,17 +532,8 @@ private struct IceBarContentView: View {
             }
             .padding(.horizontal, horizontalPadding)
             .padding(.vertical, verticalPadding)
-            .menuBarItemContainer(appState: appState, colorInfo: colorManager.colorInfo)
-            .foregroundStyle(colorManager.colorInfo?.isBright(for: screen) == true ? .black : .white)
-            .clipShape(clipShape)
-
-            if configuration.current.borderOnThawBar {
-                clipShape
-                    .inset(by: configuration.current.borderWidth / 2)
-                    .stroke(lineWidth: configuration.current.borderWidth)
-                    .foregroundStyle(Color(cgColor: configuration.current.borderColor))
-            }
         }
+        .animation(.easeInOut(duration: 0.35), value: colorManager.colorInfo)
         .padding(5)
         .frame(maxWidth: screen.frame.width)
         .fixedSize(horizontal: true, vertical: layout == .horizontal)
@@ -614,7 +658,12 @@ private struct IceBarContentView: View {
                 Self.diagLog.warning("IceBar content: showing '\(self.cacheGracePeriodActive ? "Loading…" : "Unable to display")' for section \(self.section.logString) — imageCache.cacheFailed=true (grace period active: \(self.cacheGracePeriodActive), loadingTimedOut: \(self.loadingTimedOut), cached images count: \(self.imageCache.images.count), items in section: \(self.itemManager.itemCache[self.section].count))")
             }
         } else {
-            let isLightBackground = colorManager.colorInfo?.isBright(for: screen) == true
+            let isLightBackground = thawBarConfiguration.prefersDarkForeground(
+                sampledColor: colorManager.colorInfo?.color,
+                sampledBrightness: colorManager.colorInfo?.brightness,
+                screenHasNotch: screen.hasNotch
+            )
+            let hasRoundedShape = thawBarConfiguration.cornerStyle.isFullyRounded
             switch layout {
             case .horizontal:
                 ScrollView(.horizontal) {
@@ -628,7 +677,7 @@ private struct IceBarContentView: View {
                                 section: section,
                                 displayID: screen.displayID,
                                 maxHeight: itemMaxHeight,
-                                hasRoundedShape: configuration.hasRoundedShape,
+                                hasRoundedShape: hasRoundedShape,
                                 tooltipDelay: appState.settings.advanced.tooltipDelay,
                                 isLightBackground: isLightBackground
                             )
@@ -655,7 +704,7 @@ private struct IceBarContentView: View {
                                 section: section,
                                 displayID: screen.displayID,
                                 maxHeight: itemMaxHeight,
-                                hasRoundedShape: configuration.hasRoundedShape,
+                                hasRoundedShape: hasRoundedShape,
                                 tooltipDelay: appState.settings.advanced.tooltipDelay,
                                 isLightBackground: isLightBackground
                             )
@@ -682,7 +731,7 @@ private struct IceBarContentView: View {
                                         section: section,
                                         displayID: screen.displayID,
                                         maxHeight: itemMaxHeight,
-                                        hasRoundedShape: configuration.hasRoundedShape,
+                                        hasRoundedShape: hasRoundedShape,
                                         tooltipDelay: appState.settings.advanced.tooltipDelay,
                                         isLightBackground: isLightBackground
                                     )

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -10,6 +10,12 @@ import Combine
 import Observation
 import SwiftUI
 
+/// Live-samples the menu bar / wallpaper strip under the Thaw Bar so Match
+/// Menu Bar can track desktop tone as the wallpaper, Space, or theme changes.
+///
+/// Sampling is not a fixed color: ``colorInfo`` is rewritten on show, on
+/// frame moves, on space / display / appearance notifications, and on a short
+/// periodic timer while the panel is visible.
 @MainActor
 @Observable
 final class IceBarColorManager {
@@ -48,13 +54,7 @@ final class IceBarColorManager {
             iceBarPanel.publisher(for: \.screen)
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self] screen in
-                    guard
-                        let self,
-                        let screen,
-                        screen == .main
-                    else {
-                        return
-                    }
+                    guard let self, let screen else { return }
                     Task { [weak self] in
                         guard let self else { return }
                         await self.updateWindowImage(for: screen)
@@ -69,12 +69,11 @@ final class IceBarColorManager {
                         let self,
                         let iceBarPanel,
                         let screen = iceBarPanel.screen,
-                        iceBarPanel.isVisible,
-                        screen == .main
+                        iceBarPanel.isVisible
                     else {
                         return
                     }
-                    withAnimation(.interactiveSpring) {
+                    withAnimation(.easeInOut(duration: 0.25)) {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
                 }
@@ -94,17 +93,14 @@ final class IceBarColorManager {
             )
             .receive(on: DispatchQueue.main)
             .sink { [weak self, weak iceBarPanel] in
-                guard let self else {
-                    return
-                }
+                guard let self else { return }
                 // Clear window image on display changes to prevent memory growth
                 // and invalidate any in-flight capture from before the change.
                 self.clearWindowImage()
                 guard
                     let iceBarPanel,
                     iceBarPanel.isVisible,
-                    let screen = iceBarPanel.screen,
-                    screen == .main
+                    let screen = iceBarPanel.screen
                 else {
                     return
                 }
@@ -112,7 +108,7 @@ final class IceBarColorManager {
                 Task { [weak self] in
                     guard let self else { return }
                     await self.updateWindowImage(for: screen)
-                    withAnimation {
+                    withAnimation(.easeInOut(duration: 0.35)) {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
                 }
@@ -120,18 +116,13 @@ final class IceBarColorManager {
             .store(in: &c)
 
             // Manage visibility: update colors immediately + start/stop periodic timer.
-            // Single subscription replaces the previous two \.isVisible observers.
             iceBarPanel.publisher(for: \.isVisible)
                 .removeDuplicates()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self, weak iceBarPanel] isVisible in
                     guard let self else { return }
                     if isVisible {
-                        // Refresh windowImage immediately so the first color
-                        // update isn't stale. Awaiting inside a Task so
-                        // updateColorInfo reads the fresh capture, not the
-                        // previous cycle's leftover.
-                        if let iceBarPanel, let screen = iceBarPanel.screen, screen == .main {
+                        if let iceBarPanel, let screen = iceBarPanel.screen {
                             let frame = iceBarPanel.frame
                             Task { [weak self] in
                                 guard let self else { return }
@@ -150,18 +141,18 @@ final class IceBarColorManager {
         cancellables = c
     }
 
-    /// Starts the 5-second periodic refresh timer for color updates.
+    /// Starts a short periodic refresh so wallpaper / desktop tone changes
+    /// propagate into Match Menu Bar without waiting for a Space switch.
     private func startPeriodicRefresh(for iceBarPanel: IceBarPanel?) {
         stopPeriodicRefresh()
-        periodicRefreshCancellable = Timer.publish(every: 5, tolerance: 1, on: .main, in: .default)
+        periodicRefreshCancellable = Timer.publish(every: 1.5, tolerance: 0.4, on: .main, in: .default)
             .autoconnect()
             .sink { [weak self, weak iceBarPanel] _ in
                 guard
                     let self,
                     let iceBarPanel,
                     iceBarPanel.isVisible,
-                    let screen = iceBarPanel.screen,
-                    screen == .main
+                    let screen = iceBarPanel.screen
                 else {
                     return
                 }
@@ -169,7 +160,7 @@ final class IceBarColorManager {
                 Task { [weak self] in
                     guard let self else { return }
                     await self.updateWindowImage(for: screen)
-                    withAnimation {
+                    withAnimation(.easeInOut(duration: 0.35)) {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
                 }
@@ -204,7 +195,10 @@ final class IceBarColorManager {
         }
 
         let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
-        let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
+        // Quartz window bounds use a top-left origin. Capture the menu bar
+        // window's own frame so the average matches the visible bar, not a
+        // single pixel row or the bottom of the display.
+        let bounds = menuBarWindow.bounds
 
         // Stamp our generation before suspending. If the counter advances while
         // we await (a clearWindowImage, a stopPeriodicRefresh, or a newer
@@ -256,14 +250,16 @@ final class IceBarColorManager {
 
         guard
             let croppedImage = image.cropping(to: cropRect),
-            let averageColor = croppedImage.averageColor()
+            // ignoreAlpha matches MenuBarManager's adaptive capture so
+            // transparent composites don't pull the average toward black.
+            let averageColor = croppedImage.averageColor(option: .ignoreAlpha)
         else {
             return
         }
 
-        // Just use `menuBarWindow` as the source for now, regardless
-        // of whether its image contributed to the average.
-        colorInfo = MenuBarAverageColorInfo(color: averageColor, source: .menuBarWindow)
+        let next = MenuBarAverageColorInfo(color: averageColor, source: .menuBarWindow)
+        guard colorInfo != next else { return }
+        colorInfo = next
     }
 
     func updateAllProperties(with frame: CGRect, screen: NSScreen) {
@@ -273,8 +269,20 @@ final class IceBarColorManager {
         // cycle's leftover.
         Task { [weak self] in
             guard let self else { return }
-            await self.updateWindowImage(for: screen)
-            self.updateColorInfo(with: frame, screen: screen)
+            await self.refresh(with: frame, screen: screen)
         }
+    }
+
+    /// Drops the standing sample so a cross-display Thaw Bar open cannot
+    /// briefly reuse the previous screen's brightness for icon contrast.
+    func invalidateColorInfo() {
+        colorInfo = nil
+        clearWindowImage()
+    }
+
+    /// Captures the menu bar strip for `screen` and rewrites ``colorInfo``.
+    func refresh(with frame: CGRect, screen: NSScreen) async {
+        await updateWindowImage(for: screen)
+        updateColorInfo(with: frame, screen: screen)
     }
 }

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -57,7 +57,7 @@ final class IceBarColorManager {
                     guard let self, let screen else { return }
                     Task { [weak self] in
                         guard let self else { return }
-                        await self.updateWindowImage(for: screen)
+                        _ = await self.updateWindowImage(for: screen)
                     }
                 }
                 .store(in: &c)
@@ -107,7 +107,7 @@ final class IceBarColorManager {
                 let frame = iceBarPanel.frame
                 Task { [weak self] in
                     guard let self else { return }
-                    await self.updateWindowImage(for: screen)
+                    guard await self.updateWindowImage(for: screen) else { return }
                     withAnimation(.easeInOut(duration: 0.35)) {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
@@ -126,7 +126,7 @@ final class IceBarColorManager {
                             let frame = iceBarPanel.frame
                             Task { [weak self] in
                                 guard let self else { return }
-                                await self.updateWindowImage(for: screen)
+                                guard await self.updateWindowImage(for: screen) else { return }
                                 self.updateColorInfo(with: frame, screen: screen)
                             }
                         }
@@ -159,7 +159,7 @@ final class IceBarColorManager {
                 let frame = iceBarPanel.frame
                 Task { [weak self] in
                     guard let self else { return }
-                    await self.updateWindowImage(for: screen)
+                    guard await self.updateWindowImage(for: screen) else { return }
                     withAnimation(.easeInOut(duration: 0.35)) {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
@@ -183,7 +183,14 @@ final class IceBarColorManager {
         windowImage = nil
     }
 
-    private func updateWindowImage(for screen: NSScreen) async {
+    /// Captures the menu bar / wallpaper strip for `screen`.
+    ///
+    /// - Returns: `true` when this call stored the current generation's image.
+    ///   Callers must not update ``colorInfo`` after a `false` result — a stale
+    ///   capture would otherwise sample a newer `windowImage` with an older
+    ///   frame / screen.
+    @discardableResult
+    private func updateWindowImage(for screen: NSScreen) async -> Bool {
         let windows = WindowInfo.createWindows(option: .onScreen)
         let displayID = screen.displayID
 
@@ -191,7 +198,7 @@ final class IceBarColorManager {
             let menuBarWindow = WindowInfo.menuBarWindow(from: windows, for: displayID),
             let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: displayID)
         else {
-            return
+            return false
         }
 
         let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
@@ -212,8 +219,9 @@ final class IceBarColorManager {
             screenBounds: bounds,
             option: .nominalResolution
         )
-        guard generation == windowImageGeneration, let image else { return }
+        guard generation == windowImageGeneration, let image else { return false }
         windowImage = image
+        return true
     }
 
     /// The horizontal position (`0...1`) of the bar's center within the screen,
@@ -289,7 +297,7 @@ final class IceBarColorManager {
 
     /// Captures the menu bar strip for `screen` and rewrites ``colorInfo``.
     func refresh(with frame: CGRect, screen: NSScreen) async {
-        await updateWindowImage(for: screen)
+        guard await updateWindowImage(for: screen) else { return }
         updateColorInfo(with: frame, screen: screen)
     }
 }

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -244,9 +244,16 @@ final class IceBarColorManager {
 
         let percentage = Self.colorSamplePercentage(frame: frame, screenFrame: screen.frame)
 
-        let cropRect = CGRect(x: imageBounds.width * percentage, y: 0, width: 0, height: 1)
-            .insetBy(dx: -150, dy: 0)
-            .intersection(imageBounds)
+        // Sample a horizontal band across the full captured menu-bar height so
+        // the average tracks the visible bar body, not only the top pixel row.
+        let cropRect = CGRect(
+            x: imageBounds.width * percentage,
+            y: 0,
+            width: 0,
+            height: imageBounds.height
+        )
+        .insetBy(dx: -150, dy: 0)
+        .intersection(imageBounds)
 
         guard
             let croppedImage = image.cropping(to: cropRect),

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -15,6 +15,9 @@ import SwiftUI
 struct ThawBarBorderShape: Shape {
     /// Corner radius of the un-inset clip path.
     var cornerRadius: CGFloat
+    /// Matches ``ThawBarChrome``'s clip: circular for fully rounded ends,
+    /// continuous for square corners.
+    var cornerStyle: RoundedCornerStyle = .continuous
     /// When `true`, the path starts at the top-leading corner, runs down the
     /// leading side, across the bottom, and up the trailing side — leaving the
     /// top edge open.
@@ -28,7 +31,7 @@ struct ThawBarBorderShape: Shape {
         let radius = min(max(cornerRadius - inset, 0), min(drawRect.width, drawRect.height) / 2)
 
         if !omitTopEdge {
-            return RoundedRectangle(cornerRadius: radius, style: .continuous)
+            return RoundedRectangle(cornerRadius: radius, style: cornerStyle)
                 .path(in: drawRect)
         }
 
@@ -41,6 +44,9 @@ struct ThawBarBorderShape: Shape {
             return path
         }
 
+        // Continuous corners approximate a squircle; for the open-top path we
+        // still stroke circular arcs of the same radius so the visible edges
+        // meet the clip cleanly for both styles.
         var path = Path()
         // Top-leading → down the leading edge → bottom-leading arc →
         // bottom edge → bottom-trailing arc → up the trailing edge →

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -1,0 +1,68 @@
+//
+//  ThawBarBorderShape.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+/// A rounded rectangle whose stroke can omit the top edge.
+///
+/// Used by the Thaw Bar when square corners meet the display's rounded
+/// screen corners (#325): drawing the top edge would be clipped and look
+/// broken, so only the leading, trailing, and bottom edges are stroked.
+struct ThawBarBorderShape: Shape {
+    /// Corner radius of the un-inset clip path.
+    var cornerRadius: CGFloat
+    /// When `true`, the path starts at the top-leading corner, runs down the
+    /// leading side, across the bottom, and up the trailing side — leaving the
+    /// top edge open.
+    var omitTopEdge: Bool
+    /// Inset applied before constructing the path (half the stroke width so
+    /// the stroke sits on the clip edge, matching `InsettableShape.inset`).
+    var inset: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        let drawRect = rect.insetBy(dx: inset, dy: inset)
+        let radius = min(max(cornerRadius - inset, 0), min(drawRect.width, drawRect.height) / 2)
+
+        if !omitTopEdge {
+            return RoundedRectangle(cornerRadius: radius, style: .continuous)
+                .path(in: drawRect)
+        }
+
+        guard radius > 0 else {
+            var path = Path()
+            path.move(to: CGPoint(x: drawRect.minX, y: drawRect.minY))
+            path.addLine(to: CGPoint(x: drawRect.minX, y: drawRect.maxY))
+            path.addLine(to: CGPoint(x: drawRect.maxX, y: drawRect.maxY))
+            path.addLine(to: CGPoint(x: drawRect.maxX, y: drawRect.minY))
+            return path
+        }
+
+        var path = Path()
+        // Top-leading → down the leading edge → bottom-leading arc →
+        // bottom edge → bottom-trailing arc → up the trailing edge →
+        // top-trailing. No top edge.
+        path.move(to: CGPoint(x: drawRect.minX, y: drawRect.minY))
+        path.addLine(to: CGPoint(x: drawRect.minX, y: drawRect.maxY - radius))
+        path.addArc(
+            center: CGPoint(x: drawRect.minX + radius, y: drawRect.maxY - radius),
+            radius: radius,
+            startAngle: .degrees(180),
+            endAngle: .degrees(90),
+            clockwise: true
+        )
+        path.addLine(to: CGPoint(x: drawRect.maxX - radius, y: drawRect.maxY))
+        path.addArc(
+            center: CGPoint(x: drawRect.maxX - radius, y: drawRect.maxY - radius),
+            radius: radius,
+            startAngle: .degrees(90),
+            endAngle: .degrees(0),
+            clockwise: true
+        )
+        path.addLine(to: CGPoint(x: drawRect.maxX, y: drawRect.minY))
+        return path
+    }
+}

--- a/Thaw/MenuBar/IceBar/ThawBarChrome.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarChrome.swift
@@ -1,0 +1,183 @@
+//
+//  ThawBarChrome.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+/// Draws the Thaw Bar's background fill, tint overlay, clip, and border from
+/// a ``ThawBarAppearancePartialConfiguration``.
+///
+/// Replaces the shared ``MenuBarItemContainer`` path for the Thaw Bar so its
+/// fill and tint are independent of the menu bar overlay settings.
+///
+/// ``ThawBarBackgroundKind/adaptive`` ("Match Menu Bar") paints the live
+/// average of the menu bar / wallpaper strip from ``IceBarColorManager``,
+/// with optional brightness and liquid-glass blend from the appearance editor.
+struct ThawBarChrome<Content: View>: View {
+    let configuration: ThawBarAppearancePartialConfiguration
+    let colorInfo: MenuBarAverageColorInfo?
+    let contentHeight: CGFloat
+    let screen: NSScreen
+    let content: Content
+
+    init(
+        configuration: ThawBarAppearancePartialConfiguration,
+        colorInfo: MenuBarAverageColorInfo?,
+        contentHeight: CGFloat,
+        screen: NSScreen,
+        @ViewBuilder content: () -> Content
+    ) {
+        self.configuration = configuration
+        self.colorInfo = colorInfo
+        self.contentHeight = contentHeight
+        self.screen = screen
+        self.content = content()
+    }
+
+    private var cornerRadius: CGFloat {
+        configuration.cornerRadius(contentHeight: contentHeight)
+    }
+
+    private var clipShape: RoundedRectangle {
+        if configuration.cornerStyle.isFullyRounded {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .circular)
+        } else {
+            RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+        }
+    }
+
+    private var prefersDarkForeground: Bool {
+        configuration.prefersDarkForeground(
+            sampledColor: colorInfo?.color,
+            sampledBrightness: colorInfo?.brightness,
+            screenHasNotch: screen.hasNotch
+        )
+    }
+
+    var body: some View {
+        ZStack {
+            content
+                .foregroundStyle(prefersDarkForeground ? Color.black : Color.white)
+                .background {
+                    fillLayer
+                }
+                .overlay {
+                    tintLayer
+                }
+                .clipShape(clipShape)
+                .modifier(ThawBarGlassModifier(
+                    isEnabled: configuration.appliesLiquidGlass,
+                    style: glassStyle,
+                    shape: clipShape
+                ))
+
+            if configuration.hasBorder {
+                borderOverlay
+            }
+        }
+    }
+
+    private var glassStyle: MenuBarGlassStyle {
+        switch configuration.backgroundKind {
+        case .glass:
+            configuration.backgroundGlassStyle
+        case .adaptive:
+            // Clear keeps more of the sampled fill visible under the glass blend.
+            .clear
+        case .solid, .gradient, .none, .sampled:
+            configuration.backgroundGlassStyle
+        }
+    }
+
+    @ViewBuilder
+    private var fillLayer: some View {
+        switch configuration.backgroundKind {
+        case .adaptive:
+            if let colorInfo {
+                Color(cgColor: configuration.brightnessAdjustedSample(from: colorInfo.color))
+                    .opacity(configuration.adaptiveFillOpacity)
+            } else {
+                Color.defaultLayoutBar
+            }
+        case .sampled:
+            if let colorInfo {
+                Color(cgColor: colorInfo.color)
+                    .opacity(configuration.backgroundOpacity)
+            } else {
+                Color.defaultLayoutBar
+            }
+        case .solid:
+            Color(cgColor: configuration.backgroundColor)
+                .opacity(configuration.backgroundOpacity)
+        case .gradient:
+            configuration.backgroundGradient
+                .withAlpha(configuration.backgroundOpacity)
+                .swiftUIView(using: .displayP3)
+        case .glass:
+            Color.clear
+        case .none:
+            Color.clear
+        }
+    }
+
+    @ViewBuilder
+    private var tintLayer: some View {
+        switch configuration.tintKind {
+        case .noTint, .glass:
+            EmptyView()
+        case .solid:
+            Color(cgColor: configuration.tintColor)
+                .opacity(configuration.tintOpacity)
+                .allowsHitTesting(false)
+        case .gradient:
+            configuration.tintGradient
+                .withAlpha(configuration.tintOpacity)
+                .swiftUIView(using: .displayP3)
+                .allowsHitTesting(false)
+        case .adaptive:
+            if let colorInfo {
+                Color(cgColor: colorInfo.color)
+                    .opacity(configuration.tintOpacity)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var borderOverlay: some View {
+        ThawBarBorderShape(
+            cornerRadius: cornerRadius,
+            omitTopEdge: configuration.shouldOmitTopBorder,
+            inset: configuration.borderWidth / 2
+        )
+        .stroke(
+            Color(cgColor: configuration.borderColor),
+            lineWidth: configuration.borderWidth
+        )
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Glass modifier
+
+/// Applies SwiftUI liquid glass when the Thaw Bar background opts into glass.
+private struct ThawBarGlassModifier<S: InsettableShape>: ViewModifier {
+    let isEnabled: Bool
+    let style: MenuBarGlassStyle
+    let shape: S
+
+    func body(content: Content) -> some View {
+        if isEnabled {
+            switch style {
+            case .regular:
+                content.glassEffect(.regular, in: shape)
+            case .clear:
+                content.glassEffect(.clear, in: shape)
+            }
+        } else {
+            content
+        }
+    }
+}

--- a/Thaw/MenuBar/IceBar/ThawBarChrome.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarChrome.swift
@@ -149,6 +149,7 @@ struct ThawBarChrome<Content: View>: View {
     private var borderOverlay: some View {
         ThawBarBorderShape(
             cornerRadius: cornerRadius,
+            cornerStyle: configuration.cornerStyle.isFullyRounded ? .circular : .continuous,
             omitTopEdge: configuration.shouldOmitTopBorder,
             inset: configuration.borderWidth / 2
         )

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -136,6 +136,18 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     /// The cached item images, keyed by their corresponding tags.
     private(set) var images = [MenuBarItemTag: CapturedImage]()
 
+    /// Display ID of the screen the current ``images`` were last captured for.
+    ///
+    /// Used by the Thaw Bar to drop stale bitmaps when opening on a different
+    /// screen: menu bar icon light/dark tint is baked into the capture, so
+    /// reusing another display's cache briefly shows the wrong icon colors.
+    private(set) var lastCaptureDisplayID: CGDirectDisplayID?
+
+    /// Per-display icon snapshots so switching screens can restore the correct
+    /// light/dark tint immediately instead of flashing the previous screen.
+    @ObservationIgnored
+    private var imagesByDisplay = [CGDirectDisplayID: [MenuBarItemTag: CapturedImage]]()
+
     /// Memoized results of ``trimmedImage(for:)``, keyed by tag, each paired
     /// with the `CGImage` it was derived from so a recapture invalidates it.
     ///
@@ -787,7 +799,7 @@ final class MenuBarItemImageCache: @unchecked Sendable {
 
             let nav = appState.navigationState
 
-            let preferredDisplayID = appState.itemManager.itemCache.displayID
+            let preferredDisplayID = preferredCaptureDisplayID(appState: appState)
             guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
                 MenuBarItemImageCache.diagLog.warning("liveRefresh: no connected screens available, skipping")
                 continue
@@ -899,6 +911,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                         await refreshImages(of: offscreenBatch, scale: scale)
                     }
                 }
+            }
+
+            await MainActor.run {
+                storeImages(for: screen.displayID)
             }
         }
 
@@ -1712,12 +1728,41 @@ final class MenuBarItemImageCache: @unchecked Sendable {
 
     // MARK: Update Cache
 
+    /// Display to capture from while a consumer is visible.
+    ///
+    /// Prefer the Thaw Bar's screen when it is presented so a cross-display
+    /// open does not keep sampling the previous menu bar's icon tint.
+    @MainActor
+    private func preferredCaptureDisplayID(
+        appState: AppState,
+        override: CGDirectDisplayID? = nil
+    ) -> CGDirectDisplayID? {
+        if let override {
+            return override
+        }
+        if appState.navigationState.isIceBarPresented,
+           let iceBarDisplayID = appState.menuBarManager.iceBarPanel.screen?.displayID
+        {
+            return iceBarDisplayID
+        }
+        return appState.itemManager.itemCache.displayID
+    }
+
     /// Updates the cache for the given sections, without checking whether
     /// caching is necessary.
+    ///
+    /// - Parameter preferredDisplayID: When set (e.g. the Thaw Bar's screen),
+    ///   capture from that display instead of the standing item-cache display.
     @MainActor
-    func updateCacheWithoutChecks(sections: [MenuBarSection.Name]) async {
+    func updateCacheWithoutChecks(
+        sections: [MenuBarSection.Name],
+        preferredDisplayID: CGDirectDisplayID? = nil
+    ) async {
         await withCapturePermit {
-            await performCacheUpdateWithoutChecks(sections: sections)
+            await performCacheUpdateWithoutChecks(
+                sections: sections,
+                preferredDisplayID: preferredDisplayID
+            )
         }
     }
 
@@ -1734,7 +1779,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     }
 
     @MainActor
-    private func performCacheUpdateWithoutChecks(sections: [MenuBarSection.Name]) async {
+    private func performCacheUpdateWithoutChecks(
+        sections: [MenuBarSection.Name],
+        preferredDisplayID: CGDirectDisplayID? = nil
+    ) async {
         guard let appState else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: appState is nil, aborting")
             return
@@ -1746,15 +1794,15 @@ final class MenuBarItemImageCache: @unchecked Sendable {
             return
         }
 
-        let preferredDisplayID = appState.itemManager.itemCache.displayID
-        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+        let resolvedPreferred = preferredCaptureDisplayID(appState: appState, override: preferredDisplayID)
+        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: resolvedPreferred) else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: no connected screens available, aborting")
             return
         }
         let screen = resolvedScreen.screen
-        if resolvedScreen.usedFallback, let preferredDisplayID {
+        if resolvedScreen.usedFallback, let resolvedPreferred {
             MenuBarItemImageCache.diagLog.warning(
-                "updateCacheWithoutChecks: cached displayID \(preferredDisplayID) is not connected; using displayID \(screen.displayID)"
+                "updateCacheWithoutChecks: cached displayID \(resolvedPreferred) is not connected; using displayID \(screen.displayID)"
             )
         }
 
@@ -1801,7 +1849,7 @@ final class MenuBarItemImageCache: @unchecked Sendable {
             appState.itemManager.itemCache.managedItems.map(\.tag)
         )
 
-        await MainActor.run { [newImages, allValidTags] in
+        await MainActor.run { [newImages, allValidTags, screen] in
             let beforeCount = images.count
 
             // Tags with recent capture failures should keep their cached images
@@ -1895,6 +1943,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 MenuBarItemImageCache.diagLog.warning(
                     "Cache inconsistency: \(afterCount) cached images vs \(finalAccessOrderCount) LRU entries"
                 )
+            }
+
+            if !newImages.isEmpty {
+                storeImages(for: screen.displayID)
             }
         }
     }
@@ -1997,6 +2049,110 @@ final class MenuBarItemImageCache: @unchecked Sendable {
         )
     }
 
+    /// Force-recaptures a section for a specific display, including off-screen
+    /// (hidden / always-hidden) items via SkyLight.
+    ///
+    /// Used when the Thaw Bar opens on a different screen than the standing
+    /// image cache: ``updateCacheWithoutChecks`` skips off-screen items, and
+    /// waiting for the live-refresh loop would leave a ~1s wrong-tint flash.
+    @MainActor
+    func recaptureSection(
+        _ section: MenuBarSection.Name,
+        preferredDisplayID: CGDirectDisplayID
+    ) async {
+        guard let appState else { return }
+        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+            return
+        }
+        let screen = resolvedScreen.screen
+        let scale = screen.backingScaleFactor
+        let items = appState.itemManager.itemCache.managedItems(for: section)
+            .filter { !$0.isControlItem }
+        guard !items.isEmpty else { return }
+
+        MenuBarItemImageCache.diagLog.notice(
+            "recaptureSection: section=\(section.logString) displayID=\(screen.displayID) items=\(items.count)"
+        )
+
+        await withCapturePermit {
+            if section == .visible {
+                await refreshImages(of: items, scale: scale, viaSCK: true)
+            } else {
+                await refreshImages(of: items, scale: scale, viaSCK: false)
+            }
+        }
+        storeImages(for: screen.displayID)
+    }
+
+    /// Restores a warm per-display snapshot for the Thaw Bar, or clears the
+    /// section when only another screen's bitmaps are available.
+    ///
+    /// Call before the panel is ordered front so the first paint either has
+    /// the correct tint or a loading state — never the wrong screen's icons.
+    @MainActor
+    func prepareImagesForDisplay(_ displayID: CGDirectDisplayID, section: MenuBarSection.Name) {
+        guard let appState else { return }
+        let sectionItems = appState.itemManager.itemCache[section]
+        guard !sectionItems.isEmpty else { return }
+
+        if let stored = imagesByDisplay[displayID], !stored.isEmpty {
+            var applied = 0
+            for item in sectionItems {
+                if let image = storedImage(for: item.tag, in: stored) {
+                    images[item.tag] = image
+                    updateAccessOrder(for: item.tag)
+                    applied += 1
+                }
+            }
+            if applied > 0 {
+                lastCaptureDisplayID = displayID
+                MenuBarItemImageCache.diagLog.notice(
+                    "prepareImagesForDisplay: restored \(applied)/\(sectionItems.count) icons for display \(displayID)"
+                )
+                return
+            }
+        }
+
+        if lastCaptureDisplayID != displayID {
+            MenuBarItemImageCache.diagLog.notice(
+                "prepareImagesForDisplay: no warm cache for display \(displayID); clearing section \(section.logString) to avoid wrong tint"
+            )
+            clearImages(for: section)
+        }
+    }
+
+    /// Snapshots the standing ``images`` under `displayID` for instant restore.
+    @MainActor
+    func storeImages(for displayID: CGDirectDisplayID) {
+        guard !images.isEmpty else { return }
+        var stored = imagesByDisplay[displayID] ?? [:]
+        stored.merge(images) { _, new in new }
+        imagesByDisplay[displayID] = stored
+        lastCaptureDisplayID = displayID
+        pruneDisconnectedDisplayCaches()
+    }
+
+    @MainActor
+    private func storedImage(
+        for tag: MenuBarItemTag,
+        in stored: [MenuBarItemTag: CapturedImage]
+    ) -> CapturedImage? {
+        if let exact = stored[tag] {
+            return exact
+        }
+        guard !tag.isSystemItem else { return nil }
+        for (storedTag, image) in stored where storedTag.matchesIgnoringWindowID(tag) {
+            return image
+        }
+        return nil
+    }
+
+    @MainActor
+    private func pruneDisconnectedDisplayCaches() {
+        let connected = Set(NSScreen.screens.map(\.displayID))
+        imagesByDisplay = imagesByDisplay.filter { connected.contains($0.key) }
+    }
+
     /// Clears the images for the given section.
     @MainActor
     func clearImages(for section: MenuBarSection.Name) {
@@ -2008,6 +2164,32 @@ final class MenuBarItemImageCache: @unchecked Sendable {
         for tag in tags {
             accessOrder.remove(tag)
         }
+        if images.isEmpty {
+            lastCaptureDisplayID = nil
+        }
+    }
+
+    /// Prepares icons for `displayID` and reports whether a fresh capture is needed.
+    ///
+    /// Restores a warm per-display snapshot when available; otherwise clears
+    /// wrong-display bitmaps. Returns `true` when the section still has no
+    /// usable icons (caller should recapture ASAP in the background).
+    @MainActor
+    func prepareImagesForThawBar(
+        displayID: CGDirectDisplayID,
+        section: MenuBarSection.Name
+    ) -> Bool {
+        prepareImagesForDisplay(displayID, section: section)
+        return !sectionHasCachedImages(section)
+    }
+
+    @MainActor
+    private func sectionHasCachedImages(_ section: MenuBarSection.Name) -> Bool {
+        guard let appState else { return false }
+        let items = appState.itemManager.itemCache[section]
+        guard !items.isEmpty else { return true }
+        let keys = Set(images.keys)
+        return items.contains { keys.contains($0.tag) }
     }
 
     /// Clears all cached images and failure tracking.
@@ -2015,6 +2197,8 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     func clearAll() {
         images.removeAll()
         accessOrder.removeAll()
+        imagesByDisplay.removeAll()
+        lastCaptureDisplayID = nil
         failedCapturesLock.withLock { $0.removeAll() }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -1542,6 +1542,24 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 "Memory pressure: Cleared \(tagsToRemove.count) items from cache"
             )
         }
+
+        // Per-display warm snapshots are independent of the standing LRU; drop
+        // non-standing displays first, then trim the standing copy to match.
+        let standing = lastCaptureDisplayID
+        for displayID in imagesByDisplay.keys where displayID != standing {
+            imagesByDisplay.removeValue(forKey: displayID)
+        }
+        if let standing, var standingImages = imagesByDisplay[standing] {
+            standingImages = standingImages.filter { images[$0.key] != nil }
+            if standingImages.count > images.count {
+                let excess = standingImages.count - images.count
+                let dropKeys = Array(standingImages.keys.prefix(excess))
+                for key in dropKeys {
+                    standingImages.removeValue(forKey: key)
+                }
+            }
+            imagesByDisplay[standing] = standingImages
+        }
     }
 
     /// Returns the `count` least recently used tags, sorted by access time (oldest first).
@@ -2078,6 +2096,9 @@ final class MenuBarItemImageCache: @unchecked Sendable {
             if section == .visible {
                 await refreshImages(of: items, scale: scale, viaSCK: true)
             } else {
+                // Share the live-refresh SkyLight budget so repeated IceBar
+                // opens cannot bypass the #759 leak throttle.
+                lastSkyLightBatchAt = ContinuousClock.now
                 await refreshImages(of: items, scale: scale, viaSCK: false)
             }
         }
@@ -2089,27 +2110,40 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     ///
     /// Call before the panel is ordered front so the first paint either has
     /// the correct tint or a loading state — never the wrong screen's icons.
+    ///
+    /// - Returns: `true` when a background recapture is still needed (cold or
+    ///   incomplete warm restore).
     @MainActor
-    func prepareImagesForDisplay(_ displayID: CGDirectDisplayID, section: MenuBarSection.Name) {
-        guard let appState else { return }
+    @discardableResult
+    func prepareImagesForDisplay(_ displayID: CGDirectDisplayID, section: MenuBarSection.Name) -> Bool {
+        guard let appState else { return true }
         let sectionItems = appState.itemManager.itemCache[section]
-        guard !sectionItems.isEmpty else { return }
+        guard !sectionItems.isEmpty else { return false }
 
         if let stored = imagesByDisplay[displayID], !stored.isEmpty {
             var applied = 0
+            var missingTags = [MenuBarItemTag]()
             for item in sectionItems {
                 if let image = storedImage(for: item.tag, in: stored) {
                     images[item.tag] = image
                     updateAccessOrder(for: item.tag)
                     applied += 1
+                } else {
+                    missingTags.append(item.tag)
                 }
+            }
+            // Drop unrestored tags so previous-display bitmaps cannot linger
+            // beside a partial warm restore.
+            for tag in missingTags {
+                images.removeValue(forKey: tag)
+                accessOrder.remove(tag)
             }
             if applied > 0 {
                 lastCaptureDisplayID = displayID
                 MenuBarItemImageCache.diagLog.notice(
                     "prepareImagesForDisplay: restored \(applied)/\(sectionItems.count) icons for display \(displayID)"
                 )
-                return
+                return !missingTags.isEmpty
             }
         }
 
@@ -2118,18 +2152,22 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 "prepareImagesForDisplay: no warm cache for display \(displayID); clearing section \(section.logString) to avoid wrong tint"
             )
             clearImages(for: section)
+            return true
         }
+        return !sectionHasCachedImages(section)
     }
 
     /// Snapshots the standing ``images`` under `displayID` for instant restore.
     @MainActor
     func storeImages(for displayID: CGDirectDisplayID) {
         guard !images.isEmpty else { return }
-        var stored = imagesByDisplay[displayID] ?? [:]
-        stored.merge(images) { _, new in new }
-        imagesByDisplay[displayID] = stored
+        // Replace the display snapshot with the standing cache rather than
+        // merging forever — otherwise every live-refresh tick accumulates
+        // tags that the main LRU / memory-pressure paths already dropped.
+        imagesByDisplay[displayID] = images
         lastCaptureDisplayID = displayID
         pruneDisconnectedDisplayCaches()
+        enforcePerDisplayCacheLimit()
     }
 
     @MainActor
@@ -2151,6 +2189,35 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     private func pruneDisconnectedDisplayCaches() {
         let connected = Set(NSScreen.screens.map(\.displayID))
         imagesByDisplay = imagesByDisplay.filter { connected.contains($0.key) }
+    }
+
+    /// Caps total icons retained across per-display snapshots.
+    @MainActor
+    private func enforcePerDisplayCacheLimit() {
+        let total = imagesByDisplay.values.reduce(0) { $0 + $1.count }
+        let limit = Self.maxCacheSize * max(imagesByDisplay.count, 1)
+        guard total > limit else { return }
+
+        // Prefer dropping snapshots for displays that are not the standing one.
+        let standing = lastCaptureDisplayID
+        let victims = imagesByDisplay.keys.filter { $0 != standing }
+        for displayID in victims {
+            imagesByDisplay.removeValue(forKey: displayID)
+            let remaining = imagesByDisplay.values.reduce(0) { $0 + $1.count }
+            if remaining <= limit { return }
+        }
+
+        if var standingImages = standing.flatMap({ imagesByDisplay[$0] }),
+           standingImages.count > Self.maxCacheSize
+        {
+            let keys = Array(standingImages.keys.prefix(standingImages.count - Self.maxCacheSize))
+            for key in keys {
+                standingImages.removeValue(forKey: key)
+            }
+            if let standing {
+                imagesByDisplay[standing] = standingImages
+            }
+        }
     }
 
     /// Clears the images for the given section.
@@ -2180,7 +2247,6 @@ final class MenuBarItemImageCache: @unchecked Sendable {
         section: MenuBarSection.Name
     ) -> Bool {
         prepareImagesForDisplay(displayID, section: section)
-        return !sectionHasCachedImages(section)
     }
 
     @MainActor

--- a/Thaw/Settings/Search/SearchIndex.swift
+++ b/Thaw/Settings/Search/SearchIndex.swift
@@ -869,6 +869,50 @@ nonisolated enum SearchIndex {
             property: nil
         ),
         SearchEntry(
+            id: "appearance.thawBar",
+            titleKey: "\(Constants.displayName) Bar",
+            titleText: "\(Constants.displayName) Bar",
+            descriptionText: "Background, tint, corners, border, and shadow for the floating bar that shows hidden items.",
+            pane: .menuBarAppearance,
+            sectionKey: "\(Constants.displayName) Bar",
+            sectionText: "\(Constants.displayName) Bar",
+            keywords: ["thaw bar", "icebar", "ice bar", "hidden", "popup", "background", "tint", "corners", "border", "glass", "adaptive"],
+            property: nil
+        ),
+        SearchEntry(
+            id: "appearance.thawBar.background",
+            titleKey: "Background",
+            titleText: "Background",
+            descriptionText: "Fill style for the Thaw Bar: match menu bar (with brightness and glass), solid, gradient, glass, sampled color, or none.",
+            pane: .menuBarAppearance,
+            sectionKey: "\(Constants.displayName) Bar",
+            sectionText: "\(Constants.displayName) Bar",
+            keywords: ["thaw bar", "background", "adaptive", "match", "menu bar", "solid", "gradient", "glass", "sampled"],
+            property: nil
+        ),
+        SearchEntry(
+            id: "appearance.thawBar.corners",
+            titleKey: "Corners",
+            titleText: "Corners",
+            descriptionText: "Rounded capsule or square ends for the Thaw Bar.",
+            pane: .menuBarAppearance,
+            sectionKey: "\(Constants.displayName) Bar",
+            sectionText: "\(Constants.displayName) Bar",
+            keywords: ["thaw bar", "corners", "rounded", "square", "pill"],
+            property: nil
+        ),
+        SearchEntry(
+            id: "appearance.thawBar.omitTopBorder",
+            titleKey: "Omit top border edge",
+            titleText: "Omit top border edge",
+            descriptionText: "When corners are square, skip the top border stroke so it is not clipped by the display corners.",
+            pane: .menuBarAppearance,
+            sectionKey: "\(Constants.displayName) Bar",
+            sectionText: "\(Constants.displayName) Bar",
+            keywords: ["thaw bar", "border", "square", "omit", "top", "clip"],
+            property: nil
+        ),
+        SearchEntry(
             id: "appearance.reset",
             titleKey: "Reset Appearance",
             titleText: "Reset Appearance",

--- a/ThawTests/MenuBar/Appearance/MenuBarAppearanceConfigurationTests.swift
+++ b/ThawTests/MenuBar/Appearance/MenuBarAppearanceConfigurationTests.swift
@@ -262,5 +262,19 @@ struct MenuBarAppearanceConfigurationTests {
             #expect(configuration.notchShapeInfo == defaultConfiguration.notchShapeInfo)
             #expect(configuration.isDynamic == defaultConfiguration.isDynamic)
         }
+
+        @Test("V1 migration seeds Thaw Bar appearance from the shared border flag")
+        func migratedThawBarAppearance() {
+            let configuration = MenuBarAppearanceConfigurationV2(migrating: oldConfiguration)
+            let thawBar = configuration.thawBarStaticConfiguration
+
+            #expect(thawBar.hasBorder)
+            #expect(thawBar.borderWidth == 3)
+            #expect(thawBar.tintKind == .noTint)
+            #expect(thawBar.backgroundKind == .adaptive)
+            #expect(thawBar.backgroundGlassStyle == .clear)
+            #expect(thawBar.cornerStyle == .rounded)
+            #expect(thawBar.omitTopBorderWhenSquare)
+        }
     }
 }

--- a/ThawTests/MenuBar/Appearance/ThawBarAppearanceConfigurationTests.swift
+++ b/ThawTests/MenuBar/Appearance/ThawBarAppearanceConfigurationTests.swift
@@ -159,6 +159,21 @@ struct ThawBarAppearanceConfigurationTests {
             #expect(config.resolvedFillColor(sampled: sampled) === sampled)
         }
 
+        @Test("Translucent fills composite over the sample before contrast")
+        func translucentFillCompositesForContrast() throws {
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            config.backgroundKind = .solid
+            config.backgroundColor = CGColor(gray: 1, alpha: 1)
+            config.backgroundOpacity = 0.25
+            let darkSample = CGColor(gray: 0.1, alpha: 1)
+
+            let resolved = try #require(config.resolvedFillColor(sampled: darkSample))
+            let components = try #require(resolved.components)
+            // 0.25 white over 0.1 gray ≈ 0.325 — well below a light fill.
+            #expect(components[0] < 0.5)
+            #expect(components[0] > 0.2)
+        }
+
         @Test("Glass kind always uses liquid glass; Match Menu Bar follows the glass slider")
         func appliesLiquidGlass() {
             #expect(ThawBarBackgroundKind.glass.usesLiquidGlass)

--- a/ThawTests/MenuBar/Appearance/ThawBarAppearanceConfigurationTests.swift
+++ b/ThawTests/MenuBar/Appearance/ThawBarAppearanceConfigurationTests.swift
@@ -1,0 +1,307 @@
+//
+//  ThawBarAppearanceConfigurationTests.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Thaw
+
+@Suite("Thaw Bar appearance configuration")
+struct ThawBarAppearanceConfigurationTests {
+    @Suite("Kinds")
+    struct KindTests {
+        @Test("Background kind raw values stay stable for persistence", arguments: [
+            (ThawBarBackgroundKind.adaptive, 0),
+            (.solid, 1),
+            (.gradient, 2),
+            (.glass, 3),
+            (.none, 4),
+            (.sampled, 5),
+        ])
+        func backgroundKindRawValues(kind: ThawBarBackgroundKind, raw: Int) {
+            #expect(kind.rawValue == raw)
+        }
+
+        @Test("Corner style raw values stay stable for persistence", arguments: [
+            (ThawBarCornerStyle.rounded, 0),
+            (.square, 1),
+        ])
+        func cornerStyleRawValues(style: ThawBarCornerStyle, raw: Int) {
+            #expect(style.rawValue == raw)
+        }
+
+        @Test("Unknown background kind raw values fail to decode")
+        func unknownBackgroundKindFails() throws {
+            let data = Data("99".utf8)
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(ThawBarBackgroundKind.self, from: data)
+            }
+        }
+
+        @Test("Unknown corner style raw values fail to decode")
+        func unknownCornerStyleFails() throws {
+            let data = Data("99".utf8)
+            #expect(throws: DecodingError.self) {
+                _ = try JSONDecoder().decode(ThawBarCornerStyle.self, from: data)
+            }
+        }
+    }
+
+    @Suite("Partial configuration")
+    struct PartialTests {
+        @Test("Defaults use match-menu-bar sample, no tint, rounded corners, and omit-top for square")
+        func defaults() {
+            let config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+
+            #expect(config.backgroundKind == .adaptive)
+            #expect(config.backgroundGlassStyle == .clear)
+            #expect(config.backgroundOpacity == 1)
+            #expect(config.adaptiveBrightness == 0)
+            #expect(config.adaptiveGlassAmount == 0)
+            #expect(config.tintKind == .noTint)
+            #expect(config.cornerStyle == .rounded)
+            #expect(!config.hasBorder)
+            #expect(config.omitTopBorderWhenSquare)
+            #expect(config.hasShadow)
+            #expect(!config.appliesLiquidGlass)
+        }
+
+        @Test("Migration clears tint and carries Thaw Bar border from the menu bar partial")
+        func migratingFromMenuBarPartial() {
+            var menuBar = MenuBarAppearancePartialConfiguration.defaultConfiguration
+            menuBar.borderOnThawBar = true
+            menuBar.borderWidth = 2
+            menuBar.tintKind = .solid
+
+            let thawBar = ThawBarAppearancePartialConfiguration.migrating(from: menuBar)
+
+            #expect(thawBar.hasBorder)
+            #expect(thawBar.borderWidth == 2)
+            #expect(thawBar.tintKind == .noTint)
+            #expect(thawBar.backgroundKind == .adaptive)
+            #expect(thawBar.backgroundGlassStyle == .clear)
+            #expect(thawBar.omitTopBorderWhenSquare)
+        }
+
+        @Test("The default partial survives a round trip")
+        func encodeDecode() throws {
+            let original = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            let data = try JSONEncoder().encode(original)
+            let decoded = try JSONDecoder().decode(ThawBarAppearancePartialConfiguration.self, from: data)
+
+            #expect(decoded == original)
+        }
+
+        @Test("An empty payload decodes to the defaults")
+        func decodeEmpty() throws {
+            let decoded = try JSONDecoder().decode(
+                ThawBarAppearancePartialConfiguration.self,
+                from: Data("{}".utf8)
+            )
+            #expect(decoded == .defaultConfiguration)
+        }
+
+        @Test("shouldOmitTopBorder is true only for square corners with the preference on")
+        func shouldOmitTopBorder() {
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            config.hasBorder = true
+            config.cornerStyle = .square
+            config.omitTopBorderWhenSquare = true
+            #expect(config.shouldOmitTopBorder)
+
+            config.omitTopBorderWhenSquare = false
+            #expect(!config.shouldOmitTopBorder)
+
+            config.omitTopBorderWhenSquare = true
+            config.cornerStyle = .rounded
+            #expect(!config.shouldOmitTopBorder)
+
+            config.cornerStyle = .square
+            config.hasBorder = false
+            #expect(!config.shouldOmitTopBorder)
+        }
+
+        @Test("Corner radius matches pill vs square sizing")
+        func cornerRadius() {
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            config.cornerStyle = .rounded
+            #expect(config.cornerRadius(contentHeight: 40) == 20)
+
+            config.cornerStyle = .square
+            #expect(config.cornerRadius(contentHeight: 40) == 10)
+        }
+
+        @Test("Resolved fill color follows the background kind")
+        func resolvedFillColor() {
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            let sampled = CGColor(gray: 0.8, alpha: 1)
+
+            config.backgroundKind = .adaptive
+            #expect(config.resolvedFillColor(sampled: sampled) === sampled)
+
+            config.adaptiveBrightness = 0.5
+            let brightened = config.resolvedFillColor(sampled: sampled)
+            #expect(brightened != nil)
+            #expect(brightened !== sampled)
+
+            config.backgroundKind = .sampled
+            #expect(config.resolvedFillColor(sampled: sampled) === sampled)
+
+            config.backgroundKind = .solid
+            config.backgroundColor = CGColor(gray: 0.2, alpha: 1)
+            #expect(config.resolvedFillColor(sampled: sampled) === config.backgroundColor)
+
+            config.backgroundKind = .none
+            #expect(config.resolvedFillColor(sampled: sampled) === sampled)
+        }
+
+        @Test("Glass kind always uses liquid glass; Match Menu Bar follows the glass slider")
+        func appliesLiquidGlass() {
+            #expect(ThawBarBackgroundKind.glass.usesLiquidGlass)
+            #expect(!ThawBarBackgroundKind.adaptive.usesLiquidGlass)
+
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            config.backgroundKind = .adaptive
+            #expect(!config.appliesLiquidGlass)
+
+            config.adaptiveGlassAmount = 0.25
+            #expect(config.appliesLiquidGlass)
+
+            config.backgroundKind = .glass
+            #expect(config.appliesLiquidGlass)
+        }
+
+        @Test("Brightness adjustment mixes toward white or black")
+        func adjustingBrightness() {
+            let mid = CGColor(red: 0.4, green: 0.4, blue: 0.4, alpha: 1)
+            let lighter = ThawBarAppearancePartialConfiguration.adjustingBrightness(of: mid, by: 1)
+            let darker = ThawBarAppearancePartialConfiguration.adjustingBrightness(of: mid, by: -1)
+            #expect(lighter?.components?[0] == 1)
+            #expect(darker?.components?[0] == 0)
+            #expect(ThawBarAppearancePartialConfiguration.adjustingBrightness(of: mid, by: 0) === mid)
+        }
+
+        @Test("prefersDarkForeground uses the resolved fill brightness")
+        func prefersDarkForeground() {
+            var config = ThawBarAppearancePartialConfiguration.defaultConfiguration
+            config.backgroundKind = .solid
+            config.backgroundColor = CGColor(gray: 0.95, alpha: 1)
+
+            #expect(
+                config.prefersDarkForeground(
+                    sampledColor: nil,
+                    sampledBrightness: nil,
+                    screenHasNotch: false
+                )
+            )
+
+            config.backgroundColor = CGColor(gray: 0.1, alpha: 1)
+            #expect(
+                !config.prefersDarkForeground(
+                    sampledColor: nil,
+                    sampledBrightness: nil,
+                    screenHasNotch: false
+                )
+            )
+        }
+    }
+
+    @Suite("V2 integration")
+    struct V2IntegrationTests {
+        @Test("V2 defaults include Thaw Bar defaults")
+        func v2Defaults() {
+            let config = MenuBarAppearanceConfigurationV2.defaultConfiguration
+            #expect(config.thawBarStaticConfiguration == .defaultConfiguration)
+            #expect(config.thawBarLightModeConfiguration == .defaultConfiguration)
+            #expect(config.thawBarDarkModeConfiguration == .defaultConfiguration)
+        }
+
+        @Test("A legacy V2 payload without thawBar keys migrates borders and clears tint")
+        func legacyV2Migration() throws {
+            var menuBar = MenuBarAppearancePartialConfiguration.defaultConfiguration
+            menuBar.borderOnThawBar = true
+            menuBar.borderWidth = 3
+            menuBar.tintKind = .solid
+
+            let legacy = MenuBarAppearanceConfigurationV2(
+                lightModeConfiguration: menuBar,
+                darkModeConfiguration: menuBar,
+                staticConfiguration: menuBar,
+                thawBarLightModeConfiguration: .defaultConfiguration,
+                thawBarDarkModeConfiguration: .defaultConfiguration,
+                thawBarStaticConfiguration: .defaultConfiguration,
+                shapeKind: .noShape,
+                fullShapeInfo: .defaultValue,
+                splitShapeInfo: .defaultValue,
+                notchShapeInfo: .defaultValue,
+                isInset: true,
+                leftMargin: 0,
+                rightMargin: 0,
+                notchMargin: 0,
+                isDynamic: false
+            )
+
+            // Strip thawBar keys to simulate a pre-feature payload.
+            let encoded = try JSONEncoder().encode(legacy)
+            var object = try #require(JSONSerialization.jsonObject(with: encoded) as? [String: Any])
+            object.removeValue(forKey: "thawBarLightModeConfiguration")
+            object.removeValue(forKey: "thawBarDarkModeConfiguration")
+            object.removeValue(forKey: "thawBarStaticConfiguration")
+            let stripped = try JSONSerialization.data(withJSONObject: object)
+
+            let decoded = try JSONDecoder().decode(MenuBarAppearanceConfigurationV2.self, from: stripped)
+
+            #expect(decoded.thawBarStaticConfiguration.hasBorder)
+            #expect(decoded.thawBarStaticConfiguration.borderWidth == 3)
+            #expect(decoded.thawBarStaticConfiguration.tintKind == .noTint)
+            #expect(decoded.thawBarStaticConfiguration.backgroundKind == .adaptive)
+        }
+
+        @Test("Thaw Bar fields survive a V2 round trip")
+        func v2RoundTrip() throws {
+            var config = MenuBarAppearanceConfigurationV2.defaultConfiguration
+            config.thawBarStaticConfiguration.backgroundKind = .solid
+            config.thawBarStaticConfiguration.backgroundColor = CGColor(red: 0.1, green: 0.2, blue: 0.3, alpha: 1)
+            config.thawBarStaticConfiguration.cornerStyle = .square
+            config.thawBarStaticConfiguration.hasBorder = true
+            config.thawBarStaticConfiguration.omitTopBorderWhenSquare = false
+
+            let decoded = try JSONDecoder().decode(
+                MenuBarAppearanceConfigurationV2.self,
+                from: try JSONEncoder().encode(config)
+            )
+
+            #expect(decoded.thawBarStaticConfiguration.backgroundKind == .solid)
+            #expect(decoded.thawBarStaticConfiguration.cornerStyle == .square)
+            #expect(decoded.thawBarStaticConfiguration.hasBorder)
+            #expect(!decoded.thawBarStaticConfiguration.omitTopBorderWhenSquare)
+        }
+    }
+}
+
+@Suite("Thaw Bar border shape")
+struct ThawBarBorderShapeTests {
+    @Test("A closed border path is a continuous rounded rectangle")
+    func closedPath() {
+        let shape = ThawBarBorderShape(cornerRadius: 8, omitTopEdge: false)
+        let path = shape.path(in: CGRect(x: 0, y: 0, width: 100, height: 40))
+        #expect(!path.isEmpty)
+        // Closed shapes report a non-zero bounding box matching the rect.
+        #expect(path.boundingRect.width > 0)
+        #expect(path.boundingRect.height > 0)
+    }
+
+    @Test("An open-top path still spans the full width and height")
+    func openTopPath() {
+        let shape = ThawBarBorderShape(cornerRadius: 8, omitTopEdge: true, inset: 0.5)
+        let rect = CGRect(x: 0, y: 0, width: 120, height: 36)
+        let path = shape.path(in: rect)
+        #expect(!path.isEmpty)
+        #expect(path.boundingRect.maxY <= rect.maxY)
+        #expect(path.boundingRect.minX >= rect.minX)
+    }
+}

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -16,6 +16,8 @@ DERIVED="${DERIVED_DATA_PATH:-${HOME}/Library/Developer/Xcode/DerivedData/Thaw-l
 APP="${DERIVED}/Build/Products/Debug/Thaw.app"
 
 echo "Building with identity: ${NAME}"
+# Self-signed local identity cannot satisfy Hardened Runtime entitlement
+# checks; keep this Debug-only helper off Hardened Runtime on purpose.
 xcodebuild \
   -scheme Thaw \
   -destination 'platform=macOS' \

--- a/scripts/run-debug.sh
+++ b/scripts/run-debug.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Build Debug Thaw with the stable local codesign identity and launch it.
+# Run scripts/setup-local-codesign.sh once first.
+set -euo pipefail
+
+NAME="Thaw Local Codesign"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "${ROOT}"
+
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -F "\"${NAME}\"" >/dev/null; then
+  echo "Local codesign identity missing. Running setup…"
+  bash "${ROOT}/scripts/setup-local-codesign.sh"
+fi
+
+DERIVED="${DERIVED_DATA_PATH:-${HOME}/Library/Developer/Xcode/DerivedData/Thaw-local}"
+APP="${DERIVED}/Build/Products/Debug/Thaw.app"
+
+echo "Building with identity: ${NAME}"
+xcodebuild \
+  -scheme Thaw \
+  -destination 'platform=macOS' \
+  -configuration Debug \
+  -derivedDataPath "${DERIVED}" \
+  CODE_SIGN_STYLE=Manual \
+  CODE_SIGN_IDENTITY="${NAME}" \
+  DEVELOPMENT_TEAM= \
+  ENABLE_HARDENED_RUNTIME=NO \
+  OTHER_CODE_SIGN_FLAGS=--timestamp=none \
+  build
+
+# Ensure nested XPC is signed with the same identity (Manual style can miss it).
+if [[ -d "${APP}/Contents/XPCServices" ]]; then
+  find "${APP}/Contents/XPCServices" -name '*.xpc' -print0 2>/dev/null \
+    | while IFS= read -r -d '' xpc; do
+      codesign --force --sign "${NAME}" --timestamp=none --deep "${xpc}" || true
+    done
+fi
+codesign --force --sign "${NAME}" --timestamp=none --deep "${APP}"
+
+echo "Codesign verify:"
+codesign -dv --verbose=2 "${APP}" 2>&1 | rg -i "Authority|Identifier|Signature|TeamIdentifier|Format" || true
+
+pkill -x Thaw 2>/dev/null || true
+sleep 0.4
+open "${APP}"
+sleep 1
+pgrep -lf "Thaw.app/Contents/MacOS/Thaw" | head -3 || true
+echo "Launched: ${APP}"

--- a/scripts/setup-local-codesign.sh
+++ b/scripts/setup-local-codesign.sh
@@ -61,7 +61,6 @@ security unlock-keychain -p "" "${KEYCHAIN}" 2>/dev/null || true
 security import "${TMP}/cert.p12" \
   -k "${KEYCHAIN}" \
   -P thaw-local \
-  -A \
   -T /usr/bin/codesign \
   -T /usr/bin/security \
   -T /usr/bin/productsign

--- a/scripts/setup-local-codesign.sh
+++ b/scripts/setup-local-codesign.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Creates a stable self-signed code-signing identity in the login keychain so
+# Debug rebuilds keep the same designated requirement. Ad-hoc ("-") signing
+# changes the CDHash on every build, which forces macOS to re-prompt for
+# Accessibility / Screen Recording. A fixed local cert avoids that.
+set -euo pipefail
+
+NAME="Thaw Local Codesign"
+KEYCHAIN="${HOME}/Library/Keychains/login.keychain-db"
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+STATE_DIR="${ROOT}/.local-codesign"
+mkdir -p "${STATE_DIR}"
+
+if security find-identity -v -p codesigning 2>/dev/null | grep -F "\"${NAME}\"" >/dev/null; then
+  echo "Codesigning identity already installed: ${NAME}"
+  security find-identity -v -p codesigning | grep -F "${NAME}" || true
+  exit 0
+fi
+
+TMP="$(mktemp -d "${TMPDIR:-/tmp}/thaw-codesign.XXXXXX")"
+cleanup() { rm -rf "${TMP}"; }
+trap cleanup EXIT
+
+cat > "${TMP}/cert.conf" <<EOF
+[req]
+default_bits = 2048
+prompt = no
+default_md = sha256
+distinguished_name = dn
+x509_extensions = v3_codesign
+
+[dn]
+CN = ${NAME}
+O = Thaw Local Development
+OU = Debug
+
+[v3_codesign]
+basicConstraints = critical,CA:false
+keyUsage = critical,digitalSignature
+extendedKeyUsage = critical,codeSigning
+EOF
+
+openssl req -x509 -newkey rsa:2048 \
+  -keyout "${TMP}/key.pem" \
+  -out "${TMP}/cert.pem" \
+  -days 3650 \
+  -nodes \
+  -config "${TMP}/cert.conf"
+
+# Keep a copy for re-import / trust repair; not a secret beyond the keychain.
+cp "${TMP}/cert.pem" "${STATE_DIR}/thaw-local-codesign.cer.pem"
+
+openssl pkcs12 -export \
+  -out "${TMP}/cert.p12" \
+  -inkey "${TMP}/key.pem" \
+  -in "${TMP}/cert.pem" \
+  -passout pass:thaw-local
+
+security unlock-keychain -p "" "${KEYCHAIN}" 2>/dev/null || true
+
+security import "${TMP}/cert.p12" \
+  -k "${KEYCHAIN}" \
+  -P thaw-local \
+  -A \
+  -T /usr/bin/codesign \
+  -T /usr/bin/security \
+  -T /usr/bin/productsign
+
+# Allow codesign to use the private key without a GUI prompt in this session.
+security set-key-partition-list \
+  -S apple-tool:,apple:,codesign: \
+  -s \
+  -k "" \
+  "${KEYCHAIN}" 2>/dev/null || true
+
+# Prefer user-keychain trust; fall back to system (may prompt for password).
+if ! security add-trusted-cert \
+  -d \
+  -r trustRoot \
+  -p codeSign \
+  -k "${KEYCHAIN}" \
+  "${TMP}/cert.pem" 2>/dev/null
+then
+  echo "User-keychain trust failed; trying System keychain (may ask for your password)…"
+  sudo security add-trusted-cert \
+    -d \
+    -r trustRoot \
+    -p codeSign \
+    -k /Library/Keychains/System.keychain \
+    "${TMP}/cert.pem"
+fi
+
+echo
+echo "Installed codesigning identity:"
+security find-identity -v -p codesigning | grep -F "${NAME}" || {
+  echo "error: identity not visible to codesign after import" >&2
+  exit 1
+}
+
+echo
+echo "Done. Use scripts/run-debug.sh to build and launch with this identity."
+echo "First launch after switching from ad-hoc may still ask for permissions once;"
+echo "later rebuilds with this same identity should keep them."

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -37,9 +37,11 @@ $(SRCROOT)/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfiguration
 $(SRCROOT)/Thaw/MenuBar/Appearance/Configurations/MenuBarAppearanceConfigurationV2.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/Configurations/MenuBarShapes.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/Configurations/MenuBarTintKind.swift
+$(SRCROOT)/Thaw/MenuBar/Appearance/Configurations/ThawBarAppearanceConfiguration.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditor.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarAppearanceEditorPanel.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/MenuBarShapePicker.swift
+$(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarAppearanceEditor/ThawBarAppearanceEditor.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarAppearanceManager.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
 $(SRCROOT)/Thaw/MenuBar/Appearance/MissionControlDetector.swift
@@ -51,6 +53,8 @@ $(SRCROOT)/Thaw/MenuBar/IceBar/IceBar.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarColorManager.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLayout.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLocation.swift
+$(SRCROOT)/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+$(SRCROOT)/Thaw/MenuBar/IceBar/ThawBarChrome.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBar.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift


### PR DESCRIPTION
## Summary
- Give the Thaw Bar its own appearance model and editor (background, tint, corners, border, shadow), including Match Menu Bar brightness/glass sliders and #325 square-corner top-border omission.
- Paint Match Menu Bar from a live menu-bar sample, with optional brightness and liquid-glass blend, instead of sharing the menu bar overlay tint.
- Fix multi-display light/dark icon flashes by keeping per-display icon caches, restoring the warm snapshot on open, and always ordering the panel front immediately so the first click still shows the bar.
- Local Debug helpers (`scripts/setup-local-codesign.sh`, `scripts/run-debug.sh`) keep a stable self-signed identity so Accessibility / Screen Recording survive rebuilds.

PR is larger than the usual ≤500 LOC aim because the appearance model, editor, IceBar rendering, multi-display image cache, and local codesign tooling are one user-facing change set for #325 / Thaw Bar appearance.

Closes: #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added customizable Thaw Bar appearance settings, including backgrounds, tint, glass effects, corners, borders, shadows, and light/dark configurations.
  * Added live appearance previews and improved menu bar rendering across displays.
  * Added appearance-related settings search entries.

* **Bug Fixes**
  * Improved display-specific color sampling and image restoration.
  * Migrated existing appearance settings for compatibility with the new Thaw Bar options.

* **Chores**
  * Added local debug signing and launch tools.
  * Added coverage for appearance configuration, migration, encoding, and border rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->