### PR TITLE
fix(l10n): fix broken strings

### DIFF
--- a/Thaw/MenuBar/Groups/MenuBarItemGroupManager.swift
+++ b/Thaw/MenuBar/Groups/MenuBarItemGroupManager.swift
@@ -129,7 +129,7 @@ final class MenuBarItemGroupManager {
         if let detected = members.first?.autoDetectedName {
             return detected
         }
-        return String(localized: "^[\(group.count) items](inflect: true)", comment: "Fallback name for an unnamed item group")
+        return String(localized: "[\(group.count) items]", comment: "Fallback name for an unnamed item group")
     }
 
     // MARK: Editing

--- a/Thaw/Resources/Localizable.xcstrings
+++ b/Thaw/Resources/Localizable.xcstrings
@@ -120,129 +120,415 @@
         }
       }
     },
-    "%@ %@ %@" : {
+    "[%lld items]" : {
+      "comment" : "Fallback name for an unnamed item group",
+      "localizations" : {
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "[%lld item]"
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "[%lld items]"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "%@" : {
+
+    },
+    "%@ — placed by trigger “%@”" : {
       "localizations" : {
         "cs" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "en" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@%2$@%3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "id" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "ja" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "ko" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "pt-BR" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "ru" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "th" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "uk" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "new",
-            "value" : "%1$@ %2$@ %3$@"
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         },
         "zh-Hant" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ %2$@ %3$@"
+            "state" : "new",
+            "value" : "%1$@ — placed by trigger “%2$@”"
           }
         }
       }
+    },
+    "%@ (not present)" : {
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not present)"
+          }
+        }
+      }
+    },
+    "%@ (not running)" : {
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@ (not running)"
+          }
+        }
+      }
+    },
+    "%@ %@" : {
+      "comment" : "A version number.",
+      "isCommentAutoGenerated" : true,
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@"
+          }
+        }
+      },
+      "shouldTranslate" : false
+    },
+    "%@ %@ %@ %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ %2$@ %3$@ %4$@"
+          }
+        }
+      },
+      "shouldTranslate" : false
     },
     "%@ %@ pt" : {
       "localizations" : {
@@ -483,242 +769,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ %2$@ 區域"
-          }
-        }
-      }
-    },
-    "%@ (not present)" : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not present)"
-          }
-        }
-      }
-    },
-    "%@ (not running)" : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%@ (not running)"
           }
         }
       }
@@ -1194,126 +1244,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@ 可以在沒有螢幕錄製權限下以限制模式執行。"
-          }
-        }
-      }
-    },
-    "%@ can work in a limited mode without this permission." : {
-      "comment" : "A callout box that explains that the app can work in a limited mode without a particular permission.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bez tohoto oprávnění dokáže %@ pracovat v omezeném režimu."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ funktioniert nur eingeschränkt ohne diese Erlaubnis."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ puede funcionar en modo limitado sin este permiso."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sans ces autorisations, %@ fonctionnera en mode restreint."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ korlátozott módban is működhet ezen engedély nélkül."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ dapat berjalan dalam mode terbatas tanpa izin ini."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ può funzionare in modalità limitata senza questa autorizzazione."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ はこの権限なしでも制限モードで動作できます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@은(는) 이 권한 없이도 제한된 모드로 작동할 수 있습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ kan zonder deze toestemming in een beperkte modus werken."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ może działać w ograniczonym zakresie bez tego uprawnienia."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ pode funcionar de modo limitado sem essa permissão."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ может работать в ограниченном режиме без этого разрешения."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ สามารถทำงานได้อย่างจำกัด โดยไม่ต้องมีสิทธิ์นี้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ bu izin olmadan sınırlı modda çalışabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ може працювати в обмеженому режимі без цього дозволу."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ có thể hoạt động ở chế độ giới hạn mà không có quyền này."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 可以在没有此权限的情况下以受限模式运行。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 可以在沒有此權限的情況下以有限模式運作。"
           }
         }
       }
@@ -1798,6 +1728,26 @@
         }
       }
     },
+    "%@ failed with exit status %d: %@" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ failed with exit status %2$d: %3$@"
+          }
+        }
+      }
+    },
+    "%@ failed with exit status %d." : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ failed with exit status %2$d."
+          }
+        }
+      }
+    },
     "%@ icon" : {
       "comment" : "The text that will be displayed in the \"Location\" picker view for the Ice Bar.",
       "localizations" : {
@@ -2161,246 +2111,6 @@
         }
       }
     },
-    "%@ needs this to:" : {
-      "comment" : "A section within a permission box that lists the reasons why a particular permission is needed. The argument is the name of the app.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Proč potřebuje %@ tato oprávnění?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ benötigt für:"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita este permiso para:"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ a besoin de cette autorisation pour :"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ehhez van szüksége erre:"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ memerlukan ini untuk:"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ obbligatorio per:"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ がこれを必要とする理由："
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@에 필요한 권한:"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ heeft dit nodig om:"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ potrzebuje tego, aby:"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ precisa desta permissão para:"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ нуждается в этом для:"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ต้องการสิทธิ์นี้เพื่อ:"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ bunun için buna ihtiyaç duyuyor:"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ потребує цього для:"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ cần điều này để:"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要此权限来："
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要此權限以進行："
-          }
-        }
-      }
-    },
-    "%@ needs your permission to manage the menu bar." : {
-      "comment" : "A paragraph explaining the app's purpose and its commitment to user privacy.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aplikace %@ potřebuje vaše oprávnění, aby mohla spravovat řádek nabídek."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ benötigt die Erlaubnis die Menüleiste zu steuern."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necesita tu permiso para administrar la barra de menús."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ a besoin de votre autorisation pour gérer la barre des menus."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A(z) %@ engedélyt kér a menüsor kezeléséhez."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ membutuhkan izin untuk mengelola bar menu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ necessita della tua autorizzazione per gestire la barra dei menu."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ がメニューバーを管理するには、権限が必要です。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@이(가) 메뉴 막대를 관리하려면 권한이 필요합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ heeft uw toestemming nodig om de menubalk te beheren."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ potrzebuje Twojej zgody na zarządzanie paskiem menu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ precisa da sua permissão para gerencia a barra de menus."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ требуется разрешение для управления строкой меню."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ ต้องการขออนุญาตจากคุณในการจัดการแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ menü çubuğunu yönetmek için izninize ihtiyaç duyuyor."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ потребує вашого дозволу для керування рядком меню."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ cần sự cho phép của bạn để quản lý thanh menu."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要您的授权以管理菜单栏。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 需要您授予權限以管理選單列。"
-          }
-        }
-      }
-    },
     "%@ seconds" : {
       "localizations" : {
         "cs" : {
@@ -2638,501 +2348,11 @@
         }
       }
     },
-    "%@ — placed by trigger “%@”" : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "en" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ — placed by trigger “%2$@”"
-          }
-        }
-      }
+    "%@ spacer" : {
+
     },
-    "%lf seconds" : {
-      "comment" : "A localized string key that represents a duration in seconds. The argument is a number of seconds.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekundy"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekund"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekunda"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekund"
-                }
-              }
-            }
-          }
-        },
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf Sekunde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf Sekunden"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf second"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%lf seconds"
-                }
-              }
-            }
-          }
-        },
-        "es" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf segundo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf segundos"
-                }
-              }
-            }
-          }
-        },
-        "fr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf seconde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf secondes"
-                }
-              }
-            }
-          }
-        },
-        "hu" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf másodperc"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf másodperc"
-                }
-              }
-            }
-          }
-        },
-        "id" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf detik"
-                }
-              }
-            }
-          }
-        },
-        "it" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf secondo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf secondi"
-                }
-              }
-            }
-          }
-        },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf 秒"
-                }
-              }
-            }
-          }
-        },
-        "ko" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf 초"
-                }
-              }
-            }
-          }
-        },
-        "nl" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf seconde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf seconden"
-                }
-              }
-            }
-          }
-        },
-        "pl" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekundy"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekund"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekunda"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf sekund"
-                }
-              }
-            }
-          }
-        },
-        "pt-BR" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf segundo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf segundos"
-                }
-              }
-            }
-          }
-        },
-        "ru" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунды"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунд"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунда"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунды"
-                }
-              }
-            }
-          }
-        },
-        "th" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf วินาที"
-                }
-              }
-            }
-          }
-        },
-        "tr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf saniye"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf saniye"
-                }
-              }
-            }
-          }
-        },
-        "uk" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунди"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунд"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунда"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf секунди"
-                }
-              }
-            }
-          }
-        },
-        "vi" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf giây"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf 秒"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hant" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lf 秒"
-                }
-              }
-            }
-          }
-        }
-      }
+    "%@ will delete its cache folder and quit. Launch the app again afterward." : {
+
     },
     "%lld fps" : {
       "comment" : "A label showing the current frame rate of the icon refresh timer. The argument is the current frame rate, rounded to the nearest whole number.",
@@ -3371,378 +2591,6 @@
         }
       }
     },
-    "%lld seconds" : {
-      "comment" : "Text that describes the rehide interval, in seconds. The argument is the number of seconds.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekundy"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekund"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekunda"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekund"
-                }
-              }
-            }
-          }
-        },
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Sekunde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld Sekunden"
-                }
-              }
-            }
-          }
-        },
-        "en" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld second"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "new",
-                  "value" : "%lld seconds"
-                }
-              }
-            }
-          }
-        },
-        "es" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld segundo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld segundos"
-                }
-              }
-            }
-          }
-        },
-        "fr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld seconde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld secondes"
-                }
-              }
-            }
-          }
-        },
-        "hu" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld másodperc"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld másodperc"
-                }
-              }
-            }
-          }
-        },
-        "id" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld detik"
-                }
-              }
-            }
-          }
-        },
-        "it" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld secondo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld secondi"
-                }
-              }
-            }
-          }
-        },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 秒"
-                }
-              }
-            }
-          }
-        },
-        "ko" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 초"
-                }
-              }
-            }
-          }
-        },
-        "nl" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld seconde"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld seconden"
-                }
-              }
-            }
-          }
-        },
-        "pl" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekundy"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekund"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekunda"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld sekund"
-                }
-              }
-            }
-          }
-        },
-        "pt-BR" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld segundo"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld segundos"
-                }
-              }
-            }
-          }
-        },
-        "ru" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунды"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунд"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунда"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунды"
-                }
-              }
-            }
-          }
-        },
-        "th" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld วินาที"
-                }
-              }
-            }
-          }
-        },
-        "tr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld saniye"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld saniye"
-                }
-              }
-            }
-          }
-        },
-        "uk" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунди"
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунд"
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунда"
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld секунди"
-                }
-              }
-            }
-          }
-        },
-        "vi" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld giây"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 秒"
-                }
-              }
-            }
-          }
-        },
-        "zh-Hant" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "%lld 秒"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
     "+%lld" : {
       "localizations" : {
         "cs" : {
@@ -3857,125 +2705,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "+%lld"
-          }
-        }
-      }
-    },
-    "^[%lld items](inflect: true)" : {
-      "comment" : "Fallback name for an unnamed item group",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "^[%lld items](inflect: true)"
           }
         }
       }
@@ -4218,126 +2947,6 @@
         }
       }
     },
