### PR TITLE
ci: macOS 27 support

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+# Runner labels actionlint does not know about. The Xcode 27 preview images
+# are GitHub-hosted but not yet in actionlint's built-in label list.
+self-hosted-runner:
+  labels:
+    - xcode-27
+    - xcode-27-xlarge

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -63,6 +63,7 @@ runs:
       shell: bash
       env:
         SOURCE: ${{ inputs.source }}
+        INPUT_REF: ${{ inputs.ref }}
         THAW_NEXT_TOKEN: ${{ inputs.thaw-next-token }}
         GITHUB_TOKEN: ${{ inputs.github-token }}
       run: |
@@ -85,10 +86,20 @@ runs:
             exit 1
             ;;
         esac
+        # actions/checkout resolves an empty ref on the triggering repository
+        # to github.context.ref, the ref that dispatched the workflow, not to
+        # the default branch the "empty = default branch" contract promises.
+        # Resolve the default branch explicitly for Thaw; thaw-next keeps the
+        # empty ref, for which checkout already uses the foreign default branch.
+        checkout_ref=""
+        if [[ "$SOURCE" == "Thaw" && -z "$INPUT_REF" ]]; then
+          checkout_ref="refs/heads/$(gh api "repos/$GITHUB_REPOSITORY" --jq .default_branch)"
+        fi
         echo "::add-mask::$token"
         {
           echo "token=$token"
           echo "repository=$repository"
+          echo "ref=$checkout_ref"
         } >> "$GITHUB_OUTPUT"
 
     # Checking out over the caller's sparse checkout of this repository is
@@ -99,8 +110,15 @@ runs:
       with:
         repository: ${{ steps.token.outputs.repository }}
         token: ${{ steps.token.outputs.token }}
-        ref: ${{ inputs.ref }}
+        # An explicit ref wins; the token step resolves an empty ref to the
+        # source repository's default branch (empty output for thaw-next, for
+        # which checkout's own default is already that repository's default
+        # branch).
+        ref: ${{ inputs.ref || steps.token.outputs.ref }}
         fetch-depth: ${{ inputs.fetch-depth }}
+        # Nothing after this step needs git credentials, and for thaw-next the
+        # token is a private-repository PAT that must not outlive the checkout.
+        persist-credentials: false
 
     # thaw-next is macOS 27 only. One of its dependencies is a binary package
     # SwiftPM cannot fetch here (see the fetch step below), so thaw-next is

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -54,6 +54,14 @@ outputs:
   deployment-target:
     description: MACOSX_DEPLOYMENT_TARGET for this source
     value: ${{ steps.meta.outputs.deployment_target }}
+  swift-compiler:
+    description: >-
+      The swiftlang build string (for example swiftlang-6.4.0.27.1) the
+      binary package's Swift module was compiled by, or empty when the source
+      has no such constraint. The binary ships without library evolution, so
+      only the Xcode carrying exactly this compiler can import it; the Select
+      Xcode step picks by it.
+    value: ${{ steps.binary.outputs.swift_compiler }}
 
 runs:
   using: composite
@@ -165,6 +173,7 @@ runs:
     # here, and every derived name is masked in the log. Nothing is republished.
     - name: Fetch the private binary package
       if: ${{ inputs.source == 'thaw-next' }}
+      id: binary
       shell: bash
       env:
         GH_TOKEN: ${{ steps.token.outputs.token }}
@@ -267,4 +276,15 @@ runs:
         json.dump(doc, sys.stdout, indent=2)
         print()
         PY
