### PR TITLE
fix: editor-drag reveal, overlay-panel space fallback, and 1.x click-gesture migration (#1010, #794, #1012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,15 @@ Please report issues at
    the active menu bar now falls back to the global active space (the two
    coincide there by definition), and the decision logs its inputs so the
    remaining field reports can be pinned to a branch.
+3. The 1.x click gestures survive the upgrade to 2.x (#1012). Option-click
+   and double-click on the menu bar toggled the always-hidden section
+   unconditionally in 1.x; 2.0 turned both into opt-in settings that
+   default to off and whose keys did not exist for upgraders, so the
+   gestures silently stopped working. Both settings now come up on when
+   they have never been explicitly set, and an explicit choice (including
+   off) is never overwritten. The control items' phantom-click suppression
+   no longer swallows the right-click menu, which it also blocked whenever
+   the menu bar transiently had no item windows on the active space.
 
 ## [2.0.1-rc.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Please report issues at
    section puts the always-hidden boundary onscreen. The reveal now
    expands the hidden section alongside the always-hidden section and
    restores both once the item settles.
+2. Menu bar appearance re-homing after a space switch no longer depends on
+   the per-display space query alone (#794). On macOS 26 setups where that
+   query stops answering, the old code silently assumed the overlay panel
+   was in place, so the tint, shape, and background stayed stuck on the
+   launch space for every recovery path. The panel on the display that owns
+   the active menu bar now falls back to the global active space (the two
+   coincide there by definition), and the decision logs its inputs so the
+   remaining field reports can be pinned to a branch.
 
 ## [2.0.1-rc.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ The `release.yml` workflow reads the section matching the release tag
 (`## [tag]`) and uses it as the release notes for both the GitHub Release
 and the Sparkle appcast, unless overridden with the `release_notes` input.
 
+## [Unreleased]
+
+Please report issues at
+[github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
+
+### Fixed
+
+1. A drag into an empty, collapsed Always-Hidden section now works even
+   when the Hidden section is also collapsed (#1010). The #988 reveal
+   expanded only the destination section, but the always-hidden divider
+   parks to the left of the hidden section's content: with the hidden
+   section collapsed behind its 10000-point spacer, the revealed divider
+   was re-placed just left of that still-parked content and never came
+   onscreen, so every drag timed out into the "open the section"
+   refusal — advice that could not help, since only expanding the hidden
+   section puts the always-hidden boundary onscreen. The reveal now
+   expands the hidden section alongside the always-hidden section and
+   restores both once the item settles.
+
 ## [2.0.1-rc.1]
 
 Please report issues at

--- a/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
+++ b/Thaw/MenuBar/Appearance/MenuBarOverlayPanel.swift
@@ -461,6 +461,9 @@ final class MenuBarOverlayPanel: NSPanel, @unchecked Sendable {
         // joins the display's current space. A stranded panel is invisible
         // by definition, so this cannot flicker. (#794)
         if isStrandedOnInactiveSpace() {
+            diagLog.info(
+                "Re-homing the overlay panel onto display \(owningScreen.displayID)'s current space (#794)"
+            )
             orderOut(nil)
         }
 
@@ -494,25 +497,62 @@ final class MenuBarOverlayPanel: NSPanel, @unchecked Sendable {
             // Never ordered — the fresh order in `show()` will place it.
             return true
         }
-        guard let currentSpace = SpaceInfo.currentSpace(for: owningScreen.displayID) else {
-            // No per-display space info — assume the panel is where it is.
-            return false
+        let panelSpaces = Bridging.getSpaceList(for: windowID)
+        let currentSpace = SpaceInfo.currentSpace(for: owningScreen.displayID)
+        let ownsActiveMenuBar = owningScreen.displayID == NSScreen.screenWithActiveMenuBar?.displayID
+        // Diagnostics for the remaining #794 reports: on macOS 26 setups
+        // where the re-home still misses (still reproducing in 2.0.1-rc.1),
+        // the per-display space query is the prime suspect — the nil branch
+        // used to silently assume the panel was fine. Log which leg of the
+        // decision produced the verdict so field reports pin the failure.
+        if currentSpace == nil {
+            diagLog.warning(
+                "Per-display space query returned nil for display \(owningScreen.displayID) (ownsActiveMenuBar: \(ownsActiveMenuBar)); panel spaces: \(panelSpaces)"
+            )
         }
-        return Self.isStranded(
-            panelSpaces: Bridging.getSpaceList(for: windowID),
-            currentSpace: currentSpace.spaceID
+        let stranded = Self.isStranded(
+            panelSpaces: panelSpaces,
+            currentSpace: currentSpace?.spaceID,
+            globalActiveSpace: Bridging.getActiveSpaceID(),
+            ownsActiveMenuBar: ownsActiveMenuBar
         )
+        if stranded {
+            diagLog.info(
+                "Overlay panel is stranded: display \(owningScreen.displayID), windowID \(windowID), panel spaces \(panelSpaces), current space \(String(describing: currentSpace?.spaceID)), active space \(Bridging.getActiveSpaceID())"
+            )
+        }
+        return stranded
     }
 
     /// The pure decision behind `isStrandedOnInactiveSpace`, so it can be
     /// exercised without a live window server connection. The panel is
     /// stranded when it does not sit on the current space of its owning
     /// display, which is also the case for a panel that was never ordered.
-    static func isStranded(panelSpaces: [CGSSpaceID], currentSpace: CGSSpaceID?) -> Bool {
-        guard let currentSpace else {
+    ///
+    /// When the per-display current space is unknown, the panel on the
+    /// display that owns the active menu bar falls back to the global
+    /// active space: the two coincide there by definition. The pre-fallback
+    /// "assume fine" branch could strand a panel permanently when macOS
+    /// stopped answering the per-display query, because every recovery path
+    /// (space switch, post-switch confirmation, housekeeping timer) funnels
+    /// through this one decision (#794). For any other display the decision
+    /// stays conservative: a wrong order-out would flicker the bar on every
+    /// housekeeping pass, and unlike the old `.moveToActiveSpace` the
+    /// explicit order-out + order-front in `show()` cannot drift the panel
+    /// onto another display.
+    static func isStranded(
+        panelSpaces: [CGSSpaceID],
+        currentSpace: CGSSpaceID?,
+        globalActiveSpace: CGSSpaceID,
+        ownsActiveMenuBar: Bool
+    ) -> Bool {
+        if let currentSpace {
+            return !panelSpaces.contains(currentSpace)
+        }
+        guard ownsActiveMenuBar else {
             return false
         }
-        return !panelSpaces.contains(currentSpace)
+        return !panelSpaces.contains(globalActiveSpace)
     }
 
     /// Schedules one delayed re-check of the stranded-panel migration after

--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -815,20 +815,23 @@ final class ControlItem {
         }
         let menuBarManager = appState.menuBarManager
 
-        // Suppress phantom clicks delivered to the status item button while
-        // no menu bar items are rendered on-screen for the active space. This
-        // catches fast top-of-screen clicks during the menu bar reveal
-        // sequence under a fullscreen app, which would otherwise expand the
-        // hidden section offscreen. NSApp.currentSystemPresentationOptions is
-        // per-app and does not reflect another app's fullscreen state, so the
-        // items-list signal is used directly.
-        let screenForCheck = window?.screen ?? NSScreen.main
-        if let screen = screenForCheck, !screen.isSystemMenuBarVisible() {
-            return
-        }
-
         switch event.type {
         case .leftMouseDown:
+            // Suppress phantom left clicks delivered to the status item
+            // button while no menu bar items are rendered on-screen for the
+            // active space. This catches fast top-of-screen clicks during
+            // the menu bar reveal sequence under a fullscreen app, which
+            // would otherwise expand the hidden section offscreen.
+            // NSApp.currentSystemPresentationOptions is per-app and does
+            // not reflect another app's fullscreen state, so the items-list
+            // signal is used directly. Scoped to left clicks so the
+            // right-click menu below keeps working when the menu bar
+            // transiently has no item windows on the active space (#1012).
+            let screenForCheck = window?.screen ?? NSScreen.main
+            if let screen = screenForCheck, !screen.isSystemMenuBarVisible() {
+                return
+            }
+
             // Capture modifier flags from the event to ensure we have the state
             // at the time of the click, not when the Task executes.
             let modifierFlags = event.modifierFlags

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -233,9 +233,13 @@ final class LayoutBarPaddingView: NSView {
             // advice has nothing to open. In that one state, reveal the
             // section to bring its divider back onscreen, retarget the move
             // onto the fresh divider, and re-conceal the section once the
-            // item has settled.
+            // item has settled. The always-hidden divider parks to the left
+            // of the hidden section's content, so revealing the destination
+            // alone is not enough to bring it onscreen when the hidden
+            // section is also collapsed (#1010): the reveal covers every
+            // section whose parked content would keep the divider offscreen.
             var destination = destination
-            var revealedSection: MenuBarSection?
+            var revealedSections: [MenuBarSection] = []
             let targetItem = destination.targetItem
             if targetItem.isControlItem {
                 let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
@@ -252,11 +256,11 @@ final class LayoutBarPaddingView: NSView {
                     LayoutSolver.isOnScreen(bounds: $0, screenFrames: screenFrames)
                 } ?? false
                 if !isReachable {
-                    if let (section, freshDivider) = await revealEmptySectionDivider(
+                    if let (sections, freshDivider) = await revealEmptySectionDivider(
                         for: targetItem,
                         appState: appState
                     ) {
-                        revealedSection = section
+                        revealedSections = sections
                         destination = switch destination {
                         case .leftOfItem: .leftOfItem(freshDivider)
                         case .rightOfItem: .rightOfItem(freshDivider)
@@ -284,20 +288,22 @@ final class LayoutBarPaddingView: NSView {
                 }
             }
 
-            let watchdogTask = Task { [weak self, weak appState, revealedSection] in
+            let watchdogTask = Task { [weak self, weak appState, revealedSections] in
                 try? await Task.sleep(for: MenuBarItemManager.layoutWatchdogTimeout + .seconds(1))
                 guard let self, !Task.isCancelled else { return }
                 await self.resetStabilizingStateIfNeeded()
-                if let revealedSection {
+                if !revealedSections.isEmpty {
                     // The move never returned, so the completion path that
-                    // re-conceals the section revealed for the drag (#988)
-                    // has not run and may never run. Restore it here, the
+                    // re-conceals the sections revealed for the drag (#988)
+                    // has not run and may never run. Restore them here, the
                     // same way, and give the spacer a beat to re-park the
                     // divider before the closing cache pass records the
                     // settled bar. Idempotent with a late completion: the
                     // restore recomputes the persisted presentation.
                     await MainActor.run {
-                        revealedSection.updateControlItemState(for: nil)
+                        for section in revealedSections {
+                            section.updateControlItemState(for: nil)
+                        }
                     }
                     try? await Task.sleep(for: .milliseconds(250))
                 }
@@ -425,15 +431,17 @@ final class LayoutBarPaddingView: NSView {
                     alert.runModal()
                 }
             }
-            if let revealedSection {
-                // Re-conceal the section that was revealed for the drag
+            if !revealedSections.isEmpty {
+                // Re-conceal the sections that were revealed for the drag
                 // (#988). desiredState was never modified, so
                 // updateControlItemState restores whatever presentation the
                 // user configured — including the ice-bar overrides that
                 // force these sections collapsed — and parks the divider
                 // with the newly moved item back offscreen.
                 await MainActor.run {
-                    revealedSection.updateControlItemState(for: nil)
+                    for section in revealedSections {
+                        section.updateControlItemState(for: nil)
+                    }
                 }
                 // Give the spacer a beat to re-park the divider before the
                 // closing cache pass records the settled bar.
@@ -556,7 +564,7 @@ final class LayoutBarPaddingView: NSView {
     }
 
     /// Maps a section-divider tag to the name of the section it bounds.
-    private nonisolated static func sectionName(forDividerTag tag: MenuBarItemTag) -> MenuBarSection.Name? {
+    private static nonisolated func sectionName(forDividerTag tag: MenuBarItemTag) -> MenuBarSection.Name? {
         switch tag {
         case .hiddenControlItem: .hidden
         case .alwaysHiddenControlItem: .alwaysHidden
@@ -584,9 +592,31 @@ final class LayoutBarPaddingView: NSView {
         return isSectionConcealed && isEnabled
     }
 
-    /// Reveals an empty, concealed destination section so its parked divider
-    /// returns onscreen, and returns the section together with the divider's
-    /// fresh live item (#988).
+    /// Which sections must expand inline so the given section divider can
+    /// return onscreen for an editor drag.
+    ///
+    /// The always-hidden divider sits to the LEFT of everything in the
+    /// hidden section. Revealing the always-hidden section alone shrinks
+    /// its 10000-point parked spacer back to a normal-width item, but AppKit
+    /// re-places that item just left of the hidden section's own content —
+    /// which is still parked offscreen behind the hidden divider's
+    /// 10000-point spacer while the hidden section is collapsed (#1010).
+    /// Both sections must expand together; a hidden destination needs only
+    /// itself. Pure over its input.
+    static nonisolated func sectionsToRevealForEditorDrag(
+        forDividerTag dividerTag: MenuBarItemTag
+    ) -> [MenuBarSection.Name] {
+        switch dividerTag {
+        case .hiddenControlItem: [.hidden]
+        case .alwaysHiddenControlItem: [.hidden, .alwaysHidden]
+        default: []
+        }
+    }
+
+    /// Reveals an empty, concealed destination section — together with every
+    /// section whose parked content would keep its divider offscreen
+    /// (#1010) — so the divider returns onscreen, and returns the revealed
+    /// sections together with the divider's fresh live item (#988).
     ///
     /// Returns nil — leaving the bar untouched — when the state does not
     /// qualify per `shouldRevealSectionForEditorDrag`, or the divider did
@@ -595,7 +625,7 @@ final class LayoutBarPaddingView: NSView {
     private func revealEmptySectionDivider(
         for divider: MenuBarItem,
         appState: AppState
-    ) async -> (section: MenuBarSection, divider: MenuBarItem)? {
+    ) async -> (sections: [MenuBarSection], divider: MenuBarItem)? {
         guard let sectionName = Self.sectionName(forDividerTag: divider.tag) else {
             return nil
         }
@@ -619,19 +649,36 @@ final class LayoutBarPaddingView: NSView {
             return nil
         }
 
-        Self.diagLog.info(
-            "Revealing the empty \(sectionName.logString) to bring its divider onscreen for the editor drag (#988)"
-        )
-        await MainActor.run {
-            section.controlItem.state = .showSection
+        // Resolve the full reveal scope. Sections ahead of the destination
+        // are expanded regardless of their own state: the gate above only
+        // qualifies the destination, and the leading sections exist purely
+        // to bring the destination's divider onscreen (#1010).
+        let revealNames = Self.sectionsToRevealForEditorDrag(forDividerTag: divider.tag)
+        var sections: [MenuBarSection] = []
+        for name in revealNames {
+            guard let resolved = await MainActor.run(body: {
+                appState.menuBarManager.section(withName: name)
+            }) else {
+                return nil
+            }
+            sections.append(resolved)
         }
 
-        // A cancelled drag must not leave the empty section showing: the
+        Self.diagLog.info(
+            "Revealing \(revealNames.map(\.logString).joined(separator: " + ")) to bring the \(sectionName.logString) divider onscreen for the editor drag (#988, #1010)"
+        )
+        await MainActor.run {
+            for revealedSection in sections {
+                revealedSection.controlItem.state = .showSection
+            }
+        }
+
+        // A cancelled drag must not leave the revealed sections showing: the
         // reveal is a Thaw-internal detour, so every cancellation exit
-        // restores the section's persisted state, the same way the timeout
+        // restores the sections' persisted state, the same way the timeout
         // path below does.
         if Task.isCancelled {
-            await revertRevealedSection(section)
+            await revertRevealedSections(sections)
             return nil
         }
 
@@ -641,14 +688,14 @@ final class LayoutBarPaddingView: NSView {
         // captured item's windowID survives the state change, but its
         // bounds snapshot does not, so resolve a fresh item.
         let screenFrames = NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-        for _ in 0..<40 {
+        for _ in 0 ..< 40 {
             try? await Task.sleep(for: .milliseconds(50))
             // A cancelled sleep returns immediately, so without this check a
             // cancelled task would burn through the remaining iterations and
             // fall into the revert below, which owns the timeout path — not
             // cancellation. Exit the reveal outright.
             if Task.isCancelled {
-                await revertRevealedSection(section)
+                await revertRevealedSections(sections)
                 return nil
             }
             let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
@@ -656,7 +703,7 @@ final class LayoutBarPaddingView: NSView {
                let bounds = Bridging.getWindowBounds(for: fresh.windowID),
                LayoutSolver.isOnScreen(bounds: bounds, screenFrames: screenFrames)
             {
-                return (section, fresh)
+                return (sections, fresh)
             }
         }
 
@@ -665,17 +712,19 @@ final class LayoutBarPaddingView: NSView {
         Self.diagLog.warning(
             "The \(sectionName.logString) divider did not come onscreen after revealing; refusing the drag"
         )
-        await revertRevealedSection(section)
+        await revertRevealedSections(sections)
         return nil
     }
 
-    /// Returns a section's control item to its persisted state after a
-    /// temporary reveal, on the main actor. Shared by the cancellation and
-    /// timeout exits so a cancelled or failed reveal cannot leave an empty
-    /// section showing.
-    private func revertRevealedSection(_ section: MenuBarSection) async {
+    /// Returns every revealed section's control item to its persisted state
+    /// after a temporary reveal, on the main actor. Shared by the
+    /// cancellation and timeout exits so a cancelled or failed reveal cannot
+    /// leave a section showing.
+    private func revertRevealedSections(_ sections: [MenuBarSection]) async {
         await MainActor.run {
-            section.updateControlItemState(for: nil)
+            for section in sections {
+                section.updateControlItemState(for: nil)
+            }
         }
     }
 

--- a/Thaw/Settings/Models/AdvancedSettings.swift
+++ b/Thaw/Settings/Models/AdvancedSettings.swift
@@ -132,7 +132,7 @@ final class AdvancedSettings {
     /// - Otherwise snaps to `1 / clamp(round(1 / interval), 1, ceiling)`,
     ///   where the ceiling is ``MenuBarItemImageCache/maxIconRefreshRate``.
     /// - Idempotent: already-on-grid values round-trip unchanged.
-    nonisolated static func normalizedIconRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
+    static nonisolated func normalizedIconRefreshInterval(_ interval: TimeInterval) -> TimeInterval {
         guard interval > 0 else { return 0 }
         let ceiling = MenuBarItemImageCache.maxIconRefreshRate
         let fps = min(max((1.0 / interval).rounded(), 1), ceiling)
@@ -281,6 +281,20 @@ final class AdvancedSettings {
 
     /// Loads the model's initial state.
     private func loadInitialState() {
+        // 1.x click-gesture migration (#1012): option-click and double-click
+        // on the menu bar toggled the always-hidden section unconditionally
+        // in 1.x. 2.0 replaced them with opt-in gates whose keys did not
+        // exist for upgraders, so the gestures silently stopped working —
+        // reported as "2.0 did not honor the settings from 1.2". Seed both
+        // gates on when they have never been explicitly set; an explicit
+        // choice (either value, including off) is never overwritten.
+        if Defaults.object(forKey: .useOptionClickToShowAlwaysHiddenSection) == nil {
+            Defaults.set(true, forKey: .useOptionClickToShowAlwaysHiddenSection)
+        }
+        if Defaults.object(forKey: .useDoubleClickToShowAlwaysHiddenSection) == nil {
+            Defaults.set(true, forKey: .useDoubleClickToShowAlwaysHiddenSection)
+        }
+
         Defaults.ifPresent(key: .enableAlwaysHiddenSection, assign: &enableAlwaysHiddenSection)
         Defaults.ifPresent(key: .useOptionClickToShowAlwaysHiddenSection, assign: &useOptionClickToShowAlwaysHiddenSection)
         Defaults.ifPresent(key: .useDoubleClickToShowAlwaysHiddenSection, assign: &useDoubleClickToShowAlwaysHiddenSection)

--- a/ThawTests/MenuBar/Appearance/MenuBarOverlayPanelSpaceTests.swift
+++ b/ThawTests/MenuBar/Appearance/MenuBarOverlayPanelSpaceTests.swift
@@ -10,9 +10,9 @@ import Foundation
 import Testing
 @testable import Thaw
 
-/// Covers `MenuBarOverlayPanel.isStranded(panelSpaces:currentSpace:)`, the
-/// pure decision behind the space migration in `show()` (#794). The rest of
-/// the migration talks to the window server (per-display current space and
+/// Covers `MenuBarOverlayPanel.isStranded(panelSpaces:currentSpace:globalActiveSpace:ownsActiveMenuBar:)`,
+/// the pure decision behind the space migration in `show()` (#794). The rest
+/// of the migration talks to the window server (per-display current space,
 /// the panel's own space list) and isn't practically unit-testable; this is
 /// the one piece of its logic that is.
 @Suite("Menu bar overlay panel spaces")
@@ -21,7 +21,9 @@ struct MenuBarOverlayPanelSpaceTests {
     func onCurrentSpaceIsNotStranded() {
         let stranded = MenuBarOverlayPanel.isStranded(
             panelSpaces: [10],
-            currentSpace: 10
+            currentSpace: 10,
+            globalActiveSpace: 10,
+            ownsActiveMenuBar: false
         )
         #expect(!stranded)
     }
@@ -31,7 +33,9 @@ struct MenuBarOverlayPanelSpaceTests {
         // Panel sits on space 10 while its display moved on to space 11.
         let stranded = MenuBarOverlayPanel.isStranded(
             panelSpaces: [10],
-            currentSpace: 11
+            currentSpace: 11,
+            globalActiveSpace: 11,
+            ownsActiveMenuBar: false
         )
         #expect(stranded)
     }
@@ -41,18 +45,61 @@ struct MenuBarOverlayPanelSpaceTests {
         // No spaces at all until the first order-front places it.
         let stranded = MenuBarOverlayPanel.isStranded(
             panelSpaces: [],
-            currentSpace: 10
+            currentSpace: 10,
+            globalActiveSpace: 10,
+            ownsActiveMenuBar: false
         )
         #expect(stranded)
     }
 
-    @Test("An unknown owning display's current space does not strand the panel")
-    func unknownCurrentSpaceIsNotStranded() {
-        // Without per-display space info, `show()` keeps the panel where it
-        // is rather than ordering it out on a guess.
+    @Test("A known current space beats the fallback")
+    func knownCurrentSpaceBeatsFallback() {
+        // The display's own space is authoritative: even with the panel
+        // owning the active menu bar and the global active space pointing
+        // elsewhere, a known per-display space decides the verdict alone.
         let stranded = MenuBarOverlayPanel.isStranded(
             panelSpaces: [10],
-            currentSpace: nil
+            currentSpace: 10,
+            globalActiveSpace: 11,
+            ownsActiveMenuBar: true
+        )
+        #expect(!stranded)
+    }
+
+    @Test("An unknown current space falls back to the global active space on the active display")
+    func unknownCurrentSpaceFallsBackOnActiveDisplay() {
+        // #794: on macOS 26 setups where the per-display query stops
+        // answering, the display that owns the active menu bar can still
+        // judge the panel against the global active space — the two
+        // coincide there by definition. A panel the switch left behind is
+        // stranded; one that followed is not.
+        let stranded = MenuBarOverlayPanel.isStranded(
+            panelSpaces: [10],
+            currentSpace: nil,
+            globalActiveSpace: 11,
+            ownsActiveMenuBar: true
+        )
+        #expect(stranded)
+
+        let followed = MenuBarOverlayPanel.isStranded(
+            panelSpaces: [11],
+            currentSpace: nil,
+            globalActiveSpace: 11,
+            ownsActiveMenuBar: true
+        )
+        #expect(!followed)
+    }
+
+    @Test("An unknown current space does not strand a panel on a sibling display")
+    func unknownCurrentSpaceIsNotStrandedOnSiblingDisplay() {
+        // The fallback must not reach sibling displays: the global active
+        // space says nothing about their current space, and a wrong
+        // order-out would flicker the bar on every housekeeping pass.
+        let stranded = MenuBarOverlayPanel.isStranded(
+            panelSpaces: [10],
+            currentSpace: nil,
+            globalActiveSpace: 11,
+            ownsActiveMenuBar: false
         )
         #expect(!stranded)
     }
@@ -64,7 +111,9 @@ struct MenuBarOverlayPanelSpaceTests {
         // current space.
         let stranded = MenuBarOverlayPanel.isStranded(
             panelSpaces: [30],
-            currentSpace: 30
+            currentSpace: 30,
+            globalActiveSpace: 30,
+            ownsActiveMenuBar: false
         )
         #expect(!stranded)
     }

--- a/ThawTests/MenuBar/Layout/EmptySectionEditorDragTests.swift
+++ b/ThawTests/MenuBar/Layout/EmptySectionEditorDragTests.swift
@@ -123,4 +123,27 @@ struct EmptySectionEditorDragTests {
             )
         )
     }
+
+    @Test("An always-hidden destination reveals the hidden section with it (#1010)")
+    func alwaysHiddenDestinationRevealsLeadingSections() {
+        // #1010: the always-hidden divider parks to the LEFT of the hidden
+        // section's content. Revealing the always-hidden section alone
+        // shrinks its parked spacer, but AppKit re-places the divider just
+        // left of the hidden section's still-parked content, so it never
+        // comes onscreen and the reveal times out into the #923 refusal —
+        // the reporter's "still same error even after a few system
+        // restarts". The hidden section must expand with it.
+        #expect(
+            LayoutBarPaddingView.sectionsToRevealForEditorDrag(forDividerTag: .alwaysHiddenControlItem)
+                == [.hidden, .alwaysHidden]
+        )
+        // A hidden destination has nothing parked ahead of it that a reveal
+        // would not cover; non-divider tags reveal nothing at all.
+        #expect(
+            LayoutBarPaddingView.sectionsToRevealForEditorDrag(forDividerTag: .hiddenControlItem)
+                == [.hidden]
+        )
+        #expect(LayoutBarPaddingView.sectionsToRevealForEditorDrag(forDividerTag: .visibleControlItem).isEmpty)
+        #expect(LayoutBarPaddingView.sectionsToRevealForEditorDrag(forDividerTag: .clock).isEmpty)
+    }
 }

--- a/ThawTests/Settings/Models/AdvancedSettingsTests.swift
+++ b/ThawTests/Settings/Models/AdvancedSettingsTests.swift
@@ -81,6 +81,36 @@ struct AdvancedSettingsTests {
 
     // MARK: Initial load
 
+    @Test("Never-set click gates are seeded on for 1.x upgraders (#1012)")
+    func unsetClickGatesAreSeededOn() throws {
+        try withScratchDefaults { _ in
+            let settings = makeSettings()
+
+            // 1.x toggled the always-hidden section on option-click and
+            // double-click unconditionally; the 2.0 gates defaulted to off
+            // and their keys did not exist for upgraders, so the gestures
+            // silently died. Absent keys must come up on.
+            #expect(settings.useOptionClickToShowAlwaysHiddenSection)
+            #expect(settings.useDoubleClickToShowAlwaysHiddenSection)
+            #expect(Defaults.bool(forKey: .useOptionClickToShowAlwaysHiddenSection))
+            #expect(Defaults.bool(forKey: .useDoubleClickToShowAlwaysHiddenSection))
+        }
+    }
+
+    @Test("An explicit click-gate choice is never overwritten (#1012)")
+    func explicitClickGateChoicesAreRespected() throws {
+        try withScratchDefaults { _ in
+            Defaults.set(false, forKey: .useOptionClickToShowAlwaysHiddenSection)
+            Defaults.set(false, forKey: .useDoubleClickToShowAlwaysHiddenSection)
+            let settings = makeSettings()
+
+            #expect(!settings.useOptionClickToShowAlwaysHiddenSection)
+            #expect(!settings.useDoubleClickToShowAlwaysHiddenSection)
+            #expect(!Defaults.bool(forKey: .useOptionClickToShowAlwaysHiddenSection))
+            #expect(!Defaults.bool(forKey: .useDoubleClickToShowAlwaysHiddenSection))
+        }
+    }
+
     @Test("Stored values are loaded into the model")
     func storedValuesAreLoaded() throws {
         try withScratchDefaults { _ in


### PR DESCRIPTION
# Summary

Three field-reported fixes, each with its own test and changelog entry:

**1. Always-hidden editor drag reveal scope (#1010)** — dragging an item onto an empty, collapsed Always-Hidden section in Settings → Menu Bar Layout still refused with "The Always-Hidden section is collapsed, so its divider is offscreen." The #988 reveal expanded only the destination section, but the always-hidden divider parks to the **left** of the hidden section's content: with the hidden section collapsed behind its 10000-point spacer, AppKit re-placed the revealed divider just left of that still-parked content, so it never came onscreen and the 2-second poll timed out. The reveal scope is now derived from the destination divider (`sectionsToRevealForEditorDrag`): an always-hidden destination expands the hidden section alongside the always-hidden section, and every revealed section is restored to its persisted presentation on the success, watchdog-timeout, and cancellation paths.

**2. Overlay panel space-migration fallback + diagnostics (#794)** — on macOS 26 setups still reproducing in 2.0.1-rc.1 (see the issue thread, e.g. [comment #5477110783](https://github.com/thaw-app/Thaw/issues/794#issuecomment-5477110783)), the per-display space query can stop answering, and the pre-existing `guard let currentSpace … else { return false }` branch then assumed the overlay panel was in place *forever* — every recovery path (space switch, post-switch confirmation, 60 s housekeeping timer) funnels through that one nil guard. The panel on the display that owns the active menu bar now falls back to the global active space (the two coincide there by definition), sibling displays keep the conservative "assume fine" verdict, and the decision logs its inputs plus each actual re-home so remaining field reports can be pinned to a branch.


**3. 1.x click gestures lost in the 2.0 upgrade (#1012)** — the reporter's downgrade to 1.2.0 confirmed both claims in the thread. Option-click and double-click toggled the always-hidden section unconditionally in 1.x; 2.0 turned both into opt-in settings whose keys did not exist for upgraders, so the gestures silently died — matching "2.0 did not honor the settings from 1.2". `loadInitialState()` now seeds both gates on when they have never been explicitly set (an explicit choice, including off, is never overwritten). Additionally, the phantom-click guard sat before the event switch in `ControlItem.performAction()`, so it also swallowed `rightMouseUp` — the control items' context menu was unreachable whenever the menu bar transiently had no item windows on the active space. The guard is now scoped to `leftMouseDown`, the case it was written to protect.

**Scope:** Three focused bug fixes, each with its own test and changelog entry; no refactoring.

## Linked issue (required)

Closes: #1010

Refs: #794 (hardening + diagnostics; not auto-closing until the reporter confirms)
Refs: #1012 (the two bug claims in the comments; the report-form complaint is out of scope here)

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

- [ ] menubar
- [ ] icebar
- [x] layout
- [x] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- **#1010:** dropping an item onto an empty, collapsed Always-Hidden section now expands the hidden section together with the always-hidden section so the destination divider physically returns onscreen, performs the move onto the fresh divider, and re-conceals both sections afterwards. A hidden destination behaves exactly as before.
- **#794:** when the per-display current-space query returns nil, the overlay panel on the display owning the active menu bar judges strandedness against the global active space and re-homes (order-out + order-front joins the display's current space, so it cannot drift displays like the old `.moveToActiveSpace`). All other displays keep the conservative verdict. `isStranded` gained two parameters and is still pure; `show()` and the decision point now log.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -derivedDataPath Build/ CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO -only-testing:ThawTests/EmptySectionEditorDragTests -only-testing:ThawTests/MenuBarOverlayPanelSpaceTests -only-testing:ThawTests/AdvancedSettingsTests` — 36/36 passed
- Broader layout suites (`HiddenDividerBoundaryTests`, `StrandedHiddenDividerTests`, `ParkedAnchorTests`, `MenuBarSectionGeometryTests`, `PrunedSectionOrderTests`, `MidSectionTransitionTests`, `ControlItemPairAlwaysHiddenRecoveryTests`) — 84/84 passed
- `swiftlint lint` and `swiftformat --lint` clean on all changed Swift files

## Known limitations / follow-ups

- **#1010:** the live drag path (synthetic event move onto the revealed divider) can't be exercised by unit tests; a test build should be confirmed on the reporter's bar (empty always-hidden + collapsed hidden section, multi-display).
- **#1012:** the migration seeds *on* for fresh installs too (matching the 1.x product default). If the 2.0 opt-in default was intentional for brand-new users, this should be narrowed to upgrader detection instead.
- **#794:** the fallback only covers the display that owns the active menu bar; a sibling display whose per-display query is broken keeps the conservative verdict (by design, to avoid housekeeping flicker). The new diagnostics should confirm whether this branch is actually the field failure — worth asking the thread for a log from a build with this instrumentation before assuming closure.
- The last-resort editor alert copy ("Open the section and try dragging the item again") is intentionally unchanged to avoid churning localizations now that the path should be effectively unreachable.

## Other information

- The `README.md` change sitting in my working tree is unrelated and is intentionally **not** part of this branch.
- CHANGELOG.md `## [Unreleased]` documents both fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop behavior for empty, collapsed Hidden and Always-Hidden sections, temporarily revealing the necessary sections and restoring their previous states afterward.
  - Fixed menu bar appearance when switching spaces, including more reliable recovery when space information is unavailable.
  - Preserved option-click and double-click settings for users upgrading from version 1.x, while respecting explicit preferences.
  - Fixed right-click menus so they remain available when menu bar items are hidden on the active space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->