-    "Absolutely no personal information is collected or stored." : {
-      "comment" : "A description of how user data is handled by the app.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neukládáme žádné osobní informace."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keinerlei persönliche Informationen werden gesammelt oder gespeichert."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se recopila ni almacena ninguna información personal."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aucune information personnelle n'est collectée ni stockée."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Semmilyen személyes adat nem kerül gyűjtésre vagy tárolásra."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sama sekali tidak ada informasi pribadi yang dikumpulkan atau disimpan."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Non viene raccolta né conservata alcuna informazione personale."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個人情報は一切収集・保存されません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개인 정보는 절대 수집되거나 저장되지 않습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er wordt absoluut geen persoonlijke informatie verzameld of opgeslagen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Absolutnie żadne dane osobowe nie są gromadzone ani przechowywane."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nenhuma informação pessoal é coletada ou armazenada."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Никакие персональные данные не собираются и не хранятся."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ไม่มีการเก็บรวบรวมหรือเก็บรักษาข้อมูลส่วนบุคคลใดๆ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kesinlikle hiçbir kişisel bilgi toplanmaz veya saklanmaz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Жодна особиста інформація не збирається та не зберігається."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tuyệt đối không có thông tin cá nhân nào được thu thập hoặc lưu trữ."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "绝不收集或存储任何个人信息。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "此程式絕不會收集或儲存您的個人資訊。"
-          }
-        }
-      }
-    },
     "Accessibility" : {
       "comment" : "Title of the accessibility permission.",
       "localizations" : {
@@ -4456,6 +3065,12 @@
           }
         }
       }
+    },
+    "Accessibility and Screen Recording permissions will be cleared for %@. The app will quit so you can grant them again on next launch." : {
+
+    },
+    "Accessibility is all Simple Mode needs for hiding and arranging; adding Screen Recording draws your real menu bar icons in the layout editor." : {
+
     },
     "Acknowledgements" : {
       "comment" : "The button that opens the acknowledgements page.",
@@ -5525,126 +4140,6 @@
         }
       }
     },
-    "Add Application Manually" : {
-      "comment" : "A heading for the section where users can add apps manually.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přidat aplikaci ručně"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Anwendung manuell hinzufügen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Agregar aplicación manualmente"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajouter une application manuellement"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alkalmazás manuális hozzáadása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tambahkan Aplikasi Secara Manual"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aggiungi l'applicazione manualmente"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手動でアプリケーションを追加"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "수동으로 애플리케이션 추가"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toepassing handmatig toevoegen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodaj aplikację ręcznie"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Adicionar App Manualmente"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Добавить приложение вручную"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เพิ่มแอปพลิเคชันด้วยตนเอง"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamayı Manuel Ekle"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Додати програму вручну"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thêm ứng dụng theo cách thủ công"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手动添加应用程序"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "手動新增應用程式"
-          }
-        }
-      }
-    },
     "Add Condition" : {
       "localizations" : {
         "cs" : {
@@ -5762,6 +4257,9 @@
           }
         }
       }
+    },
+    "Add Spacer" : {
+
     },
     "Add Trigger" : {
       "localizations" : {
@@ -7546,6 +6044,9 @@
         }
       }
     },
+    "Also start a new log file once the current one has been open for an hour or a day. The size limit still applies." : {
+
+    },
     "Always Hidden" : {
       "localizations" : {
         "cs" : {
@@ -8495,6 +6996,9 @@
           }
         }
       }
+    },
+    "App language" : {
+
     },
     "Appearance" : {
       "comment" : "The localized string key for the \"Appearance\" section in the \"Settings\" interface.",
@@ -11482,6 +9986,9 @@
         }
       }
     },
+    "Assigns a profile to the Space you are currently on. Spaces have no system name, so each assignment is labelled by its Mission Control position at the time you made it. A Space assignment takes precedence over a display assignment; a Focus Filter still overrides both." : {
+
+    },
     "Auto-rehide off" : {
       "comment" : "Profile preview summary fragment: automatic rehiding is disabled in the profile.",
       "localizations" : {
@@ -11957,6 +10464,12 @@
           }
         }
       }
+    },
+    "Automatic rehiding is off" : {
+
+    },
+    "Automatic rehiding is on" : {
+
     },
     "Automatically check for updates" : {
       "comment" : "A toggle that lets the user enable or disable automatic checking for updates.",
@@ -13384,8 +11897,11 @@
         }
       }
     },
-    "BETA" : {
-      "comment" : "The text displayed in the badge.",
+    "Behavior" : {
+
+    },
+    "Beta" : {
+      "comment" : "A segment in the update channel picker that displays \"Beta\".",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -13503,8 +12019,8 @@
         }
       }
     },
-    "Beta" : {
-      "comment" : "A segment in the update channel picker that displays \"Beta\".",
+    "BETA" : {
+      "comment" : "The text displayed in the badge.",
       "localizations" : {
         "cs" : {
           "stringUnit" : {
@@ -14217,6 +12733,9 @@
         }
       }
     },
+    "Cache cleared. Quitting…" : {
+
+    },
     "Can modify settings" : {
       "comment" : "A description of the permission that allows an app to modify Thaw settings.",
       "localizations" : {
@@ -14574,6 +13093,9 @@
         }
       }
     },
+    "Capture One Frame" : {
+
+    },
     "Capture Reference" : {
       "localizations" : {
         "cs" : {
@@ -14924,126 +13446,6 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Capturing…"
-          }
-        }
-      }
-    },
-    "Change the menu bar's appearance." : {
-      "comment" : "Detail about the \"Screen Recording\" permission, describing how to change the menu bar's appearance.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Změňte vzhled panelu nabídek."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die Darstellung der Menüleiste verändern."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cambiar la apariencia de la barra de menús"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifier l'apparence de la barre des menus."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menüsor megjelenésének módosítása."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rubah tampilan menu bar."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modifica l'aspetto della barra dei menu."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーの外観を変更します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대의 모양을 변경합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wijzig het uiterlijk van de menubalk."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmienić wygląd paska menu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alterar a aparência da barra de menus."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Изменить внешний вид строки меню."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เปลี่ยนลักษณะของแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğunun görünümünü değiştir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Змінювати вигляд рядка меню."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thay đổi giao diện của thanh menu."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更改菜单栏的外观。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "變更選單列外觀。"
           }
         }
       }
@@ -16592,6 +14994,9 @@
         }
       }
     },
+    "Choose an item" : {
+
+    },
     "Choose an item…" : {
       "localizations" : {
         "cs" : {
@@ -17422,6 +15827,9 @@
         }
       }
     },
+    "Clear Accessibility and Screen Recording decisions for %@, then quit so you can re-grant them on next launch." : {
+
+    },
     "Clear hook" : {
       "comment" : "A button that removes a hook.",
       "localizations" : {
@@ -17658,6 +16066,9 @@
           }
         }
       }
+    },
+    "Click" : {
+
     },
     "Click an empty area of the menu bar to show hidden menu bar items." : {
       "comment" : "Toggle that allows the user to enable or disable the feature of showing hidden menu bar items by clicking on an empty area of the menu bar.",
@@ -19440,6 +17851,13 @@
         }
       }
     },
+    "Control Center preferences were reset." : {
+      "comment" : "A success message displayed when the user resets the",
+      "isCommentAutoGenerated" : true
+    },
+    "Control Center will quit and its preference files will be deleted. macOS usually relaunches it automatically." : {
+
+    },
     "Controlled by a trigger" : {
       "localizations" : {
         "cs" : {
@@ -19914,6 +18332,9 @@
         }
       }
     },
+    "Couldn't confirm that the group settled into place." : {
+
+    },
     "Couldn't move %@ right now." : {
       "localizations" : {
         "cs" : {
@@ -20385,6 +18806,13 @@
           }
         }
       }
+    },
+    "Couldn't run tool" : {
+
+    },
+    "Create Group" : {
+      "comment" : "A button that creates a new group of two items.",
+      "isCommentAutoGenerated" : true
     },
     "Created: %@" : {
       "comment" : "A sublabel within the profile list showing when a profile was created.",
@@ -20980,6 +19408,10 @@
         }
       }
     },
+    "Daily" : {
+      "comment" : "Localized string key for the \"Daily\" option in the log rotation interval picker.",
+      "isCommentAutoGenerated" : true
+    },
     "Dark Appearance" : {
       "comment" : "Title of the system appearance when the user has a dark appearance.",
       "localizations" : {
@@ -21098,6 +19530,9 @@
           }
         }
       }
+    },
+    "Days to keep log files" : {
+
     },
     "default" : {
       "comment" : "Label for the default item spacing offset.",
@@ -21336,6 +19771,13 @@
           }
         }
       }
+    },
+    "Delete %@'s cache folder, then quit the app." : {
+      "comment" : "A destructive action button that deletes the cache folder for a given app.",
+      "isCommentAutoGenerated" : true
+    },
+    "Delete older log files after this many days, or sooner if more than 50 pile up. The file being written is always kept." : {
+
     },
     "Delete Profile?" : {
       "comment" : "An alert title that asks the user to confirm deleting a profile.",
@@ -22048,125 +20490,6 @@
         }
       }
     },
-    "Development" : {
-      "comment" : "A label for the \"Development\" segment in the update channel picker.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Testovací"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entwicklung"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desarrollo"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Développement"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fejlesztés"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pengembangan"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sviluppo"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開発版"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개발"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ontwikkeling"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wersja rozwojowa"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desenvolvimento"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Разработка"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "การพัฒนา"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Geliştirme"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Розробка"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Phát triển"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "开发版"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開發版"
-          }
-        }
-      }
-    },
     "Device" : {
       "localizations" : {
         "cs" : {
@@ -22403,6 +20726,9 @@
           }
         }
       }
+    },
+    "Diagnostics and Onboarding are non-destructive. Reset and Troubleshooting can delete preferences, clear the cache, or quit apps." : {
+
     },
     "Discard" : {
       "comment" : "A button label that dismisses an edit prompt.",
@@ -22642,125 +20968,8 @@
         }
       }
     },
-    "Display images of individual menu bar items." : {
-      "comment" : "Descriptive detail for the \"Screen Recording\" permission, describing the app's ability to display images of individual menu bar items.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukázat obrázky jednotlivých ikon v řádku nabídek"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bilder von individuellen Menüleisten-Einträgen anzeigen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar imágenes de elementos individuales de la barra de menús."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les images des éléments individuels de la barre des menus."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az egyes menüsor elemek képeinek megjelenítése."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tampilkan gambar untuk setiap item bar menu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visualizza le immagini delle singole voci della barra dei menu."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "個々のメニューバー項目の画像を表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "개별 메뉴 막대 항목의 이미지를 표시합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afbeeldingen van afzonderlijke menubalkitems weergeven."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyświetlać ikony poszczególnych elementów paska menu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exibe imagens de itens individuais da barra de menus."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отображать изображения отдельных элементов строки меню."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "แสดงภาพของไอคอนแต่ละรายการในแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tekil menü çubuğu öğelerinin görüntülerini göster."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відображати зображення окремих об'єктів рядка меню."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiển thị hình ảnh của các mục thanh menu riêng lẻ."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "显示单个菜单栏项目的图像。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "顯示個別選單列項目的圖像。"
-          }
-        }
-      }
+    "Display" : {
+
     },
     "Display the icon as a monochrome image that dynamically adjusts to match the menu bar's appearance. This setting removes all color from the icon, but ensures consistent rendering with both light and dark backgrounds." : {
       "comment" : "A description of a setting that controls whether a custom ice icon uses a dynamic or static appearance.",
@@ -24308,126 +22517,6 @@
         }
       }
     },