-        echo "Binary package ${version} staged for the workspace build"
+        # The module is a binary .swiftmodule, not a .swiftinterface, so it
+        # imports only under the compiler that wrote it; that compiler's
+        # build string is recorded inside the module. Surface it so the
+        # caller can select the matching Xcode rather than the newest one.
+        module="$(find "$override/$framework" -name '*.swiftmodule' -type f | head -1)"
+        swift_compiler="$(strings "$module" | grep -oE 'swiftlang-[0-9.]+' | head -1)"
+        if [[ -z "$swift_compiler" ]]; then
+          echo "::error::Could not read the compiler build string from the binary package's Swift module"
+          exit 1
+        fi
+        echo "swift_compiler=$swift_compiler" >> "$GITHUB_OUTPUT"
+        echo "Binary package ${version} staged for the workspace build (built by ${swift_compiler})"

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -1,0 +1,241 @@
+name: Checkout source
+description: >-
+  Check out the repository a Thaw build comes from. "Thaw" is this repository;
+  "thaw-next" is the private macOS 27 codebase, which needs a read token and
+  one binary package fetched by hand. Everything specific to building
+  thaw-next from this repository lives here, so when that source is merged or
+  published the whole directory can be deleted and callers go back to a plain
+  actions/checkout.
+
+inputs:
+  source:
+    description: Thaw or thaw-next
+    required: true
+  ref:
+    description: Branch, tag, or commit to check out (empty = default branch)
+    required: false
+    default: ""
+  fetch-depth:
+    description: Passed to actions/checkout
+    required: false
+    default: "1"
+  thaw-next-token:
+    description: >-
+      Fine-grained PAT with contents read on thaw-app/thaw-next and on the
+      repository that publishes its binary package. Only read when source is
+      thaw-next.
+    required: false
+    default: ""
+  binary-package:
+    description: >-
+      SwiftPM identity of the binary package thaw-next pins from a private
+      release (the THAW_NEXT_BINARY_PACKAGE repository variable). Only read
+      when source is thaw-next; never written into this repository.
+    required: false
+    default: ""
+  github-token:
+    description: Token for the Thaw source (defaults to the job token)
+    required: false
+    default: ${{ github.token }}
+
+outputs:
+  repository:
+    description: owner/name that was checked out
+    value: ${{ steps.meta.outputs.repository }}
+  commit:
+    description: Full commit SHA that was checked out
+    value: ${{ steps.meta.outputs.commit }}
+  project-name:
+    description: Xcode project to build, or empty when a workspace is used
+    value: ${{ steps.meta.outputs.project_name }}
+  workspace-name:
+    description: Xcode workspace to build, or empty when the project is used
+    value: ${{ steps.meta.outputs.workspace_name }}
+  deployment-target:
+    description: MACOSX_DEPLOYMENT_TARGET for this source
+    value: ${{ steps.meta.outputs.deployment_target }}
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve the source token
+      id: token
+      shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        THAW_NEXT_TOKEN: ${{ inputs.thaw-next-token }}
+        GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+        case "$SOURCE" in
+          Thaw)
+            token="$GITHUB_TOKEN"
+            repository="$GITHUB_REPOSITORY"
+            ;;
+          thaw-next)
+            if [[ -z "$THAW_NEXT_TOKEN" ]]; then
+              echo "::error::thaw-next-token is empty; set THAW_NEXT_READ_TOKEN where this workflow reads its secrets"
+              exit 1
+            fi
+            token="$THAW_NEXT_TOKEN"
+            repository="thaw-app/thaw-next"
+            ;;
+          *)
+            echo "::error::Unsupported source: $SOURCE"
+            exit 1
+            ;;
+        esac
+        echo "::add-mask::$token"
+        {
+          echo "token=$token"
+          echo "repository=$repository"
+        } >> "$GITHUB_OUTPUT"
+
+    # Checking out over the caller's sparse checkout of this repository is
+    # fine: actions/checkout wipes the directory when the remote differs and
+    # reuses it when it matches.
+    - name: Checkout source
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        repository: ${{ steps.token.outputs.repository }}
+        token: ${{ steps.token.outputs.token }}
+        ref: ${{ inputs.ref }}
+        fetch-depth: ${{ inputs.fetch-depth }}
+
+    # thaw-next is macOS 27 only. One of its dependencies is a binary package
+    # SwiftPM cannot fetch here (see the fetch step below), so thaw-next is
+    # built through ThawDev.xcworkspace, which is what points SwiftPM at the
+    # locally staged copy. Thaw keeps the project build.
+    - name: Resolve build settings
+      id: meta
+      shell: bash
+      env:
+        SOURCE: ${{ inputs.source }}
+        REPOSITORY: ${{ steps.token.outputs.repository }}
+      run: |
+        set -euo pipefail
+        case "$SOURCE" in
+          Thaw)
+            project_name="Thaw.xcodeproj"
+            workspace_name=""
+            deployment_target="26.0"
+            ;;
+          thaw-next)
+            project_name=""
+            workspace_name="ThawDev.xcworkspace"
+            deployment_target="27.0"
+            ;;
+        esac
+        commit="$(git rev-parse HEAD)"
+        {
+          echo "repository=$REPOSITORY"
+          echo "commit=$commit"
+          echo "project_name=$project_name"
+          echo "workspace_name=$workspace_name"
+          echo "deployment_target=$deployment_target"
+        } >> "$GITHUB_OUTPUT"
+        echo "Checked out $REPOSITORY@$commit"
+
+    # thaw-next pins one binary Swift package whose zip is published as a
+    # private GitHub release. SwiftPM cannot authenticate to that download, so
+    # this step does it: read the pin from thaw-next's Package.resolved, read
+    # the package manifest at that tag for the asset name and checksum,
+    # download the asset from its own release, verify it against the release's
+    # .sha256 and the manifest checksum, and hand it to the build as a
+    # path-based package in the override slot ThawDev.xcworkspace reads. The
+    # package's identity comes from the caller, so nothing about it is written
+    # here, and every derived name is masked in the log. Nothing is republished.
+    - name: Fetch the private binary package
+      if: ${{ inputs.source == 'thaw-next' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ steps.token.outputs.token }}
+        PACKAGE: ${{ inputs.binary-package }}
+      run: |
+        set -euo pipefail
+        if [[ -z "$PACKAGE" ]]; then
+          echo "::error::binary-package is empty; set the THAW_NEXT_BINARY_PACKAGE repository variable"
+          exit 1
+        fi
+        echo "::add-mask::$PACKAGE"
+
+        resolved="Thaw.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+        read -r version location < <(python3 -c "
+        import json, sys
+        pins = json.load(open(sys.argv[1]))['pins']
+        pin = next(p for p in pins if p['identity'] == sys.argv[2])
+        print(pin['state']['version'], pin['location'])
+        " "$resolved" "$PACKAGE")
+        repo="${location#https://github.com/}"
+        repo="${repo%.git}"
+        echo "::add-mask::$repo"
+
+        # The manifest at the pinned tag names the asset and its checksum.
+        manifest="$RUNNER_TEMP/binary-package-manifest.swift"
+        gh api "repos/${repo}/contents/Package.swift?ref=${version}" -q .content | base64 -d > "$manifest"
+        asset="$(grep -oE 'releases/download/[^/"]+/[^"\\)]+' "$manifest" | head -1 | sed 's#.*/##')"
+        manifest_sum="$(grep -oE '[0-9a-f]{64}' "$manifest" | head -1)"
+        package_name="$(sed -nE 's/^[[:space:]]*name: "([^"]+)",?$/\1/p' "$manifest" | head -1)"
+        target_name="$(grep -A1 -E '\.binaryTarget\(' "$manifest" | sed -nE 's/^[[:space:]]*name: "([^"]+)",?$/\1/p' | head -1)"
+        platform="$(grep -oE '\.macOS\(\.v[0-9]+\)' "$manifest" | head -1)"
+        : "${platform:=.macOS(.v26)}"
+        for v in asset manifest_sum package_name target_name; do
+          if [[ -z "${!v}" ]]; then
+            echo "::error::Could not read ${v} from the package manifest at ${version}"
+            exit 1
+          fi
+        done
+        echo "::add-mask::$asset"
+        echo "::add-mask::$package_name"
+        echo "::add-mask::$target_name"
+
+        work="$RUNNER_TEMP/binary-package"
+        rm -rf "$work"
+        mkdir -p "$work"
+        gh release download "$version" \
+          --repo "$repo" \
+          --pattern "$asset" \
+          --pattern "${asset}.sha256" \
+          --dir "$work"
+
+        # 1. The release's own checksum sidecar.
+        expected="$(awk '{print $1}' "$work/${asset}.sha256")"
+        echo "${expected}  ${work}/${asset}" | shasum -a 256 -c - >/dev/null
+        # 2. The checksum SwiftPM would have enforced. Guards against a
+        #    re-uploaded asset.
+        if [[ "$manifest_sum" != "$expected" ]]; then
+          echo "::error::Manifest checksum does not match the release asset for ${version}"
+          exit 1
+        fi
+
+        override=".swiftpm-overrides/${PACKAGE}"
+        rm -rf "$override"
+        mkdir -p "$override"
+        ditto -x -k "$work/${asset}" "$override"
+        framework="$(cd "$override" && ls -d ./*.xcframework | head -1 | sed 's#^\./##')"
+        if [[ -z "$framework" ]]; then
+          echo "::error::The downloaded asset contains no xcframework"
+          exit 1
+        fi
+
+        cat > "$override/Package.swift" <<EOF
+        // swift-tools-version: 6.3
+        // Generated in CI: path-based stand-in for a binary package SwiftPM cannot fetch here.
+        import PackageDescription
+
+        let package = Package(
+            name: "${package_name}",
+            platforms: [${platform}],
+            products: [
+                .library(name: "${target_name}", targets: ["${target_name}"]),
+            ],
+            targets: [
+                .binaryTarget(name: "${target_name}", path: "${framework}"),
+            ]
+        )
+        EOF
+
+        # The workspace build runs with -onlyUsePackageVersionsFromResolvedFile,
+        # so its Package.resolved must match the project's.
+        cp -f "$resolved" ThawDev.xcworkspace/xcshareddata/swiftpm/Package.resolved
+        echo "Binary package ${version} staged for the workspace build"

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -254,6 +254,17 @@ runs:
         EOF
 
         # The workspace build runs with -onlyUsePackageVersionsFromResolvedFile,
-        # so its Package.resolved must match the project's.
-        cp -f "$resolved" ThawDev.xcworkspace/xcshareddata/swiftpm/Package.resolved
+        # so its Package.resolved must match the project's for every package
+        # it still fetches. The binary package is not one of them: the
+        # workspace replaces it with the path-based stand-in above, and a
+        # workspace resolve never records an overridden package. Copying the
+        # project's pin for it across would make the locked build clone the
+        # private repository anyway, with no credentials, and fail.
+        python3 - "$resolved" "$PACKAGE" <<'PY' > ThawDev.xcworkspace/xcshareddata/swiftpm/Package.resolved
+        import json, sys
+        doc = json.load(open(sys.argv[1]))
+        doc['pins'] = [p for p in doc['pins'] if p['identity'] != sys.argv[2]]
+        json.dump(doc, sys.stdout, indent=2)
+        print()
+        PY
         echo "Binary package ${version} staged for the workspace build"

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -111,8 +111,20 @@ runs:
         } >> "$GITHUB_OUTPUT"
 
     # Checking out over the caller's sparse checkout of this repository is
-    # fine: actions/checkout wipes the directory when the remote differs and
-    # reuses it when it matches.
+    # fine for the build: actions/checkout wipes the directory when the remote
+    # differs and reuses it when it matches. It is not fine for the runner,
+    # which comes back to this directory at the end of the job to run the
+    # post steps of the actions used here and fails the job when the action
+    # file is gone. So the action's own directory is set aside before the
+    # checkout and put back after it.
+    - name: Set this action aside
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        rm -rf "$RUNNER_TEMP/checkout-source-action"
+        cp -R "$ACTION_PATH" "$RUNNER_TEMP/checkout-source-action"
     - name: Checkout source
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       with:
@@ -127,6 +139,15 @@ runs:
         # Nothing after this step needs git credentials, and for thaw-next the
         # token is a private-repository PAT that must not outlive the checkout.
         persist-credentials: false
+    - name: Put this action back
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$(dirname "$ACTION_PATH")"
+        rm -rf "$ACTION_PATH"
+        cp -R "$RUNNER_TEMP/checkout-source-action" "$ACTION_PATH"
 
     # thaw-next is macOS 27 only. One of its dependencies is a binary package
     # SwiftPM cannot fetch here (see the fetch step below), so thaw-next is

--- a/.github/actions/checkout-source/action.yml
+++ b/.github/actions/checkout-source/action.yml
@@ -276,15 +276,25 @@ runs:
         json.dump(doc, sys.stdout, indent=2)
         print()
         PY
-        # The module is a binary .swiftmodule, not a .swiftinterface, so it
-        # imports only under the compiler that wrote it; that compiler's
-        # build string is recorded inside the module. Surface it so the
-        # caller can select the matching Xcode rather than the newest one.
-        module="$(find "$override/$framework" -name '*.swiftmodule' -type f | head -1)"
-        swift_compiler="$(strings "$module" | grep -oE 'swiftlang-[0-9.]+' | head -1)"
-        if [[ -z "$swift_compiler" ]]; then
-          echo "::error::Could not read the compiler build string from the binary package's Swift module"
-          exit 1
+        # A module built with library evolution ships a .swiftinterface and
+        # imports under any compiler that can read it, so it puts no
+        # constraint on the Xcode. One built without ships only a binary
+        # .swiftmodule, which imports only under the compiler that wrote it;
+        # that compiler's build string is recorded inside the module.
+        # Surface it so the caller can select the matching Xcode rather
+        # than the newest one.
+        swift_compiler=""
+        if [[ -z "$(find "$override/$framework" -name '*.swiftinterface' -type f | head -1)" ]]; then
+          module="$(find "$override/$framework" -name '*.swiftmodule' -type f | head -1)"
+          swift_compiler="$(strings "$module" | grep -oE 'swiftlang-[0-9.]+' | head -1)"
+          if [[ -z "$swift_compiler" ]]; then
+            echo "::error::Could not read the compiler build string from the binary package's Swift module"
+            exit 1
+          fi
         fi
         echo "swift_compiler=$swift_compiler" >> "$GITHUB_OUTPUT"
-        echo "Binary package ${version} staged for the workspace build (built by ${swift_compiler})"
+        if [[ -n "$swift_compiler" ]]; then
+          echo "Binary package ${version} staged for the workspace build (built by ${swift_compiler}; no library evolution, so that Xcode is required)"
+        else
+          echo "Binary package ${version} staged for the workspace build (library evolution; any Xcode 27 will do)"
+        fi

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -1,10 +1,38 @@
 name: Build DMG
 
+# Manual, unsigned-of-provenance dev build: a signed and notarized DMG uploaded
+# as a short-lived workflow artifact, never a release. Use it to hand a build
+# to a tester or to check a branch builds and notarizes before tagging.
+#
+# The source input picks which repository is built. Thaw (default) is this
+# repository at the ref given (or the default branch). thaw-next builds the
+# private thaw-app/thaw-next repository at the ref given, using
+# THAW_NEXT_READ_TOKEN (contents: read on thaw-next and its binary
+# package's repository). This
+# workflow runs outside the release environment, so that secret must exist at
+# the repository level as well as in the release environment. Everything
+# thaw-next-specific lives in .github/actions/checkout-source, shared with
+# release.yml.
+
 on:
   workflow_dispatch:
+    inputs:
+      source:
+        description: Repository to build (thaw-next is the private macOS 27 codebase)
+        required: true
+        type: choice
+        default: Thaw
+        options:
+          - Thaw
+          - thaw-next
+      ref:
+        description: Branch, tag, or commit to build (empty = the source repository's default branch)
+        required: false
+        type: string
+        default: ""
 
 concurrency:
-  group: build-dmg-${{ github.ref }}
+  group: build-dmg-${{ inputs.source }}-${{ inputs.ref || github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -13,18 +41,48 @@ permissions:
 jobs:
   build-dmg:
     if: github.repository == 'thaw-app/Thaw'
-    runs-on: blacksmith-6vcpu-macos-26
+    # GitHub-hosted Xcode 27 preview image (arm64); xcode-27-xlarge for more cores.
+    runs-on: xcode-27
     env:
       APP_NAME: "Thaw.app"
       DMG_NAME: "Thaw-dev.dmg"
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      # A local composite action has to exist on disk before it can run, so
+      # this sparse checkout brings in .github/actions and nothing else.
+      - name: Checkout build actions
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          sparse-checkout: .github/actions
 
-      # Issues with other Xcode versions, so we need to specify the version explicitly
-      - run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
+      - name: Checkout source
+        id: source
+        uses: ./.github/actions/checkout-source
+        with:
+          source: ${{ inputs.source }}
+          ref: ${{ inputs.ref }}
+          thaw-next-token: ${{ secrets.THAW_NEXT_READ_TOKEN }}
+          binary-package: ${{ vars.THAW_NEXT_BINARY_PACKAGE }}
+
+      - name: Select Xcode
+        env:
+          XCODE_APP: Xcode_27
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # A prefix, so a preview image's Xcode_27.0-beta.N.app is picked up
+          # as well as a final Xcode_27.0.app. The last glob match sorts highest.
+          candidates=(/Applications/"${XCODE_APP}"*.app)
+          if [[ ${#candidates[@]} -eq 0 ]]; then
+            echo "No /Applications/${XCODE_APP}*.app on this runner. Installed:"
+            ls -d /Applications/Xcode*.app || true
+            exit 1
+          fi
+          selected="${candidates[${#candidates[@]}-1]}"
+          sudo xcode-select -s "$selected/Contents/Developer"
+          xcodebuild -version
 
       - name: Configure signing
-        uses: thaw-app/org-ci/actions/configure-signing@30ef248bedd07c2823c695ffa65f49e61b4a1159
+        uses: thaw-app/org-ci/actions/configure-signing@5c8f979eeee7674b7af949c89edb6b37ac4af413
         with:
           apple-application-cert: ${{ secrets.APPLE_APPLICATION_CERT }}
           apple-application-cert-password: ${{ secrets.APPLE_APPLICATION_CERT_PASSWORD }}
@@ -33,22 +91,23 @@ jobs:
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
 
       - name: Build
-        uses: thaw-app/org-ci/actions/build@30ef248bedd07c2823c695ffa65f49e61b4a1159
+        uses: thaw-app/org-ci/actions/build@5c8f979eeee7674b7af949c89edb6b37ac4af413
         with:
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          project-name: Thaw.xcodeproj
+          project-name: ${{ steps.source.outputs.project-name }}
+          workspace-name: ${{ steps.source.outputs.workspace-name }}
           scheme-name: Thaw
-          deployment-target: "26.0"
+          deployment-target: ${{ steps.source.outputs.deployment-target }}
 
       - name: Export Archive
-        uses: thaw-app/org-ci/actions/export-and-package@30ef248bedd07c2823c695ffa65f49e61b4a1159
+        uses: thaw-app/org-ci/actions/export-and-package@5c8f979eeee7674b7af949c89edb6b37ac4af413
         with:
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
           app-name: ${{ env.APP_NAME }}
           dmg-name: ${{ env.DMG_NAME }}
 
       - name: Notarize
-        uses: thaw-app/org-ci/actions/notarize-and-validate@30ef248bedd07c2823c695ffa65f49e61b4a1159
+        uses: thaw-app/org-ci/actions/notarize-and-validate@5c8f979eeee7674b7af949c89edb6b37ac4af413
         with:
           dmg-name: ${{ env.DMG_NAME }}
           app-name: ${{ env.APP_NAME }}
@@ -56,7 +115,7 @@ jobs:
       - name: Upload DMG
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: Thaw-dmg
+          name: Thaw-dmg-${{ inputs.source }}-${{ steps.source.outputs.commit }}
           path: build/${{ env.DMG_NAME }}
           retention-days: 3
 

--- a/.github/workflows/build-dmg.yml
+++ b/.github/workflows/build-dmg.yml
@@ -66,6 +66,11 @@ jobs:
       - name: Select Xcode
         env:
           XCODE_APP: Xcode_27
+          # Set for thaw-next: the compiler its binary package was built by.
+          # That package ships without library evolution, so only the Xcode
+          # carrying exactly this compiler can import it; the newest install
+          # is wrong whenever it is newer than the package's release job.
+          REQUIRED_SWIFT: ${{ steps.source.outputs.swift-compiler }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -77,7 +82,25 @@ jobs:
             ls -d /Applications/Xcode*.app || true
             exit 1
           fi
-          selected="${candidates[${#candidates[@]}-1]}"
+          selected=""
+          if [[ -n "$REQUIRED_SWIFT" ]]; then
+            for candidate in "${candidates[@]}"; do
+              swiftc="$candidate/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+              if [[ -x "$swiftc" ]] && "$swiftc" --version 2>/dev/null | grep -qF "$REQUIRED_SWIFT"; then
+                selected="$candidate"
+              fi
+            done
+            if [[ -z "$selected" ]]; then
+              echo "No installed Xcode carries ${REQUIRED_SWIFT}, which the binary package requires. Installed:"
+              for candidate in "${candidates[@]}"; do
+                swiftc="$candidate/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+                echo "  $candidate: $("$swiftc" --version 2>/dev/null | head -1)"
+              done
+              exit 1
+            fi
+          else
+            selected="${candidates[${#candidates[@]}-1]}"
+          fi
           sudo xcode-select -s "$selected/Contents/Developer"
           xcodebuild -version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,6 @@ jobs:
           TAG: ${{ steps.meta.outputs.tag }}
           RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
           SOURCE_REPOSITORY: ${{ steps.source.outputs.repository }}
-          SOURCE_COMMIT: ${{ steps.source.outputs.commit }}
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
@@ -245,15 +244,6 @@ jobs:
                   source = f"none (no {changelog} section for {tag})"
           elif not notes.strip():
               source = "none (no release_notes input, no CHANGELOG.md)"
-
-          # A cross-repo build's tag in this repository does not point at the
-          # code that was built, so the body names the source commit instead.
-          source_repo = os.environ["SOURCE_REPOSITORY"]
-          source_commit = os.environ["SOURCE_COMMIT"]
-          if source_repo != os.environ["GITHUB_REPOSITORY"]:
-              notes = notes.rstrip() + (
-                  f"\n\n---\n\nBuilt from `{source_repo}@{source_commit[:12]}`."
-              )
 
           delimiter = f"notes_{uuid.uuid4().hex}"
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -198,9 +198,21 @@ jobs:
           RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
           SOURCE_REPOSITORY: ${{ steps.source.outputs.repository }}
           SOURCE_COMMIT: ${{ steps.source.outputs.commit }}
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          python3 - <<'PY'
+          # The changelog lives in this repository, whichever repository the
+          # code came from: thaw-next carries no copy and reads it from here
+          # at run time. After a cross-repo checkout the working tree is the
+          # source repository, so fetch this repository's CHANGELOG.md at the
+          # ref that dispatched the workflow and hand it to the lookup below.
+          own_changelog=""
+          if [[ "$SOURCE_REPOSITORY" != "$GITHUB_REPOSITORY" ]]; then
+            own_changelog="$RUNNER_TEMP/CHANGELOG.md"
+            gh api "repos/${GITHUB_REPOSITORY}/contents/CHANGELOG.md?ref=${GITHUB_SHA}" \
+              -H "Accept: application/vnd.github.raw" > "$own_changelog"
+          fi
+          OWN_CHANGELOG="$own_changelog" python3 - <<'PY'
           import os
           import re
           import uuid
@@ -212,9 +224,10 @@ jobs:
           # Falls back to the CHANGELOG.md section for this tag (Keep a Changelog
           # style: "## [1.2.3]" or "## 1.2.3", ending at the next "## " heading)
           # only when no manual notes were supplied at dispatch time. Thaw keeps
-          # the changelog at the repository root; thaw-next bundles it into the
-          # app as Thaw/Resources/CHANGELOG.md, so both locations are tried.
-          candidates = ["CHANGELOG.md", "Thaw/Resources/CHANGELOG.md"]
+          # the changelog at the repository root; on a cross-repo build that
+          # file was fetched into OWN_CHANGELOG above and is tried first.
+          candidates = [os.environ.get("OWN_CHANGELOG", ""), "CHANGELOG.md", "Thaw/Resources/CHANGELOG.md"]
+          candidates = [p for p in candidates if p]
           changelog = next((p for p in candidates if os.path.isfile(p)), None)
           if not notes.strip() and changelog:
               text = open(changelog, encoding="utf-8").read()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,14 @@ name: Release
 # The Thaw release is always created as a draft and only published by
 # attach-provenance, so a provenance failure cannot leave a public release
 # without its attestation bundles.
+#
+# Source selection: the source input picks which repository the tag is
+# checked out from. Thaw (default) is this repository. thaw-next is the
+# private macOS 27 codebase, built at the same tag with THAW_NEXT_READ_TOKEN
+# (a release-environment secret). Everything that differs between the two
+# lives in .github/actions/checkout-source, so retiring the private source
+# later means deleting that directory, the source input, and the two steps
+# that reference it.
 
 on:
   workflow_dispatch:
@@ -29,6 +37,14 @@ on:
         description: Existing release tag to publish (for example, 1.2.3 or 2.0.0-rc.1)
         required: true
         type: string
+      source:
+        description: Repository the tag is built from (thaw-next is the private macOS 27 codebase)
+        required: true
+        type: choice
+        default: Thaw
+        options:
+          - Thaw
+          - thaw-next
       channel:
         description: Sparkle channel (auto infers from tag suffix)
         required: true
@@ -73,7 +89,7 @@ on:
           blank, notes are auto-extracted from the CHANGELOG.md section for this
           tag (Keep a Changelog style: "## [tag]"). Used for both the Thaw
           GitHub Release body and the Sparkle appcast description. Multi-line
-          text is easiest via `gh workflow run release.yml -f release_notes="$(cat notes.md)"`
+          text is easiest via gh workflow run release.yml -f release_notes="$(cat notes.md)"
           The web UI's field is single-line.
         required: false
         type: string
@@ -90,7 +106,8 @@ permissions:
 jobs:
   release:
     if: github.repository == 'thaw-app/Thaw'
-    runs-on: blacksmith-6vcpu-macos-26
+    # GitHub-hosted Xcode 27 preview image (arm64); xcode-27-xlarge for more cores.
+    runs-on: xcode-27
     # Trust boundary: required reviewers on the `release` Environment
     # (diazdesandi). Other org owners can still unblock via admin bypass.
     # Secrets are not consumed until approval.
@@ -110,11 +127,22 @@ jobs:
       UPDATES_REPOSITORY: thaw-app/updates
       LEGACY_APPCAST_REPOSITORY: stonerl/Thaw
     steps:
-      - name: Checkout code
+      # A local composite action has to exist on disk before it can run, so
+      # this sparse checkout brings in .github/actions and nothing else.
+      - name: Checkout build actions
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          fetch-depth: 0
+          sparse-checkout: .github/actions
+
+      - name: Checkout source
+        id: source
+        uses: ./.github/actions/checkout-source
+        with:
+          source: ${{ inputs.source }}
           ref: refs/tags/${{ inputs.tag }}
+          fetch-depth: 0
+          thaw-next-token: ${{ secrets.THAW_NEXT_READ_TOKEN }}
+          binary-package: ${{ vars.THAW_NEXT_BINARY_PACKAGE }}
 
       - name: Resolve tag and channel
         id: meta
@@ -168,6 +196,8 @@ jobs:
         env:
           TAG: ${{ steps.meta.outputs.tag }}
           RELEASE_NOTES_INPUT: ${{ inputs.release_notes }}
+          SOURCE_REPOSITORY: ${{ steps.source.outputs.repository }}
+          SOURCE_COMMIT: ${{ steps.source.outputs.commit }}
         run: |
           set -euo pipefail
           python3 - <<'PY'
@@ -181,9 +211,13 @@ jobs:
 
           # Falls back to the CHANGELOG.md section for this tag (Keep a Changelog
           # style: "## [1.2.3]" or "## 1.2.3", ending at the next "## " heading)
-          # only when no manual notes were supplied at dispatch time.
-          if not notes.strip() and os.path.isfile("CHANGELOG.md"):
-              text = open("CHANGELOG.md", encoding="utf-8").read()
+          # only when no manual notes were supplied at dispatch time. Thaw keeps
+          # the changelog at the repository root; thaw-next bundles it into the
+          # app as Thaw/Resources/CHANGELOG.md, so both locations are tried.
+          candidates = ["CHANGELOG.md", "Thaw/Resources/CHANGELOG.md"]
+          changelog = next((p for p in candidates if os.path.isfile(p)), None)
+          if not notes.strip() and changelog:
+              text = open(changelog, encoding="utf-8").read()
               heading = re.compile(
                   r"^##\s+\[?" + re.escape(tag) + r"\]?.*$", re.MULTILINE
               )
@@ -193,11 +227,20 @@ jobs:
                   next_heading = re.search(r"^##\s+", rest, re.MULTILINE)
                   section = rest[: next_heading.start()] if next_heading else rest
                   notes = section.strip()
-                  source = "CHANGELOG.md"
+                  source = changelog
               else:
-                  source = f"none (no CHANGELOG.md section for {tag})"
+                  source = f"none (no {changelog} section for {tag})"
           elif not notes.strip():
               source = "none (no release_notes input, no CHANGELOG.md)"
+
+          # A cross-repo build's tag in this repository does not point at the
+          # code that was built, so the body names the source commit instead.
+          source_repo = os.environ["SOURCE_REPOSITORY"]
+          source_commit = os.environ["SOURCE_COMMIT"]
+          if source_repo != os.environ["GITHUB_REPOSITORY"]:
+              notes = notes.rstrip() + (
+                  f"\n\n---\n\nBuilt from `{source_repo}@{source_commit[:12]}`."
+              )
 
           delimiter = f"notes_{uuid.uuid4().hex}"
           with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as f:
@@ -206,7 +249,23 @@ jobs:
           print(f"Release notes source: {source}")
           PY
 
-      - run: sudo xcode-select -s /Applications/Xcode_26.6.app/Contents/Developer
+      - name: Select Xcode
+        env:
+          XCODE_APP: Xcode_27
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          # A prefix, so a preview image's Xcode_27.0-beta.N.app is picked up
+          # as well as a final Xcode_27.0.app. The last glob match sorts highest.
+          candidates=(/Applications/"${XCODE_APP}"*.app)
+          if [[ ${#candidates[@]} -eq 0 ]]; then
+            echo "No /Applications/${XCODE_APP}*.app on this runner. Installed:"
+            ls -d /Applications/Xcode*.app || true
+            exit 1
+          fi
+          selected="${candidates[${#candidates[@]}-1]}"
+          sudo xcode-select -s "$selected/Contents/Developer"
+          xcodebuild -version
 
       - name: Configure signing
         uses: thaw-app/org-ci/actions/configure-signing@5c8f979eeee7674b7af949c89edb6b37ac4af413
@@ -221,9 +280,10 @@ jobs:
         uses: thaw-app/org-ci/actions/build@5c8f979eeee7674b7af949c89edb6b37ac4af413
         with:
           apple-team-id: ${{ secrets.APPLE_TEAM_ID }}
-          project-name: Thaw.xcodeproj
+          project-name: ${{ steps.source.outputs.project-name }}
+          workspace-name: ${{ steps.source.outputs.workspace-name }}
           scheme-name: Thaw
-          deployment-target: "26.0"
+          deployment-target: ${{ steps.source.outputs.deployment-target }}
 
       - name: Export Archive
         uses: thaw-app/org-ci/actions/export-and-package@5c8f979eeee7674b7af949c89edb6b37ac4af413
@@ -459,7 +519,6 @@ jobs:
             attempt=$((attempt + 1))
             sleep $((attempt * 2))
           done
-
 
       - name: Mirror appcast to legacy stonerl Pages
         if: ${{ inputs.publish_appcast && inputs.publish_release && !inputs.dry_run }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,6 +252,11 @@ jobs:
       - name: Select Xcode
         env:
           XCODE_APP: Xcode_27
+          # Set for thaw-next: the compiler its binary package was built by.
+          # That package ships without library evolution, so only the Xcode
+          # carrying exactly this compiler can import it; the newest install
+          # is wrong whenever it is newer than the package's release job.
+          REQUIRED_SWIFT: ${{ steps.source.outputs.swift-compiler }}
         run: |
           set -euo pipefail
           shopt -s nullglob
@@ -263,7 +268,25 @@ jobs:
             ls -d /Applications/Xcode*.app || true
             exit 1
           fi
-          selected="${candidates[${#candidates[@]}-1]}"
+          selected=""
+          if [[ -n "$REQUIRED_SWIFT" ]]; then
+            for candidate in "${candidates[@]}"; do
+              swiftc="$candidate/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+              if [[ -x "$swiftc" ]] && "$swiftc" --version 2>/dev/null | grep -qF "$REQUIRED_SWIFT"; then
+                selected="$candidate"
+              fi
+            done
+            if [[ -z "$selected" ]]; then
+              echo "No installed Xcode carries ${REQUIRED_SWIFT}, which the binary package requires. Installed:"
+              for candidate in "${candidates[@]}"; do
+                swiftc="$candidate/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/swiftc"
+                echo "  $candidate: $("$swiftc" --version 2>/dev/null | head -1)"
+              done
+              exit 1
+            fi
+          else
+            selected="${candidates[${#candidates[@]}-1]}"
+          fi
           sudo xcode-select -s "$selected/Contents/Developer"
           xcodebuild -version
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,107 @@ The `release.yml` workflow reads the section matching the release tag
 (`## [tag]`) and uses it as the release notes for both the GitHub Release
 and the Sparkle appcast, unless overridden with the `release_notes` input.
 
+## [3.0.0-alpha.1] - 2026-09-03
+
+Thaw 3 is Thaw rebuilt and redesigned for macOS 27. A new engine on the platform's own model, a new settings window, new glass everywhere, and Swift 6.4 underneath. It is de-iced: the code and names inherited from Ice are gone, and what is left is more Thaw than anything before it.
+
+Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).
+
+<a href="https://www.producthunt.com/products/thaw-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-thaw-3" target="_blank" rel="noopener noreferrer"><img alt="Thaw - The only app that owns your whole menu bar, in and out | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1239794&amp;theme=light&amp;t=1788423441056"></a>
+
+Thank you to the more than 80 people who ran the preview builds, sent logs, and told us what broke. Every one of the areas below was shaped by those reports.
+
+---
+
+### Upgrade from 2.x
+
+1. macOS 27 is required. There is no 2.x compatibility layer.
+2. Update channel is Nightly for now.
+3. The Ice-era settings migrations have been removed. They could never run against the new defaults domain, so nothing is lost by dropping them.
+
+---
+
+### Not here yet
+
+Three things from the 2.1 preview line are still on their way to macOS 27.
+
+- **Scripts.** Script-driven bar modules are being tested by macOS 26 users on the 2.1.0 beta and will be added in a later 3.0 build. The Scripts pane is here as a preview of where they will live.
+- **Item triggers.** The full condition engine from 2.1, where an item moves on battery level, the frontmost app, a network, a Focus, and the rest, is not ported yet. What is here is the reveal-on-icon-change rule.
+- **Rotating diagnostic logs.**
+
+---
+
+### Menu bar
+
+- **Zen mode** seals the whole bar with one hotkey. Reveals and hover tricks stand down until you toggle it back.
+- **Item groups** bundle items so they move as one, including across sections. Same-app clusters group on their own and dissolve on request.
+- **Spacer items** create gaps on purpose: pick a width and drag them like any item.
+- **Items that ask for attention can surface themselves.** A blinking icon briefly shows the section holding it, with a cooldown so a chatty icon cannot keep the bar open. Off by default.
+- **App icons where captures cannot go.** Items nobody can capture draw their owning app's icon, so the Thaw Bar, the layout pane, and search work with Accessibility alone.
+- **Presenter mode.** With the camera and microphone watch on, the bar collapses to zen mode while either is in use and restores after. It works alongside zen mode while presenting.
+- **Confirmations.** A small capsule under the bar confirms the verbs that otherwise succeed invisibly: zen on, hidden items shown, profile applied.
+
+### Thaw Bar and appearance
+
+- **A Thaw Bar of its own.** Shape, tint, and border for the bar, independent of the menu bar it mirrors, and one per-display section instead of repeated blocks.
+- **Adaptive Gradient tint.** A gradient from the wallpaper's two dominant colours instead of one average. Wallpaper changes re-tint the bar at once; the poll stays only for dynamic and aerial wallpapers.
+- **Per-Space appearance overrides**, so the bar can dress differently on each Space.
+
+### Layout
+
+- **A standalone layout editor** opens on its own from a hotkey or a `thaw://` action, with glass chrome and last-pane restore. Items can be activated straight from it.
+- **Hover spotlighting.** Resting on a tile in the layout pane lights the matching item in the real bar. Clicking it opens the inspector.
+- **Displays as a spatial picker**, arranged the way they sit on your desk, with per-display spacing applied inline.
+
+### Search and launchers
+
+- **Search remembers.** Recently activated items sit at the top of an empty query, and selecting a result spotlights the item in the real bar.
+- **Item palette (Lab).** A centred launcher for your menu bar items, hidden ones included. Type part of a name or the owning app and press Return.
+- **Assisted item palette (Lab).** A large list of every item right where the pointer is, with big rows to read and click.
+- **Menu bar magnifier (Lab).** Rest the pointer on the bar and a blown-up slice appears below it. Each icon gets a large outline you can click, and the one you point at is named. Works without Screen Recording; the pixels need it.
+
+### Settings
+
+- **Simple Mode** collapses Settings to one page, ordered by what you touch. Everything it hides is still there when you switch it off.
+- **Sidebar by topic.** Menu Bar, App, Automation, and More. Rows carry a plain glyph, groups fold, arrow keys move through rows and Return selects, and a profile strip pinned to the foot switches profiles without opening the Profiles pane.
+- **Search in the toolbar.** Results take over the detail column with a result count and an empty state that names the query.
+- **What's New and Acknowledgements as reading pages.** A path of releases along the top, one large title with the release date under it, and the notes at reading size on the app's own glass.
+- **Tools pane** gathers the troubleshooting helpers in one place, with the destructive ones last.
+- **Onboarding** restyled in the same language as the rest of the app.
+
+### Privacy
+
+- **A Privacy pane.** Permissions, the capture inspector that shows exactly what the app reads from the screen, and every network call the app makes, each with a switch and one button to turn them all off. A test fails the build if a network client appears anywhere the list does not account for.
+- **Camera and microphone watch (Lab).** A banner names the app that took the microphone, and another says when a camera turns on. While either is in use, Thaw's menu lists what is using it. Banners can be pinned to a display, or follow the pointer, and placed left, centre, or right.
+- **Menu bar history (Lab).** When items appeared in and disappeared from the bar, stored in Thaw's own settings and cleared when the experiment is turned off.
+
+### Profiles and Spaces
+
+- **Per-Space profiles.** Bind a profile to a Space the way it binds to a display. Precedence is Focus Filter, then Space, then display.
+- **Per-Space presentation.** Show or hide the bar per Space, and see which Space each rule belongs to.
+
+### Automation, Shortcuts, and the command line
+
+- **Rules.** Reveal on icon change with a cooldown, global and per-profile hooks that run a script when a profile applies, a script environment with its own variables and timeout, and a whitelist of apps allowed to change settings over `thaw://`.
+- **Shortcuts and Spotlight.** An action opens a chosen item's menu, revealing it first if hidden, alongside actions to reveal hidden items, toggle zen mode, and apply a profile.
+- **Control Center widgets** toggle hidden items and zen mode from Control Center.
+- **A command-line client.** `thawctl` drives the `thaw://` control plane from a terminal.
+
+### The Lab
+
+- **A home for experiments** you can opt into early. Turning any experiment off returns the app to normal, and each one says exactly what it does.
+- **Menu bar overlay.** Your items drawn in a Thaw strip that appears when you point at the space they left, while the system bar keeps its app menus, clock, and modules.
+- **Show item details on hover (beta).** A small readout under an item while the pointer rests on it, showing what the item already reports.
+- **Hide Finder menus on the desktop.** Clicking the desktop puts Finder's menus in the bar; this covers them until you switch away.
+- **Transport bar.** A floating capsule at the bottom of the display your pointer is on, with the active profile, the hidden and always-hidden toggles, zen mode, and a close button. It never takes focus.
+
+### Under the hood
+
+- **Rebuilt from the ground up on a new architecture.** Thaw 3 is a new codebase, not a patched fork. The item manager cluster, AppState, MenuBarManager, the image cache, the layout bar, ControlItem, appearance, and search were written anew; the Ice-branded identifier vocabulary is Thaw's own, with persisted keys pinned so nothing you saved is lost; and the migrations that could never run are gone. The rewrite paid down years of technical debt at the same time: dead machinery and one-case abstractions are deleted, the engine sits behind explicit seams that can be tested in isolation, and the hot paths were rebuilt with performance in mind.
+- **Swift 6.4 and strict concurrency.** The `@Observable` migration is complete, with zero `ObservableObject` conformances left. Detached tasks moved onto `@concurrent` callees, workspace notifications are debounced through swift-async-algorithms, and the engine reads its settings through a configuration protocol instead of reaching into AppState.
+- **Every ScreenCaptureKit call has a watchdog**, so a capture that never answers cannot hang the refresh loop. An XPC capture helper is built in and off by default until it has been verified on macOS 27.
+- **Less idle work.** The polls that used to ask the window server questions whose answers had not changed now latch, memoize, or rate-limit, and the glyph cache publishes only when a glyph actually changed.
+
 ## [2.1.0-beta.1]
 
 Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 
 <div align="center">
   <a href="https://trendshift.io/repositories/21173" target="_blank"><img src="https://trendshift.io/api/badge/repositories/21173" alt="thaw-app/Thaw | Trendshift" style="width: 250px; height: 55px;" width="250" height="55" /></a>
+  <a href="https://www.producthunt.com/products/thaw-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-thaw-3" target="_blank" rel="noopener noreferrer"><img alt="Thaw - The only app that owns your whole menu bar, in and out | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1239794&amp;theme=light&amp;t=1788423441056"></a>
 </div>
 
 <p align="center">


### PR DESCRIPTION
# Summary

Adds macOS 27 (Golden Gate) CI support: the `release` and `build-dmg` workflows gain a `source` input, their build jobs move to the GitHub-hosted Xcode 27 preview runner, and an `actionlint` config declares the new runner labels.

**Scope:** CI plumbing only — no app code is touched.

## Linked issue (required)

Closes: #687

## PR Type

Describe **what this change does** (not the linked issue's request kind). Bug *reports* use the `Bug` Issue type; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can't be split.

- [ ] Bug fix
- [x] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config, not a product surface.

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [x] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

The `release` and `build-dmg` workflows gain a `source` input, and both build jobs now run on the GitHub-hosted Xcode 27 preview runner so macOS 27 preview builds can be produced. An `actionlint` config declares the new runner labels so the workflows lint cleanly. The release body records the exact source commit for cross-repository builds, and release notes are also read from the in-app changelog path.

No app behavior changes; this only affects CI/release automation.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green, or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `actionlint` — the new `xcode-27` / `xcode-27-xlarge` labels resolve against the `.github/actionlint.yaml` config; the remaining 52 findings are all pre-existing at the base commit (`HEAD~1`).
- No app tests run — the change touches no Swift code.

## Known limitations / follow-ups

- Pre-existing `actionlint` findings (e.g. the `blacksmith-4vcpu-ubuntu-2404` label in `release.yml`, shellcheck infos) are intentionally out of scope.

## Other information

- Files changed: `.github/actionlint.yaml`, `.github/actions/checkout-source/action.yml`, `.github/workflows/build-dmg.yml`, `.github/workflows/release.yml` (CI-only).
- Verification: `actionlint` at `HEAD~1` reports the same 52 findings, so nothing new is introduced by this branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1034"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791022257&installation_model_id=431242&pr_number=1034&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1034&signature=48785d84eabce7279249a0f2833f09085a266cbb6dad22bc8f9cf9f3e8916039"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Release**
  * Build and release workflows now support selecting Thaw or thaw-next source versions and refs.
  * Builds use Xcode 27 and automatically adapt to the selected project, workspace, deployment target, and Swift compiler.
  * Release artifacts include clearer source and commit details, with improved validation for source packages and build settings.
* **Documentation**
  * Added release notes for version 3.0.0-alpha.1, covering macOS 27 requirements, Nightly distribution, current functionality, deferred features, and migration changes.
  * Updated the README with a Product Hunt featured badge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->