-    "Due to a bug in a previous version of the app, the data for %@'s menu bar sections was corrupted and had to be reset." : {
-      "comment" : "Text in an alert that informs the user that the preferred positions of some menu bar controls have been reset because they were corrupted.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kvůli chybě v minulé verzi aplikace, byla data sekcí řádku nabídek aplikace %@ poškozena a musela být resetována."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aufgrund eines Fehlers in der vorherigen Version dieser Anwendung wurden die Daten für den Menüleisten-Bereich von %@ beschädigt und mussten zurückgesetzt werden."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Debido a un error en una versión anterior de la app, los datos de las secciones de la barra de menús de %@ se dañaron y tuvieron que restablecerse."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En raison d'un bug dans une version précédente de l'app, les données des sections de la barre des menus de %@ ont été corrompues et ont dû être réinitialisées."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az alkalmazás egy korábbi verziójának hibája miatt a(z) %@ menüsor szakaszainak adatai megsérültek, és vissza kellett állítani őket."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Karena bug di versi aplikasi sebelumnya, data bar menu %@ rusak dan harus diatur ulang."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A causa di un bug in una versione precedente dell'app, i dati per le sezioni della barra dei menu di %@ erano corrotti e hanno dovuto essere reimpostati."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "以前のバージョンのアプリのバグにより、%@ のメニューバーセクションのデータが破損し、リセットされました。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이전 버전의 앱 버그로 인해 %@의 메뉴 막대 섹션 데이터가 손상되어 재설정해야 했습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Door een bug in een eerdere versie van de app waren de gegevens voor de menubalkonderdelen van %@ beschadigd en moesten ze worden gereset."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Z powodu błędu w poprzedniej wersji aplikacji dane sekcji paska menu użytkownika %@ zostały uszkodzone i musiały zostać zresetowane."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Devido a um erro em uma versão anterior do aplicativo, os dados das seções da barra de menus do %@ foram corrompidos e tiveram que ser redefinidos."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Из-за ошибки в предыдущей версии приложения данные секций строки меню %@ были повреждены и сброшены."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เนื่องจากมีบั๊กในเวอร์ชันก่อนหน้าของแอป ข้อมูลของส่วนต่างๆ ในแถบเมนูของ %@ ถูกทำลายและจำเป็นต้องถูกรีเซ็ต"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uygulamanın önceki bir sürümündeki bir hata nedeniyle %@ menü çubuğu bölümlerinin verisi bozuldu ve sıfırlanması gerekti."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Через помилку в попередній версії програми дані про розділи рядка меню %@ було пошкоджено, і їх довелося скинути."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Do lỗi trong phiên bản trước của ứng dụng, dữ liệu cho các phần thanh menu của %@ đã bị hỏng và phải được đặt lại."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "由于早期版本的漏洞，%@ 菜单栏部分数据已损坏，必须重置。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "由於舊版本的錯誤，%@ 的選單列區域資料已損毀，必須重置。"
-          }
-        }
-      }
-    },
     "Duplicate" : {
       "comment" : "A button to duplicate a saved profile.",
       "localizations" : {
@@ -25378,6 +23467,9 @@
           }
         }
       }
+    },
+    "Enable" : {
+
     },
     "Enable diagnostic logging" : {
       "comment" : "A toggle that enables or disables diagnostic logging.",
@@ -26686,6 +24778,9 @@
         }
       }
     },
+    "Enter zen mode while presenting" : {
+
+    },
     "Environment variables passed to scripts" : {
       "comment" : "A label describing the environment variables that can be passed to scripts.",
       "localizations" : {
@@ -27043,6 +25138,9 @@
         }
       }
     },
+    "Every saved status-item position will be deleted and the menu bar host will quit, so your whole menu bar arrangement is rebuilt from scratch." : {
+
+    },
     "Example: a bash pre-hook could `defaults write com.bjango.istatmenus5 ActiveProfile -string \"$THAW_PROFILE_NAME\"` to keep iStat Menus in sync with Thaw." : {
       "comment" : "A description of how to use environment variables in a pre-hook.",
       "localizations" : {
@@ -27279,6 +25377,10 @@
           }
         }
       }
+    },
+    "Explains what a setting does directly beneath it, like this text." : {
+      "comment" : "Text that explains what a setting does directly beneath it, like this text.",
+      "isCommentAutoGenerated" : true
     },
     "Export" : {
       "comment" : "A menu item that exports a profile to a file.",
@@ -27755,240 +25857,26 @@
         }
       }
     },
-    "Failed to update configuration on %lld profile(s)." : {
-      "comment" : "A message that indicates that the configuration update failed for some profiles.",
-      "extractionState" : "stale",
+    "Failed to update configuration on [%lld profiles]." : {
+      "comment" : "A pluralized string that describes the number of profiles that failed to update their configuration.",
+      "isCommentAutoGenerated" : true,
       "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aktualizace konfigurace %lld profilu(ů) se nezdařila."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfiguration von %lld Profil(en) konnte nicht aktualisiert werden."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se ha podido actualizar la configuración en %lld perfil(es)."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Échec de la mise à jour de la configuration sur le(s) profil(s) %lld."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nem sikerült frissíteni a konfigurációt %lld profilnál."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gagal memperbarui konfigurasi pada profil %lld."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fallito l'aggiornamento della configurazione su profilo(i) %lld."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld プロファイルの設定を更新できませんでした。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "프로필 %lld개의 구성을 업데이트하는 데 실패했습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Het is niet gelukt om de configuratie van %lld profiel(en) bij te werken."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wystąpił błąd podczas aktualizacji konfiguracji dla %lld profili."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não foi possível atualizar a configuração no(s) perfil(is) %lld."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось обновить конфигурацию на профиле %lld."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ไม่สามารถอัปเดตการตั้งค่าใน %lld โปรไฟล์ได้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%lld profil(ler)inin yapılandırması güncellenemedi."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося оновити конфігурацію для %lld профілю(ів)."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không cập nhật được cấu hình trên (những) cấu hình %lld cũ."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新 %lld 个配置文件失败。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法更新 %lld 個設定檔的配置。"
-          }
-        }
-      }
-    },
-    "Failed to update configuration on ^[%lld profiles](inflect: true)." : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nezdařila se aktualizace konfigurace při ^[%lld profiles](inflect: true)."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se ha podido actualizar la configuración en %lld perfil(es)."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Het is niet gelukt om de configuratie bij te werken voor ^[%lld profielen](verbuigen: waar)."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie udało się zaktualizować konfiguracji dla ^[%lld profili](inflect: true)."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось обновить конфигурацию для %lld профиля(ов)."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "^[%lld profilde](inflect: true) yapılandırma güncellenemedi."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to update configuration on ^[%lld profiles](inflect: true)."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "更新 %lld 个配置文件失败。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法更新 %lld 個設定檔的配置。"
+        "en" : {
+          "variations" : {
+            "plural" : {
+              "one" : {
+                "stringUnit" : {
+                  "state" : "translated",
+                  "value" : "Failed to update configuration on [%lld profile]."
+                }
+              },
+              "other" : {
+                "stringUnit" : {
+                  "state" : "new",
+                  "value" : "Failed to update configuration on [%lld profiles]."
+                }
+              }
+            }
           }
         }
       }
@@ -28112,6 +26000,9 @@
         }
       }
     },
+    "Fill the spacer with a color. Fully transparent renders as an empty gap." : {
+
+    },
     "Find menu bar items visually when searching." : {
       "localizations" : {
         "cs" : {
@@ -28229,6 +26120,9 @@
           }
         }
       }
+    },
+    "First item" : {
+
     },
     "Focus" : {
       "comment" : "Localized string key for the \"Focus\" case in the `RehideStrategy` enum.",
@@ -28704,6 +26598,16 @@
         }
       }
     },
+    "Frame bounds: x=%lld, y=%lld, %lld×%lld pt" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Frame bounds: x=%1$lld, y=%2$lld, %3$lld×%4$lld pt"
+          }
+        }
+      }
+    },
     "From" : {
       "localizations" : {
         "cs" : {
@@ -29175,126 +27079,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "一般"
-          }
-        }
-      }
-    },
-    "Get real-time information about the menu bar." : {
-      "comment" : "A detail about the \"Accessibility\" permission, explaining that the app needs permission to get real-time information about the menu bar.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Získejte informace o řádku nabídek v reálném čase."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Echtzeit-Informationen über die Menüleiste erhalten"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtener información en tiempo real sobre la barra de menús"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtenir les informations de la barre des menus en temps réel."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Valós idejű információk lekérése a menüsorról."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dapatkan informasi waktu nyata pada bar menu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ottieni informazioni in tempo reale sulla barra dei menu."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーに関するリアルタイム情報を取得します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대에 대한 실시간 정보를 가져옵니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Krijg realtime informatie over de menubalk."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uzyskać informacje o pasku menu w czasie rzeczywistym."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obtenha informações em tempo real sobre a barra de menus."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Получить информацию о строке меню в реальном времени."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รับข้อมูลแถบเมนูแบบเรียลไทม์"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğu hakkında anlık bilgi alın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Отримувати інформацію про рядок меню в режимі реального часу."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nhận thông tin thời gian thực về thanh menu."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "获取有关菜单栏的实时信息。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "取得選單列的即時資訊。"
           }
         }
       }
@@ -30488,6 +28272,21 @@
         }
       }
     },
+    "Group name" : {
+      "comment" : "A label for a text field that edits a group name.",
+      "isCommentAutoGenerated" : true
+    },
+    "Grouped items stay adjacent: drag any member and the whole group moves with it." : {
+      "comment" : "Tooltip for the \"Grouped items stay adjacent: drag any member and the whole group moves with it.\" button.",
+      "isCommentAutoGenerated" : true
+    },
+    "Groups always move together: drag any member in the bars above and the whole group follows." : {
+      "comment" : "A description of how groups move together.",
+      "isCommentAutoGenerated" : true
+    },
+    "Help translate %@" : {
+
+    },
     "Hidden" : {
       "comment" : "Localized string key for the \"Hidden\" menu bar section.",
       "localizations" : {
@@ -30844,6 +28643,9 @@
           }
         }
       }
+    },
+    "Hide every concealable section for as long as a display is mirrored or your screen is being shared, then put it back. macOS offers no way to see that another app is recording the screen, so recordings are not covered." : {
+
     },
     "Hide Hidden Section" : {
       "comment" : "Title of a menu item that toggles the visibility of a hidden section in the menu bar.",
@@ -31438,126 +29240,6 @@
         }
       }
     },
-    "Hooks" : {
-      "comment" : "A heading for the hooks section.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooky"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hookok"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "フック"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "훅"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooki"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хуки"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooklar"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Надбудови"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hooks"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hook"
-          }
-        }
-      }
-    },
     "Horizontal" : {
       "comment" : "Localized string key for the horizontal layout mode.",
       "localizations" : {
@@ -32034,6 +29716,14 @@
         }
       }
     },
+    "Hourly" : {
+      "comment" : "Localized string key for the hourly log rotation interval.",
+      "isCommentAutoGenerated" : true
+    },
+    "Hover" : {
+      "comment" : "A checkbox that lets the user toggle whether the menu bar shows hidden items when they hover over it.",
+      "isCommentAutoGenerated" : true
+    },
     "Hover over an empty area of the menu bar to show hidden menu bar items." : {
       "comment" : "Text displayed in a toggle that allows the user to enable or disable the feature of showing hidden menu bar items by hovering over an empty area of the menu bar.",
       "localizations" : {
@@ -32391,245 +30081,6 @@
         }
       }
     },
-    "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU." : {
-      "comment" : "Description of the icon refresh rate setting in the layout settings pane.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "How often animated icons refresh in the visible section, Hidden Thaw Bar, Search, and Layout. Always Hidden stays at 1 fps. Higher values use more CPU."
-          }
-        }
-      }
-    },
-    "How often animated menu bar icons are refreshed in panels. Higher values are smoother but use more CPU." : {
-      "comment" : "Description of the icon refresh rate setting in the advanced settings pane.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jak často se v panelech aktualizují animované ikony řádku nabídek. Čím vyšší hodnota, tím plynulejší animace, ale také vyšší zatížení procesoru."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wie oft animierte Symbole aufgefrischt werden. Höhere Werte bedeuten eine flüssigere Darstellung, benötigen aber mehr Prozessorleistung."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Con qué frecuencia se actualizan los íconos animados de la barra de menús en los paneles. Valores más altos son más fluidos pero usan más CPU."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fréquence de rafraîchissement des icônes animées de la barre des menus. Des valeurs plus élevées offrent un affichage plus fluide mais utilisent davantage de CPU."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Milyen gyakran frissülnek az animált menüsávikonok a panelekben. A magasabb értékek simább megjelenítést adnak, de több CPU-t használnak."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seberapa sering ikon bar menu beranimasi diperbaharui di panel. Nilai lebih tinggi lebih mulus, tetapi menggunakan lebih banyak CPU."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Frequenza di aggiornamento delle icone animate della barra dei menu nei pannelli. Valori più alti sono più fluidi, ma utilizzano più CPU."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "パネル内でアニメーションするメニューバーアイコンの更新頻度です。値が大きいほど滑らかになりますが、CPUの使用量が増えます。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "패널에서 움직이는 메뉴 막대 아이콘을 얼마나 자주 새로 고칠지 설정합니다. 값이 높을수록 더 부드럽지만 CPU 사용량이 늘어납니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hoe vaak de geanimeerde pictogrammen in de menubalk in de panelen worden vernieuwd. Hogere waarden zorgen voor een vloeiender beeld, maar belasten de CPU meer."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Częstotliwość odświeżania animacji ikon na pasku menu. Większa wartość to lepsza płynność kosztem większego zużycia procesora."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Com que frequência os ícones animados da barra de menus são atualizados nos painéis. Valores mais altos proporcionam maior fluidez, mas consomem mais CPU."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Частота обновления анимированных значков строки меню в панелях. Более высокие значения обеспечивают плавность, но потребляют больше ресурсов процессора."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ความถี่ในการรีเฟรชไอคอนแถบเมนูที่เคลื่อนไหวในแผง ค่าที่สูงกว่าจะราบเรียบขึ้นแต่ใช้ CPU มากขึ้น"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Panellerde animasyonlu menü çubuğu simgelerinin ne sıklıkla yenilendiği. Daha yüksek değerler daha akıcıdır ancak daha fazla CPU kullanır."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Як часто оновлюються анімовані значки рядка меню на панелях. Вищі значення забезпечують плавніше відображення, але споживають більше процесорного часу."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tần suất các biểu tượng thanh menu động được làm mới trong bảng. Giá trị cao hơn sẽ mượt mà hơn nhưng sử dụng nhiều CPU hơn."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "面板中动画菜单栏图标的刷新频率。数值越大越流畅，但会增加CPU占用。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "面板中動態選單列圖示的重新整理頻率。數值越高越流暢，但會使用較多 CPU。"
-          }
-        }
-      }
-    },
     "Ice Cube" : {
       "comment" : "Localized string key for the Ice Cube control item image.",
       "localizations" : {
@@ -32745,126 +30196,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "冰塊"
-          }
-        }
-      }
-    },
-    "Icon positions can't be restored." : {
-      "comment" : "A footnote explaining that icon positions cannot be restored when importing settings from Ice.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Umístění ikon nelze obnovit."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Symbol-Positionen können nicht übernommen werden."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Las posiciones de los iconos no se pueden restaurar."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les positions des icônes ne peuvent pas être restaurées."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az ikonpozíciók nem állíthatók vissza."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Posisi ikon tidak dapat dipulihkan."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Le posizioni delle icone non possono essere ripristinate."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "アイコンの位置は復元できません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "아이콘 위치를 복원할 수 없습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De posities van pictogrammen kunnen niet worden hersteld."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie można przywrócić położenia ikon."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "As posições dos ícones não podem ser restauradas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позиции значков не могут быть восстановлены."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ไม่สามารถคืนค่าตำแหน่งไอคอนได้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Simge konumları geri yüklenemiyor."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Позиції значків неможливо відновити."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vị trí biểu tượng không thể được khôi phục."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法还原图标位置。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法還原圖示位置。"
           }
         }
       }
@@ -34656,6 +31987,10 @@
         }
       }
     },
+    "Inserts an empty gap item into the menu bar. Position it like any other item — hold ⌘ Command and drag it in the menu bar." : {
+      "comment" : "Text displayed in a button that adds a spacer to the menu bar.",
+      "isCommentAutoGenerated" : true
+    },
     "Inset on notched displays" : {
       "localizations" : {
         "cs" : {
@@ -34773,6 +32108,13 @@
           }
         }
       }
+    },
+    "Item groups" : {
+
+    },
+    "Item icons are cropped out of this band to draw the layout editor, the Bar, and Search." : {
+      "comment" : "A description of how the menu bar is read by Thaw.",
+      "isCommentAutoGenerated" : true
     },
     "Items are arranged in a grid with multiple columns." : {
       "comment" : "A description of the grid layout.",
@@ -35368,6 +32710,9 @@
         }
       }
     },
+    "Keep logs for (days)" : {
+
+    },
     "Keep search" : {
       "comment" : "A toggle to keep a search query open.",
       "localizations" : {
@@ -35486,6 +32831,9 @@
           }
         }
       }
+    },
+    "Language" : {
+
     },
     "Last checked: %@" : {
       "comment" : "A text label displaying the date and time of the last update check. The text is monospaced and has a secondary foreground color. If there is no previous check, the text is hidden.",
@@ -37269,124 +34617,6 @@
         }
       }
     },
-    "macOS 27 Is Not Yet Supported" : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "macOS 27 Is Not Yet Supported"
-          }
-        }
-      }
-    },
     "macOS draws a solid menu bar while Reduce Transparency is on, so %@ cannot tint or reshape it. Turn the setting off to see these effects." : {
       "localizations" : {
         "cs" : {
@@ -37980,6 +35210,12 @@
         }
       }
     },
+    "Maximum log file size (MB)" : {
+
+    },
+    "Maximum log file size in megabytes" : {
+
+    },
     "Maximum number of items per row in the grid arrangement." : {
       "localizations" : {
         "cs" : {
@@ -38094,126 +35330,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "網格排列中每列項目的最大數量。"
-          }
-        }
-      }
-    },
-    "Maximum number of items per row in the grid layout." : {
-      "comment" : "Label for the maximum number of items per row in the grid layout.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nejvyšší počet ikon v jednom řádku mřížky."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximale Anzahl von Einträgen pro Zeile im Rasterlayout."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Número máximo de elementos por fila en el diseño de la cuadrícula."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nombre d'éléments maximum par ligne dans la disposition en grille."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az elemek maximális száma soronként a rácsos elrendezésben."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jumlah maksimal item per baris dalam tata letak kisi."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Massimo numero di elementi per riga nel formato griglia."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "グリッドレイアウトにおける1行あたりの最大アイテム数。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "그리드 레이아웃에서 한 열당 최대 항목 수입니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maximaal aantal items per rij in de rasterindeling."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Maksymalna liczba elementów w jednym wierszu siatki."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Número máximo de itens por linha no layout da grade."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Максимальное количество элементов в строке в макете сетки."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "จำนวนรายการสูงสุดต่อแถวในการจัดวางแบบตาราง"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Izgara düzenindeki satır başına maksimum öge sayısı."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Maximum number of items per row in the grid layout."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Số mục tối đa trên mỗi hàng trong bố cục lưới."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "网格布局中每行的最大条目数。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "網格佈局中每列項目的最大數量。"
           }
         }
       }
@@ -39524,124 +36640,8 @@
         }
       }
     },
-    "Menu bar layout requires screen recording permissions." : {
-      "comment" : "A message displayed when the user does not have the necessary permissions to change the menu bar layout.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rozložení řádku nabídek vyžaduje oprávnění nahrávat obrazovku."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Das Menüleisten-Layout benötigt die Berechtigung für die Aufnahme von Bildschirm & Systemaudio."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La disposición de la barra de menús requiere permisos de grabación de pantalla."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La gestion de la barre des menus nécessite l'autorisation d'enregistrement de l'écran."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A menüsor elrendezéséhez képernyőfelvételi engedély szükséges."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tata letak bar menu membutuhkan izin Perekaman Layar."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per il layout della barra dei menu è necessario disporre delle autorizzazioni di registrazione dello schermo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーのレイアウトには画面収録の権限が必要です。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대 레이아웃에는 화면 기록 권한이 필요합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Voor de indeling van de menubalk zijn machtigingen voor schermopnames vereist."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Układ paska menu wymaga uprawnień do nagrywania ekranu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O layout da barra de menus requer permissões de gravação de tela."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для расположения строки меню требуется разрешение на запись экрана."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "การจัดเรียงแถบเมนูต้องการสิทธิ์ในการบันทึกหน้าจอ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğu düzeni ekran kaydı izinleri gerektirir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для керування розміткою рядка меню потрібен дозвіл на запис екрана."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bố cục thanh menu yêu cầu quyền ghi màn hình."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "菜单栏布局需要屏幕录制权限。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "選單列佈局需要螢幕錄影權限。"
-          }
-        }
-      }
+    "Menu bar layout positions were reset." : {
+
     },
     "Menu Bar Management" : {
       "comment" : "Title of the menu bar management onboarding slide.",
@@ -42490,6 +39490,9 @@
         }
       }
     },
+    "No display found." : {
+
+    },
     "No items in this section" : {
       "comment" : "A message displayed when a section of the Ice Bar has no items.",
       "localizations" : {
@@ -44628,6 +41631,9 @@
         }
       }
     },
+    "not running" : {
+
+    },
     "Notch" : {
       "comment" : "A label describing a display with a notch.",
       "localizations" : {
@@ -44865,6 +41871,9 @@
           }
         }
       }
+    },
+    "Nothing shown here is saved or sent anywhere; the capture exists only while this page is open." : {
+
     },
     "Notify when this reveals the item" : {
       "localizations" : {
@@ -45221,6 +42230,9 @@
           }
         }
       }
+    },
+    "Onboarding" : {
+
     },
     "onboarding.mockup.management.hide" : {
       "extractionState" : "manual",
@@ -46460,125 +43472,6 @@
         }
       }
     },
-    "Open %@ Settings" : {
-      "comment" : "A button that opens the settings app to grant screen recording permissions for the \\(Constants.displayName) Bar.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otevřít nastavení %@"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Öffne %@-Einstellungen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir ajustes de %@"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ouvrir les réglages de %@"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ beállítások megnyitása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Buka Pengaturan %@"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Apri %@ Impostazioni"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 設定を開く"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 설정 열기"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Open %@ Instellingen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Otwórz ustawienia %@"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abrir Configurações %@"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Открыть настройки %@"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เปิดการตั้งค่า %@"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Ayarlarını Aç"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відкрити налаштування %@"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mở Cài đặt %@"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "打开 %@ 设置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "開啟 %@ 設定"
-          }
-        }
-      }
-    },
     "Open Focus Settings" : {
       "comment" : "A button that opens the Focus settings app.",
       "localizations" : {
@@ -47054,124 +43947,6 @@
         }
       }
     },
-    "Otherwise hide in" : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Otherwise hide in"
-          }
-        }
-      }
-    },
     "Other…" : {
       "localizations" : {
         "cs" : {
@@ -47286,6 +44061,124 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Other…"
+          }
+        }
+      }
+    },
+    "Otherwise hide in" : {
+      "localizations" : {
+        "cs" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "id" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "ko" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "th" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
+          }
+        },
+        "zh-Hant" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Otherwise hide in"
           }
         }
       }
@@ -47651,6 +44544,9 @@
         }
       }
     },
+    "Per display" : {
+
+    },
     "Per-Profile Hooks" : {
       "comment" : "A heading for the hooks that apply only to a specific profile.",
       "localizations" : {
@@ -47769,6 +44665,9 @@
           }
         }
       }
+    },
+    "Per-Space override" : {
+
     },
     "Per-Space Profiles" : {
       "comment" : "Section title for assigning profiles to Spaces.",
@@ -48126,6 +45025,12 @@
           }
         }
       }
+    },
+    "Permissions cleared. Quitting…" : {
+
+    },
+    "Pick two items below to group them. Grouped items always move together." : {
+
     },
     "Post-apply" : {
       "comment" : "Label for the \"Post-apply\" hook.",
@@ -49197,6 +46102,10 @@
         }
       }
     },
+    "Quit & Clear Cache" : {
+      "comment" : "A destructive action that deletes the cache folder and quits the app.",
+      "isCommentAutoGenerated" : true
+    },
     "Quit %@" : {
       "comment" : "A button that quits the app.",
       "localizations" : {
@@ -49315,6 +46224,19 @@
           }
         }
       }
+    },
+    "Quit and clear cache" : {
+      "comment" : "A button to reset the menu bar layout positions.",
+      "isCommentAutoGenerated" : true
+    },
+    "Quit and clear cache?" : {
+
+    },
+    "Quit Control Center and delete its preference files so system menu bar item state can rebuild." : {
+
+    },
+    "Quit the menu bar host and delete its saved item positions, so the menu bar arrangement rebuilds from scratch. Use this when items refuse to return to the menu bar after rearranging." : {
+
     },
     "Radius" : {
       "localizations" : {
@@ -49908,6 +46830,9 @@
         }
       }
     },
+    "Relaunch Now" : {
+
+    },
     "Remove" : {
       "comment" : "Button that clears a profile's Space assignment.",
       "localizations" : {
@@ -50146,6 +47071,12 @@
         }
       }
     },
+    "Remove All" : {
+
+    },
+    "Remove from group" : {
+
+    },
     "Remove from whitelist" : {
       "comment" : "A label for a button that removes an app from the whitelist.",
       "localizations" : {
@@ -50265,6 +47196,9 @@
         }
       }
     },
+    "Remove Override for This Space" : {
+
+    },
     "Remove this condition" : {
       "localizations" : {
         "cs" : {
@@ -50382,6 +47316,9 @@
           }
         }
       }
+    },
+    "Remove this spacer" : {
+
     },
     "Rename" : {
       "comment" : "A menu item that lets the user rename a profile.",
@@ -50501,6 +47438,13 @@
           }
         }
       }
+    },
+    "Replay onboarding" : {
+      "comment" : "A button to replay onboarding.",
+      "isCommentAutoGenerated" : true
+    },
+    "Replay Onboarding" : {
+
     },
     "Report a Bug" : {
       "comment" : "A button that opens a web page where users can report bugs.",
@@ -51453,6 +48397,16 @@
         }
       }
     },
+    "Reset Control Center" : {
+      "comment" : "A destructive action that resets the Control Center app's preferences.",
+      "isCommentAutoGenerated" : true
+    },
+    "Reset Control Center preferences" : {
+
+    },
+    "Reset Control Center preferences?" : {
+
+    },
     "Reset failed: %@" : {
       "comment" : "A message that is displayed when the menu bar layout reset fails. The argument is a message describing the failure.",
       "localizations" : {
@@ -51572,125 +48526,8 @@
         }
       }
     },
-    "Reset Layout" : {
-      "comment" : "A button label that resets the menu bar layout.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnovit rozložení"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Layout zurücksetzen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restablecer organización"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser la disposition"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Elrendezés visszaállítása"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atur Ulang Tata Letak"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetta Layout"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "レイアウトをリセット"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "레이아웃 재설정"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset indeling"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przywróć układ domyślny"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefinir Layout"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить расположение"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเซ็ตการจัดวางแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Düzeni Sıfırla"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скинути розмітку"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đặt lại bố cục"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置布局"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置佈局"
-          }
-        }
-      }
+    "Reset Layout Positions" : {
+
     },
     "Reset Layout…" : {
       "localizations" : {
@@ -52048,125 +48885,20 @@
         }
       }
     },
-    "Reset menu bar layout?" : {
-      "comment" : "An alert title that asks the user to confirm resetting the menu bar layout.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnovit rozložení řádku nabídek?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menüleisten-Layout zurücksetzen?"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Restablecer la disposición de la barra de menús?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialiser la disposition de la barre des menus ?"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visszaállítja a menüsor elrendezését?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atur ulang tata letak bar menu?"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ripristinare il layout della barra dei menu?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーのレイアウトをリセットしますか？"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대 레이아웃을 재설정할까요?"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menu-balkindeling resetten?"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zresetować układ paska menu?"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefinir aparência da barra de menus?"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбросить расположение строки меню?"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเซ็ตการจัดวางแถบเมนูหรือไม่?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğu düzeni sıfırlansın mı?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скинути розмітку рядка меню?"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đặt lại bố cục thanh menu?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是否重置菜单栏布局？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置選單列佈局？"
-          }
-        }
-      }
+    "Reset menu bar layout positions" : {
+
+    },
+    "Reset menu bar layout positions?" : {
+
+    },
+    "Reset permissions" : {
+
+    },
+    "Reset Permissions" : {
+
+    },
+    "Reset permissions?" : {
+
     },
     "Reset to the default spacing" : {
       "comment" : "A button that resets the menu bar item spacing to its default value.",
@@ -52283,126 +49015,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "重置為預設間距"
-          }
-        }
-      }
-    },
-    "Resets dividers and moves every movable item except the %@ icon to hidden — just like a fresh install." : {
-      "comment" : "A description of what resetting the menu bar layout does.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnoví oddělovače a skryje všechny přesunutelné prvky kromě ikony %@ – přesně jako při nové instalaci."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abstände zurücksetzen und jeden bewegbaren Eintrag mit Ausnahme des %@-Symbols in den versteckten Bereich bewegen - wie bei einer Neuinstallation."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaura los separadores y mueve todos los elementos movibles, excepto el icono de %@, a Ocultos, como en una instalación nueva."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Réinitialise les séparateurs et déplace tous les éléments déplaçables, à l'exception de l'icône %@, vers les éléments masqués, comme lors d'une nouvelle installation."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visszaállítja az elválasztókat és minden mozgatható elemet a Rejtett szakaszba helyez a(z) %@ ikon kivételével – mint egy friss telepítésnél."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atur ulang pembagi dan pindahkan semua item yang dapat dipindahkan ke bagian tersembunyi kecuali ikon %@ - seperti instalasi baru."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reimposta i divisori e sposta tutti gli elementi mobili, eccetto l'icona %@, su nascosto, proprio come una nuova installazione."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "区切りをリセットし、%@ アイコンを除くすべての移動可能な項目を非表示に移動します — 新規インストール直後の状態になります。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구분선을 재설정하고 %@ 아이콘을 제외한 모든 이동 가능한 항목을 숨김으로 이동합니다 — 새로 설치한 것처럼."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reset de scheidingslijnen en verplaats alle verplaatsbare items behalve het %@-pictogram naar verborgen — net als bij een nieuwe installatie."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Resetuje separatory i przenosi do ukrytych wszystkie elementy (oprócz ikony %@), przywracając stan jak tuż po instalacji."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Redefine divisores e move todos os itens que podem ser movidos, exceto o ícone %@, para Ocultos — como em uma instalação nova."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Сбрасывает разделители и перемещает все подвижные элементы, кроме значка %@, в скрытые — как при новой установке."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "รีเซ็ตตัวแบ่งและย้ายไอคอนที่ย้ายได้ทั้งหมด ยกเว้นไอคอน %@ ให้ไปอยู่ในส่วนที่ซ่อนอยู่ เสมือนติดตั้งใหม่"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayırıcıları sıfırlar ve %@ simgesi dışındaki her taşınabilir öğeyi gizliye taşır — tıpkı yeni kurulum gibi."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Скидає роздільники та переміщує всі рухомі об'єкти, окрім значка %@, до прихованих — як після нового встановлення."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Đặt lại các ngăn và di chuyển mọi mục có thể di chuyển ngoại trừ biểu tượng %@ sang ẩn — giống như cài đặt mới."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置分隔线，并将除 %@ 图标之外的所有可移动项目移至隐藏状态，跟原版本菜单栏一样。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "重置分隔線並將除 %@ 圖示外的所有可移動項目移至隱藏區域，就像全新安裝一樣。"
           }
         }
       }
@@ -52644,125 +49256,8 @@
         }
       }
     },
-    "Restores divider defaults and moves every movable item except the %@ icon to Hidden. Use this if the layout looks broken or items won’t load." : {
-      "comment" : "A message displayed in an alert when the user confirms resetting the menu bar layout.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnoví výchozí nastavení oddělovačů a přesune všechny přesunutelné ikony kromě ikony %@ do sekce „Skryté“. Tuto funkci použijte, pokud rozložení vypadá poškozeně nebo se ikony nenačítají."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Standard-Abstände wieder herstellen und jeden bewegbaren Eintrag mit Ausnahme des %@-Symbols in den versteckten Bereich bewegen. Diese Einstellung nutzen, wenn das Layout falsch aussieht oder Einträge nicht laden."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaura los separadores y mueve todos los elementos movibles, excepto el icono de %@, a Ocultos. Usa esta opción si la barra de menús se ve rara o si algunos elementos no aparecen."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaure les séparateurs par défaut et déplace tous les éléments déplaçables, à l'exception de l'icône %@, vers les éléments masqués. À utiliser si la disposition semble incorrecte ou si certains éléments ne se chargent pas."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Visszaállítja az elválasztók alapértelmezett beállításait, és minden mozgatható elemet a Rejtett részbe helyez, a %@ ikon kivételével. Használd ezt, ha az elrendezés hibásnak tűnik, vagy az elemek nem töltődnek be."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pulihkan pembagi bawaan dan pindahkan semua item yang dapat dipindahkan ke bagian tersembunyi kecuali ikon %@. Gunakan bila tata letak terlihat bermasalah atau item tidak dimuat."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ripristina le impostazioni predefinite del divisore e sposta tutti gli elementi spostabili, tranne l'icona %@, su Nascosto. Utilizza questa opzione se il layout appare danneggiato o se gli elementi non vengono caricati."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "区切りを初期状態に戻し、%@ アイコンを除くすべての移動可能な項目を非表示にします。レイアウトの崩れや読み込みの不具合が発生した際に実行してください。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "구분선 기본 설정을 복원하고 %@ 아이콘을 제외한 모든 이동 가능한 항목을 숨김으로 이동합니다. 레이아웃이 깨져 보이거나 항목이 로드되지 않는 경우 사용하세요."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Herstelt de standaardinstellingen van de scheidingslijn en verplaatst alle verplaatsbare items, behalve het %@-pictogram, naar Verborgen. Gebruik deze optie als de lay-out er verkeerd uitziet of als items niet worden geladen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Przywraca standardowy układ separatorów, przenosząc ruchome elementy do ukrytych (z wyłączeniem ikony %@). Wybierz tę opcję, jeśli układ ikon nie wyświetla się poprawnie."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Restaure os padrões de divisores e mova todos os itens que podem ser movidos, exceto o ícone %@, para Ocultos. Use isso se o layout parecer corrompido ou os itens não carregarem."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Восстанавливает разделители по умолчанию и перемещает все подвижные элементы, кроме значка %@, в скрытые. Используйте, если расположение выглядит неправильно или элементы не загружаются."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "คืนค่าตัวแบ่งเป็นค่าเริ่มต้น และย้ายไอคอนทุกตัวที่ย้ายได้ ยกเว้นไอคอน %@ ให้ไปอยู่ในส่วนที่ซ่อนอยู่ ใช้ตัวเลือกนี้หากการจัดวางดูผิดปกติ หรือไอคอนบางตัวไม่สามารถโหลดได้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayırıcı varsayılanlarını geri yükler ve %@ simgesi dışındaki her taşınabilir öğeyi Gizli'ye taşır. Düzen bozuk görünüyorsa veya öğeler yüklenmiyorsa bunu kullanın."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Відновлює типові роздільники та переміщує всі рухомі об'єкти, окрім значка %@, до розділу «Приховані». Скористайтеся цим, якщо розмітка виглядає пошкодженою або об'єкти не завантажуються."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Khôi phục mặc định của dải phân cách và di chuyển mọi mục có thể di chuyển ngoại trừ biểu tượng %@ sang Ẩn. Hãy sử dụng tùy chọn này nếu bố cục có vẻ bị hỏng hoặc các mục không tải được."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "恢复分隔线默认设置，并将除 %@ 图标外的所有可移动元素隐藏。如果布局显示异常或元素无法加载，请使用此选项。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "還原分隔線預設值，並將除 %@ 圖示外的所有可移動項目移至隱藏區域。如果佈局顯示異常或項目無法載入，請使用此功能。"
-          }
-        }
-      }
+    "Restore %@ preferences to their defaults. Saved profiles and user data are not deleted. This cannot be undone." : {
+
     },
     "Reveal hidden items through the Thaw Bar while overflow has items ejected. The visible row has no room left beside the notch at that point, so expanding the hidden section inline cannot show them. Disable to always follow the per-display Thaw Bar setting." : {
       "localizations" : {
@@ -53000,6 +49495,9 @@
           }
         }
       }
+    },
+    "Review the feature tour and permission setup again." : {
+
     },
     "Right aligned" : {
       "comment" : "Localized string key for the right-aligned Thaw Bar location.",
@@ -53476,6 +49974,10 @@
           }
         }
       }
+    },
+    "Rotate by time" : {
+      "comment" : "Label for a picker that lets the user choose how often the app should rotate its diagnostic log files.",
+      "isCommentAutoGenerated" : true
     },
     "Round Cap" : {
       "comment" : "A description of a round-shaped menu bar end cap.",
@@ -54071,6 +50573,9 @@
         }
       }
     },
+    "Safe vs maintenance tools" : {
+
+    },
     "Sample colors from the menu bar to adjust its tint and appearance." : {
       "localizations" : {
         "cs" : {
@@ -54665,6 +51170,9 @@
         }
       }
     },
+    "Saves the appearance above for the currently active Space only. Every other Space keeps the shared appearance." : {
+
+    },
     "Screen Recording" : {
       "comment" : "Title of the screen recording permission.",
       "localizations" : {
@@ -54784,6 +51292,10 @@
         }
       }
     },
+    "Screen Recording is off, so %@ reads nothing." : {
+      "comment" : "A warning that Screen Recording is off, so the app doesn't read the screen.",
+      "isCommentAutoGenerated" : true
+    },
     "Screen recording permissions are required to display tooltips." : {
       "comment" : "A message displayed in the \"Permissions\" section of the advanced settings pane, explaining that screen recording permissions are needed to show tooltips.",
       "localizations" : {
@@ -54893,125 +51405,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "需要屏幕录制权限才能显示提示。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要螢幕錄影權限才能顯示提示。"
-          }
-        }
-      }
-    },
-    "Screen recording permissions are required to search menu bar items." : {
-      "comment" : "A message displayed when screen recording permissions are not granted.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pro funkci vyhledávání v ikonách řádku nabídek musíte udělit oprávnění nahrávání obrazovky."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Berechtigung für Aufnahme von Bildschirm & Systemaudio wird benötigt um Menüleisten-Einträge zu durchsuchen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se requieren permisos de grabación de pantalla para buscar elementos en la barra de menús."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "L'autorisation d'enregistrement de l'écran est nécessaire pour rechercher des éléments de la barre des menus."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A menüsávelemek kereséséhez képernyőfelvételi engedélyek szükségesek."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Izin Perekaman Layar diperlukan untuk mencari item bar menu."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Per cercare le voci nella barra dei menu è necessario disporre dell'autorizzazione per la registrazione dello schermo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバーの項目を検索するには、画面収録の権限が必要です。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대 항목을 검색하려면 화면 기록 권한이 필요합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er zijn machtigingen voor schermopnames nodig om in de menubalk te kunnen zoeken."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wyszukiwanie elementów paska menu wymaga uprawnień do nagrywania ekranu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Permissões de gravação de tela são necessárias para exibir dicas."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для поиска элементов строки меню требуется разрешение на запись экрана."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ต้องมีสิทธิ์บันทึกหน้าจอเพื่อค้นหารายการแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğu öğelerini aramak için ekran kaydı izni gereklidir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для пошуку об'єктів рядка меню потрібен дозвіл на запис екрана."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cần có quyền ghi màn hình để tìm kiếm các mục trên thanh menu."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "需要屏幕录制权限才能搜索菜单栏项目。"
           }
         },
         "zh-Hant" : {
@@ -55139,6 +51532,9 @@
           }
         }
       }
+    },
+    "Scroll" : {
+
     },
     "Scroll or swipe in the menu bar to show hidden menu bar items." : {
       "comment" : "Label for a toggle that enables or disables showing hidden menu bar items when scrolling or swiping in the menu bar.",
@@ -55853,6 +52249,10 @@
         }
       }
     },
+    "Second item" : {
+      "comment" : "A label that describes a picker that lets the user select a second item to group with the first.",
+      "isCommentAutoGenerated" : true
+    },
     "Section divider style" : {
       "comment" : "Label for a picker that lets the user choose the style of divider to use between menu bar sections.",
       "localizations" : {
@@ -56209,6 +52609,9 @@
         }
       }
     },
+    "Settings" : {
+
+    },
     "Settings URI disabled" : {
       "localizations" : {
         "cs" : {
@@ -56327,125 +52730,8 @@
         }
       }
     },
-    "Settings URI is disabled. External apps cannot read or modify %@ settings." : {
-      "comment" : "A callout box that describes the security implications of disabling the Settings URI scheme.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URI nastavení je deaktivováno. Externí aplikace nemohou číst ani měnit nastavení aplikace %@."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungs-URL ist deaktiviert. Externe Anwendungen können die %@-Einstellungen nicht lesen oder ändern."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "El URI de configuración está desactivado. Las aplicaciones externas no pueden leer ni modificar la configuración de %@."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Les paramètres URI sont désactivés. Les applications externes ne peuvent ni lire ni modifier les paramètres de %@."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Beállítások URI le van tiltva. Külső alkalmazások nem olvashatják vagy módosíthatják %@ beállításait."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pengaturan URL saat ini tidak aktif. Aplikasi eksternal tidak dapat membaca atau mengubah pengaturan %@."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings URI is disabled. External apps cannot read or modify %@ settings."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定URI は無効です。外部アプリは %@ の設定を読み書きできません。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "설정 URL가 비활성화되어있습니다. 외부 앱이 %@ 설정을 읽거나 수정할 수 없습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De instellingen-URI is uitgeschakeld. Externe apps kunnen de %@-instellingen niet lezen of wijzigen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URI ustawień jest wyłączony. Zewnętrzne aplikacje nie mogą odczytywać ani modyfikować ustawień %@."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "O URI de configurações está desativado. Aplicativos externos não podem ler nem modificar as configurações %@."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URI настроек отключен. Внешние приложения не могут читать или изменять настройки %@."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Settings URI ถูกปิดใช้งาน แอปภายนอกไม่สามารถอ่านหรือแก้ไขการตั้งค่า %@ ได้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ayarlar URI'si devre dışı. Harici uygulamalar %@ ayarlarını okuyamaz veya değiştiremez."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Settings URI is disabled. External apps cannot read or modify %@ settings."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "URI cài đặt bị tắt. Các ứng dụng bên ngoài không thể đọc hoặc sửa đổi cài đặt %@."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "设置 URI 已禁用。外部应用无法读取或修改 %@ 设置。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定 URI 已停用。外部應用程式無法讀取或修改 %@ 設定。"
-          }
-        }
-      }
+    "Settings were reset to defaults." : {
+
     },
     "Shadow" : {
       "comment" : "A toggle that lets the user enable or disable the shadow effect.",
@@ -57997,125 +54283,12 @@
         }
       }
     },
-    "Show hidden menu bar items in a separate bar below the menu bar on this display." : {
-      "comment" : "Label for a toggle that allows the user to enable or disable the display bar on a specific display.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na této obrazovce zobrazit skryté ikony v oddělené liště pod řádkem nabídek."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versteckte Menüleisten-Einträge auf diesem Bildschirm in einer separaten Leiste unterhalb der Menüleiste anzeigen."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar los elementos ocultos de la barra de menús en una barra separada debajo de la barra de menús en esta pantalla."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afficher les éléments masqués de la barre des menus dans une barre distincte sous la barre des menus de cet écran."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rejtett menüsávelemek megjelenítése külön sávban a menüsáv alatt ezen a kijelzőn."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tampilkan item bar menu tersembunyi di bar terpisah di bawah bar menu pada layar ini."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostra gli elementi nascosti della barra dei menu in una barra separata sotto la barra dei menu in questa visualizzazione."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "このディスプレイのメニューバーの下に、非表示のメニューバー項目を別のバーで表示します。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "이 디스플레이에서 숨겨진 메뉴 막대 항목을 메뉴 막대 아래의 별도 막대에 표시합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toon verborgen menu-items in een aparte balk onder de menubalk op dit scherm."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokaż ukryte elementy paska menu na osobnym pasku poniżej paska menu na tym ekranie."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mostrar itens ocultos da barra de menus em uma barra separada abaixo da barra de menus nesta tela."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показывать скрытые элементы строки меню в отдельной панели под строкой меню на этом дисплее."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "แสดงรายการแถบเมนูที่ซ่อนไว้ในแถบแยกต่างหากใต้แถบเมนูบนหน้าจอนี้"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu ekranda gizli menü çubuğu öğelerini menü çubuğunun altındaki ayrı bir çubukta göster."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Показувати приховані об'єкти в окремому рядку під рядком меню на цьому дисплеї."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hiển thị các mục thanh menu ẩn trong một thanh riêng bên dưới thanh menu trên màn hình này."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在该显示器的菜单栏下方，以独立菜单栏显示隐藏的项目。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "在此顯示器上以獨立列顯示隱藏的選單列項目。"
-          }
-        }
-      }
+    "Show hidden items on" : {
+      "comment" : "A label for a row that lets the user choose how to show hidden items.",
+      "isCommentAutoGenerated" : true
+    },
+    "Show hidden menu bar items by clicking, hovering, or scrolling in an empty area of the menu bar." : {
+
     },
     "Show hidden menu bar items in a separate bar below the menu bar." : {
       "comment" : "Annotation under the Use-Thaw-Bar toggle in the Global section of the Displays pane.",
@@ -59423,6 +55596,10 @@
         }
       }
     },
+    "Show setting descriptions" : {
+      "comment" : "A setting that shows a description of each setting.",
+      "isCommentAutoGenerated" : true
+    },
     "Show the %@ icon in the menu bar. Click to show hidden items, double-click for always-hidden, and right-click for settings." : {
       "comment" : "Toggle that lets the user decide whether to show the \\(Constants.displayName) icon in the menu bar.",
       "localizations" : {
@@ -59661,6 +55838,9 @@
         }
       }
     },
+    "Shows only the essential settings. All features keep working and keep their configuration." : {
+
+    },
     "Signed by: %@" : {
       "comment" : "A team identifier, if available.",
       "localizations" : {
@@ -59780,125 +55960,8 @@
         }
       }
     },
-    "Skip" : {
-      "comment" : "Label for the button that skips ahead to the final onboarding slide.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přeskočit"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Überspringen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Saltar"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ignorer"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kihagyás"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lewati"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Salta"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "スキップ"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "건너뛰기"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Overslaan"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pomiń"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pular"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пропустить"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ข้าม\n"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Atla"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Пропустити"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bỏ qua"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳过"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "跳過"
-          }
-        }
-      }
+    "Simple Mode" : {
+
     },
     "Smart" : {
       "comment" : "Localized string key for the \"Smart\" rehide strategy.",
@@ -60256,6 +56319,18 @@
           }
         }
       }
+    },
+    "Spacer" : {
+
+    },
+    "Spacer color" : {
+
+    },
+    "Spacers" : {
+
+    },
+    "Spaces with overrides: %lld" : {
+
     },
     "Spacing: %@" : {
       "localizations" : {
@@ -60731,6 +56806,9 @@
           }
         }
       }
+    },
+    "Start a new log file once the current one reaches this size." : {
+
     },
     "Strategy" : {
       "comment" : "Label for the \"Strategy\" picker in the \"Rehide Options\" section of the General Settings pane.",
@@ -61446,126 +57524,6 @@
         }
       }
     },
-    "Supported Settings" : {
-      "comment" : "A label displayed under the list of whitelisted apps.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podporované volby nastavení"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unterstütze Einstellungen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajustes soportados"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Paramètres pris en charge"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Támogatott beállítások"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pengaturan yang Didukung"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impostazioni Supportate"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "サポートされている設定"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "지원되는 설정"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ondersteunde instellingen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wspierane ustawienia"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurações Compatíveis"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Поддерживаемые настройки"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "การตั้งค่าที่รองรับ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desteklenen Ayarlar"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Підтримувані налаштування"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cài đặt được hỗ trợ"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支持的设置"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "支援的設定"
-          }
-        }
-      }
-    },
     "Surface hidden items that ask for attention" : {
       "comment" : "Toggle for briefly showing a hidden section when an item blinks.",
       "localizations" : {
@@ -61803,6 +57761,9 @@
         }
       }
     },
+    "System Default" : {
+
+    },
     "Thaw gives you complete control over your menu bar — hide clutter, customize the look, and automate your workflow." : {
       "comment" : "Description of the welcome onboarding slide.",
       "localizations" : {
@@ -61922,125 +57883,8 @@
         }
       }
     },
-    "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings." : {
-      "comment" : "Description of the permissions onboarding slide.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aby mohla aplikace Thaw spravovat váš řádek nabídek, potřebuje několik oprávnění. Můžete je udělit teď, nebo je prozatím přeskočit a udělit je později v nastavení."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw benötigt einige Berechtigungen um Deine Menüleiste zu verwalten. Du kannst diese jetzt geben oder den Schritt überspringen und sie später in den Systemeinstellungen nachträglich gewähren."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw necesita un par de permisos para gestionar tu barra de menús. Puedes asentirlos ahora, o saltar y asentirlos más tarde en Ajustes."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw a besoin de quelques autorisations pour gérer votre barre de menus. Vous pouvez les accorder maintenant, ou ignorer cette étape et les accorder plus tard dans les Paramètres."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw memerlukan beberapa izin untuk mengelola bar menu. Berikan izin sekarang, atau lewati dan berikan nanti melalui Pengaturan."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw heeft een aantal machtigingen nodig om je menubalk te beheren. Je kunt deze nu toestaan, of dit overslaan en ze later toestaan via de instellingen."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw wymaga kilku uprawnień do obsługi paska menu. Możesz je nadać w tej chwili lub pominąć i wrócić do tego później w Ustawieniach."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Приложению Thaw требуется несколько системных разрешений для работы. Вы можете предоставить их сейчас или позже из Системных настроек."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw ต้องการสิทธิ์สองอย่างเพื่อจัดการแถบเมนู คุณสามารถให้สิทธิ์เดี๋ยวนี้หรือข้ามและให้สิทธิ์ภายหลังจากการตั้งค่า\n"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw uygulamasının menü çubuğunuzu yönetebilmesi için birkaç izne ihtiyacı var. Bu izinleri şimdi verebilir veya daha sonra Ayarlar üzerinden tanımlayabilirsiniz."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Thaw needs a couple of permissions to manage your menu bar. You can grant them now, or skip and grant them later from Settings."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw cần một số quyền để quản lý thanh menu của bạn. Bạn có thể cấp chúng ngay bây giờ hoặc bỏ qua và cấp chúng sau từ Cài đặt."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw 需要几个权限才能管理你的菜单栏。你可以立即授予这些权限，也可以跳过，稍后再前往“设置”中授予。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thaw 需要一些權限才能開始管理您的選單列。您可以現在就開啟權限，或者之後在設定中開啟。"
-          }
-        }
-      }
+    "Thaw reads a band across the top of your display — the menu bar and its background. That band can contain the frontmost app's menus." : {
+
     },
     "The %@ Bar is aligned to the left edge of the display." : {
       "comment" : "A label that describes the location of the \\(Constants.displayName) Bar on a display.",
@@ -62514,125 +58358,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ 列會置中顯示在滑鼠游標下方。"
-          }
-        }
-      }
-    },
-    "The %@ Bar requires screen recording permissions." : {
-      "comment" : "A message displayed when the user hasn't granted the app permission to access the screen. Clicking the button opens the app's settings to grant the permission.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lišta %@ vyžaduje oprávnění nahrávat obrazovku."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Die %1$@-Leiste benötigt Berechtigungen für die Aufnahme von Bildschirm & Systemaudio."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La barra de %@ requiere permisos de grabación de pantalla."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La « %@ Bar » nécessite l'autorisation « enregistrement de l'écran »."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A(z) %@ sávhoz képernyőfelvételi engedély szükséges."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bar %@ membutuhkan izin Perekaman Layar."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "La barra %@ richiede l'autorizzazione alla registrazione dello schermo."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ バーには画面収録の権限が必要です。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ 바에는 화면 기록 권한이 필요합니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "De %@ Balk vereist toestemming voor schermopnames."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pasek %@ wymaga uprawnień do nagrywania ekranu."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "A Barra %@ requer permissões de gravação de tela."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для панели %@ требуется разрешение на запись экрана."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "แถบ %@ ต้องการสิทธิ์ในการบันทึกหน้าจอ"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Çubuğu ekran kaydı izinleri gerektirir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Для %@ Bar потрібен дозвіл на запис екрана."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Thanh %@ yêu cầu quyền ghi màn hình."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%@ Bar 需要屏幕录制权限。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "%1$@ 列需要螢幕錄影權限。"
           }
         }
       }
@@ -63350,6 +59075,9 @@
         }
       }
     },
+    "The capture returned nothing for this display." : {
+
+    },
     "The item was left in the visible section so it isn't stuck offscreen. Try dragging it again in a moment." : {
       "localizations" : {
         "cs" : {
@@ -63467,6 +59195,9 @@
           }
         }
       }
+    },
+    "The language change applies after %@ relaunches." : {
+
     },
     "These hooks run only when this profile is applied, after the global pre-hook and before the global post-hook." : {
       "comment" : "A description of the hooks that run only when a profile is applied.",
@@ -63943,6 +59674,9 @@
         }
       }
     },
+    "This Space uses the shared appearance." : {
+
+    },
     "This trigger controls %@'s section. Your saved layout no longer applies to it." : {
       "localizations" : {
         "cs" : {
@@ -64415,176 +60149,10 @@
         }
       }
     },
-    "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel." : {
+    "This will overwrite the settings of %lld displays with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
+      "comment" : "A message that appears in an alert that lets the user confirm that they want to apply the global template.",
+      "isCommentAutoGenerated" : true,
       "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This version of Thaw is not yet compatible with macOS 27. Preview builds are available on GitHub Releases, and macOS 27 support will be delivered through the alpha update channel."
-          }
-        }
-      }
-    },
-    "This will overwrite the settings of %lld display with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
-      "comment" : "A confirmation message that appears when the user is prompted to apply a global template. The argument is the number of displays that will be affected.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "de" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Dies überschreibt die Einstellungen von %lld Bildschirm mit der globalen Vorlage. Wenn die Abstände des aktiven Bildschirms geändert werden, werden alle Anwendungen mit Menüleisten-Einträgen neu gestartet. Der Neustart von Anwendungen kann zu ungespeicherten Eingaben führen, der Fortschritt oder Zustand von Anwendungen kann verloren gehen."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Dies überschreibt die Einstellungen von %lld Bildschirmen mit der globalen Vorlage. Wenn die Abstände des aktiven Bildschirms geändert werden, werden alle Anwendungen mit Menüleisten-Einträgen neu gestartet. Der Neustart von Anwendungen kann zu ungespeicherten Eingaben führen, der Fortschritt oder Zustand von Anwendungen kann verloren gehen."
-                }
-              }
-            }
-          }
-        },
         "en" : {
           "variations" : {
             "plural" : {
@@ -64596,429 +60164,11 @@
               },
               "other" : {
                 "stringUnit" : {
-                  "state" : "translated",
+                  "state" : "new",
                   "value" : "This will overwrite the settings of %lld displays with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
                 }
               }
             }
-          }
-        },
-        "es" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "fr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "hu" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "id" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "it" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "ja" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "ko" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "nl" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Hierdoor worden de instellingen van het %lld-scherm overschreven door de algemene sjabloon. Als de spatiëring van het actieve scherm verandert, start Thaw elke app met een menubalkitem opnieuw op. Door het opnieuw opstarten van apps kunnen niet-opgeslagen invoer, voortgang of tijdelijke app-statussen verloren gaan."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "Hierdoor worden de instellingen van %lld schermen overschreven door de algemene sjabloon. Als de spatiëring van het actieve scherm verandert, start Thaw elke app met een menubalkitem opnieuw op. Door het opnieuw opstarten van apps kunnen niet-opgeslagen invoer, voortgang of tijdelijke app-statussen verloren gaan."
-                }
-              }
-            }
-          }
-        },
-        "pl" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "pt-BR" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "ru" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "th" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "tr" : {
-          "variations" : {
-            "plural" : {
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "uk" : {
-          "variations" : {
-            "plural" : {
-              "few" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "many" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "one" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld display with the global template and may briefly relaunch apps with menu bar items."
-                }
-              },
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "vi" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "zh-Hans" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "This will overwrite the settings of %lld displays with the global template and may briefly relaunch apps with menu bar items."
-                }
-              }
-            }
-          }
-        },
-        "zh-Hant" : {
-          "variations" : {
-            "plural" : {
-              "other" : {
-                "stringUnit" : {
-                  "state" : "translated",
-                  "value" : "這將以全域模板覆寫 %lld 個顯示器的設定。若作用中顯示器的間距改變，Thaw 將重新啟動每個具有選單列項目的應用程式。重新啟動應用程式可能導致尚未儲存的輸入、進度或暫存狀態遺失。"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tímto přepíšete nastavení ^[%lld displejů](inflect: true) globální šablonou. Pokud se změní rozložení aktivního displeje, Thaw znovu spustí každou aplikaci s položkou v řádku nabídek. Při opětovném spuštění aplikací může dojít ke ztrátě neuložených dat, průběhu nebo dočasného stavu aplikace."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hierdoor worden de instellingen van ^[%lld beeldschermen](verbuigen: waar) overschreven door de algemene sjabloon. Als de spatiëring van het actieve beeldscherm verandert, zal Thaw elke app met een menubalkitem opnieuw starten. Door het opnieuw starten van apps kunnen niet-opgeslagen invoer, voortgang of tijdelijke app-statussen verloren gaan."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "To nadpisze ustawienia ^[%lld ekranów](inflect: true) globalnym szablonem. Jeśli zmienią się odstępy na aktywnym ekranie, Thaw ponownie uruchomi każdą aplikację posiadającą element na pasku menu. Ponowne uruchomienie aplikacji może spowodować utratę niezapisanych danych, postępów lub tymczasowego stanu aplikacji."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Эта настройка перезапишет настройки ^[%lld дисплеев](inflect: true) глобальным шаблоном. Если изменится интервал между элементами активного дисплея, Thaw перезапустит каждое приложение с элементом строки меню. Перезапуск приложений может привести к потере несохранённых данных, прогресса или временного состояния приложения."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bu işlem, ^[%lld ekranın](inflect: true) ayarlarının üzerine genel şablonu yazacaktır. Etkin ekranın aralık ayarları değişirse Thaw, menü çubuğu ögesine sahip her uygulamayı yeniden başlatacaktır. Uygulamaları yeniden başlatmak; kaydedilmemiş ayarların, ilerlemenin veya geçici uygulama tercihlerinin kaybolmasına neden olabilir."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This will overwrite the settings of ^[%lld displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "这会用全局模版覆盖 %lld 个显示器的设置. 如果活动显示器的间距改变, Thaw 会重启所有菜单栏里的应用. 重启应用可能导致未保存的输入，进度，或应用状态丢失。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "這將以全域模板覆寫 %lld 個顯示器的設定。若作用中顯示器的間距改變，Thaw 將重新啟動每個具有選單列項目的應用程式。重新啟動應用程式可能導致尚未儲存的輸入、進度或暫存狀態遺失。"
           }
         }
       }
@@ -65141,6 +60291,9 @@
           }
         }
       }
+    },
+    "This will reset app preferences to their default values. Saved profiles and user data will not be deleted. This action cannot be undone." : {
+
     },
     "Threshold" : {
       "localizations" : {
@@ -66098,6 +61251,9 @@
         }
       }
     },
+    "Toggle automatic rehiding" : {
+
+    },
     "Toggle the always-hidden section" : {
       "comment" : "A label describing the action of toggling the always-hidden section in the menu bar.",
       "localizations" : {
@@ -66335,6 +61491,12 @@
           }
         }
       }
+    },
+    "Toggle zen mode" : {
+
+    },
+    "Tools" : {
+
     },
     "Tooltip delay" : {
       "comment" : "A label describing the tooltip delay setting.",
@@ -67166,6 +62328,12 @@
         }
       }
     },
+    "Troubleshooting" : {
+
+    },
+    "Turn off to show every setting. Nothing you configure here is lost either way." : {
+
+    },
     "Turn on the Location flag in Developer settings and grant permission to capture your current location." : {
       "localizations" : {
         "cs" : {
@@ -67403,125 +62571,6 @@
         }
       }
     },
-    "Unable to display menu bar items" : {
-      "comment" : "A message displayed when the menu bar items cannot be displayed.",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Není možné zobrazit ikony řádku nabídek"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menüleisten-Einträge können nicht angezeigt werden"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "No se pueden mostrar los elementos de la barra de menús"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossible d'afficher les éléments de la barre des menus"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nem sikerült megjeleníteni a menüsor elemeket"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tidak dapat menampilkan item bar menu"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impossibile visualizzare le voci della barra dei menu"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "メニューバー項目を表示できません"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "메뉴 막대 항목을 표시할 수 없습니다"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kan menubalkitems niet tonen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie można wyświetlić elementów paska menu"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não é possível exibir os itens da barra de menus"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не удалось отобразить элементы строки меню"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ไม่สามารถแสดงรายการในแถบเมนู"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Menü çubuğu öğeleri gösterilemiyor"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Не вдалося показати об'єкти рядка меню"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Không thể hiển thị các mục trên thanh menu"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "无法显示菜单栏项目"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "無法顯示選單列項目"
-          }
-        }
-      }
-    },
     "Unable to load menu bar items" : {
       "comment" : "A message displayed when the app is unable to load the user's menu bar items.",
       "localizations" : {
@@ -67640,6 +62689,9 @@
           }
         }
       }
+    },
+    "Ungroup" : {
+
     },
     "Untitled" : {
       "comment" : "Name of an unnamed profile.",
@@ -69068,6 +64120,9 @@
         }
       }
     },
+    "Use %@ in a different language than the system. Takes effect after a relaunch." : {
+
+    },
     "Use a separate appearance" : {
       "comment" : "A toggle label for giving the Thaw Bar its own appearance rather than the menu bar's.",
       "localizations" : {
@@ -69186,6 +64241,9 @@
           }
         }
       }
+    },
+    "Use Current Appearance for This Space" : {
+
     },
     "Use Current Location" : {
       "localizations" : {
@@ -70729,126 +65787,6 @@
         }
       }
     },
-    "We found existing settings from Ice, the original app." : {
-      "comment" : "A description of the feature that allows users to import settings from the original app, Ice.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Našli jsme nastavení z původní aplikace Ice."
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Einstellungen von Ice (der ursprünglichen App) gefunden."
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Se encontraron ajustes de Ice (app original)."
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Des réglages provenant d'Ice l'application d'origine ont été détectés."
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Az Ice (az eredeti alkalmazás) beállításait találtuk."
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pengaturan dari Ice (aplikasi asal) ditemukan."
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Abbiamo trovato le impostazioni di Ice (l'app originale)."
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ice（元のアプリ）の設定が見つかりました。"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ice(원본 앱)의 설정을 찾았습니다."
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "We hebben instellingen gevonden van Ice, de originele app."
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wykryliśmy ustawienia z aplikacji Ice (pierwowzoru)."
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Encontramos configurações do Ice (o aplicativo original)."
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Мы нашли настройки от Ice (оригинального приложения)."
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "เราพบการตั้งค่าจากแอป Ice (แอปต้นฉบับ)"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ice (orijinal uygulama) ayarlarını bulduk."
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Знайдено налаштування з Ice (оригінальна програма)."
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chúng tôi đã tìm thấy cài đặt từ Ice (ứng dụng gốc)."
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我们找到了 Ice（原版应用）的设置。"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "我們發現了來自 Ice（原始應用程式）的設定。"
-          }
-        }
-      }
-    },
     "Welcome to Thaw" : {
       "comment" : "Title of the welcome onboarding slide.",
       "localizations" : {
@@ -70967,6 +65905,9 @@
           }
         }
       }
+    },
+    "What %@ Sees" : {
+
     },
     "When a display transition requires Thaw to apply a different menu bar spacing, Thaw relaunches apps with menu bar items. Relaunching apps may cause unsaved input, progress, or transient app state to be lost." : {
       "comment" : "A warning that a display transition requiring a different menu bar spacing relaunches menu bar apps, which can lose unsaved state.",
@@ -71092,6 +66033,9 @@
           }
         }
       }
+    },
+    "When a hidden item starts blinking its icon, briefly show its section so you see it. Thaw tells a blink apart from a clock or a battery percentage by whether the icon keeps returning to a state it already showed. It shows the section rather than moving the item, and the usual rehide puts it back." : {
+
     },
     "When a profile is active, choose whether spacing changes save to just the active profile or to every profile." : {
       "comment" : "Annotation for the profile-target picker shown when relaunch confirmations are disabled.",
@@ -72168,126 +67112,6 @@
         }
       }
     },
-    "Would you like to import your existing configuration?" : {
-      "comment" : "A question displayed to the user when they first open the app, asking if they would like to import their existing configuration.",
-      "extractionState" : "stale",
-      "localizations" : {
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chcete importovat existující nastavení?"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bestehende Einstellungen importieren?"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "¿Deseas importar tu configuración existente?"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Souhaitez-vous importer votre configuration existante ?"
-          }
-        },
-        "hu" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Szeretné importálni a meglévő konfigurációt?"
-          }
-        },
-        "id" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Impor konfigurasi yang sudah ada?"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desideri importare la tua configurazione esistente?"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "既存の設定をインポートしますか？"
-          }
-        },
-        "ko" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "기존 구성을 가져오시겠습니까?"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wilt u uw bestaande configuratie importeren?"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czy chcesz zaimportować istniejącą konfigurację?"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deseja importar sua configuração existente?"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Хотите импортировать существующую конфигурацию?"
-          }
-        },
-        "th" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "คุณต้องการนำเข้าการตั้งค่าเดิมของคุณหรือไม่?"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mevcut yapılandırmanızı içe aktarmak ister misiniz?"
-          }
-        },
-        "uk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Імпортувати наявну конфігурацію?"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bạn có muốn nhập cấu hình hiện có của mình không?"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "您想导入现有配置吗？"
-          }
-        },
-        "zh-Hant" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "是否要匯入您現有的設定？"
-          }
-        }
-      }
-    },
     "Writes detailed debug logs to a file for troubleshooting. Log files are saved to ~/Library/Logs/Thaw/. Disable when not needed to avoid unnecessary disk writes." : {
       "comment" : "A description of the diagnostic logging feature.",
       "localizations" : {
@@ -72644,6 +67468,12 @@
           }
         }
       }
+    },
+    "Zen mode is off" : {
+
+    },
+    "Zen mode is on" : {
+
     }
   },
   "version" : "1.1"

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -712,7 +712,7 @@ struct DisplaySettingsPane: View {
 
     private func globalConfirmationMessage(for pending: PendingGlobalApply) -> String {
         let profileName = pending.activeProfileName ?? ""
-        let displayMessage = String(localized: "This will overwrite the settings of ^[\(pending.displayCount) displays](inflect: true) with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
+        let displayMessage = String(localized: "This will overwrite the settings of \(pending.displayCount) displays with the global template. If the active display's spacing changes, Thaw will relaunch each app with a menu bar item. Relaunching apps may cause unsaved input, progress, or transient app state to be lost.")
         if pending.activeProfileID != nil {
             let profileInstruction = String(localized: "Save the global template to the active profile \"\(profileName)\", or save it to every profile.")
             return "\(displayMessage) \(profileInstruction)"

--- a/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/ProfileSettingsPane.swift
@@ -440,7 +440,7 @@ struct ProfileSettingsPane: View {
             }
         }
         if failed > 0 {
-            errorMessage = String(localized: "Failed to update configuration on ^[\(failed) profiles](inflect: true).")
+            errorMessage = String(localized: "Failed to update configuration on [\(failed) profiles].")
             showingError = true
         }
     }


### PR DESCRIPTION
# Summary

Fixes some broken strings for translations and removes dead strings

## Linked issue (required)

PR Metadata fails without a `Closes:` line in this exact form (keep it on its own line):

```text
Closes: N/A
```

Replace `N/A` with `#<issue_number>` (e.g. `Closes: #123`) when this PR fixes/implements a specific issue.

Closes: N/A

## PR Type

Describe **what this change does** (not the linked issue’s request kind). Bug *reports* use the `Bug` Issue type; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can’t be split.

- [x ] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config, not a product surface.

- [ ] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

What does this PR change or add, and why?

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [] I've run `swiftformat .` to keep the code style consistent.
- [ ] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [ ] I've added tests for new behavior (if applicable).
- [ ] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green, or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

-

## Known limitations / follow-ups

- (optional) What is intentionally out of scope
- (optional) Follow-up issues or planned work

## Other information

Screenshots, notes, or anything useful for reviewers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791058293&installation_model_id=431242&pr_number=1036&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1036&signature=1172eeb5aa722ab85a3bc6437f89c2db63f92c178fee6d8adc5abce756cb383e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected localized item-count messages in menu groups, display confirmations, and profile update errors.
  - Counts now appear consistently in square-bracketed text without unintended grammatical inflection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->