### PR TITLE
fix(menubar): serialize, bound, and verify menu bar moves across the layout stack

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBar.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBar.swift
@@ -25,8 +25,6 @@ struct LayoutBar: View {
     }
 
     @Environment(AppState.self) var appState: AppState
-    let imageCache: MenuBarItemImageCache
-
     let section: MenuBarSection.Name
 
     private var backgroundShape: some InsettableShape {
@@ -34,7 +32,7 @@ struct LayoutBar: View {
     }
 
     var body: some View {
-        mainContent
+        Representable(appState: appState, section: section)
             .frame(height: 48)
             .frame(maxWidth: .infinity)
             .menuBarItemContainer(appState: appState)
@@ -45,16 +43,5 @@ struct LayoutBar: View {
                 backgroundShape
                     .strokeBorder(.quaternary)
             }
-    }
-
-    @ViewBuilder
-    private var mainContent: some View {
-        if imageCache.cacheFailed(for: section) {
-            // Avoid flicker during rapid cache refreshes; hold a blank placeholder instead of the error text.
-            Color.clear
-                .frame(height: 20)
-        } else {
-            Representable(appState: appState, section: section)
-        }
     }
 }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
@@ -18,6 +18,14 @@ class LayoutBarArrangedView: NSView {
     /// Temporary information retained while dragging between layout containers.
     var oldContainerInfo: (container: LayoutBarContainer, index: Int)?
 
+    /// The container frozen when the drag began.
+    ///
+    /// `oldContainerInfo` is populated only after a destination receives an
+    /// update. A drag cancelled before that point would otherwise leave its
+    /// source container frozen indefinitely, so retain the source separately
+    /// for the lifetime of the dragging session.
+    private weak var frozenSourceContainer: LayoutBarContainer?
+
     /// A Boolean value that indicates whether the view is currently inside a container.
     var hasContainer = false
 
@@ -56,6 +64,21 @@ class LayoutBarArrangedView: NSView {
     func draggingImage() -> NSImage? {
         nil
     }
+
+    /// Whether this container is the row where the current drag began.
+    /// Intermediate rows may thaw as soon as the pointer exits, but the
+    /// original row must stay frozen so a cache refresh does not insert a
+    /// duplicate view behind the drag.
+    func beganDragging(in container: LayoutBarContainer) -> Bool {
+        frozenSourceContainer === container
+    }
+
+    /// A row stays frozen while an asynchronous system move is being
+    /// verified. Starting another drag from that row would let the older move
+    /// thaw and reconcile it underneath the newer drag.
+    var canBeginDraggingFromCurrentContainer: Bool {
+        (superview as? LayoutBarContainer)?.canSetArrangedViews == true
+    }
 }
 
 // MARK: LayoutBarArrangedView: NSDraggingSource
@@ -66,33 +89,67 @@ extension LayoutBarArrangedView: NSDraggingSource {
     }
 
     func draggingSession(_ session: NSDraggingSession, willBeginAt _: NSPoint) {
-        if let container = superview as? LayoutBarContainer {
-            container.canSetArrangedViews = false
+        let container = superview as? LayoutBarContainer
+        container?.canSetArrangedViews = false
+        frozenSourceContainer = container
+        if let container,
+           let sourceIndex = container.arrangedViews.firstIndex(of: self)
+        {
+            // Record the source synchronously. A quick cross-row drag can
+            // reach its destination before draggingUpdated gets a chance to
+            // populate this, which otherwise leaves the real source frozen
+            // and unavailable for final reconciliation.
+            oldContainerInfo = (container, sourceIndex)
         }
 
         session.animatesToStartingPositionsOnCancelOrFail = false
 
-        Task { @MainActor in
-            isDraggingPlaceholder = true
-        }
+        // This callback is already delivered on the main thread. Set the
+        // placeholder synchronously so a short drag cannot end before a queued
+        // task turns the placeholder back on.
+        isDraggingPlaceholder = true
     }
 
-    func draggingSession(_: NSDraggingSession, endedAt _: NSPoint, operation _: NSDragOperation) {
+    func draggingSession(_: NSDraggingSession, endedAt _: NSPoint, operation: NSDragOperation) {
         let sourceContainer = oldContainerInfo?.container
+        let frozenContainer = frozenSourceContainer
+        let currentContainer = superview as? LayoutBarContainer
         defer {
             oldContainerInfo = nil
+            frozenSourceContainer = nil
         }
 
         isDraggingPlaceholder = false
 
+        // Successful item drops keep both rows frozen until the asynchronous
+        // system move settles. Cancelled and rejected drops never start that
+        // task. Transfer the original view back before thawing either row;
+        // otherwise the source rebuilds a replacement from the old cache and
+        // the detached drag view is inserted beside it a moment later.
+        if operation == [] {
+            if let (container, index) = oldContainerInfo {
+                container.restoreArrangedViewAfterCancelledDrag(
+                    self,
+                    from: currentContainer,
+                    at: index
+                )
+            }
+
+            // `frozenContainer` covers a cancellation that happened before
+            // `oldContainerInfo` was populated.
+            currentContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            frozenContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+
         if isNewItemsBadge {
-            sourceContainer?.canSetArrangedViews = true
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             if let appState = sourceContainer?.appState {
                 sourceContainer?.setArrangedViews(items: appState.itemManager.itemCache.managedItems(for: sourceContainer?.section ?? .hidden))
             }
         }
 
-        if !hasContainer {
+        if operation != [], !hasContainer {
             guard let (container, index) = oldContainerInfo else {
                 return
             }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -62,6 +62,19 @@ final class LayoutBarContainer: NSView {
         }
     }
 
+    /// Resumes cache-driven updates after a drag without animating from the
+    /// editor's temporary arrangement to the settled system snapshot.
+    ///
+    /// The container is trailing-aligned. Animating child origins while its
+    /// width changes makes those children appear to fly across the row, even
+    /// though both layouts are valid. Commit the first reconciled layout as a
+    /// single frame instead.
+    func resumeArrangedViewUpdatesWithoutAnimation() {
+        guard !canSetArrangedViews else { return }
+        shouldAnimateNextLayoutPass = false
+        canSetArrangedViews = true
+    }
+
     /// The contaner's arranged views.
     ///
     /// The views are laid out from left to right in the order that they
@@ -237,6 +250,10 @@ final class LayoutBarContainer: NSView {
 
         // remove views that are no longer part of the arranged views
         for view in oldViews where !arrangedViews.contains(view) {
+            // A cross-row drag transfers the same NSView instance to the
+            // destination. A stale source snapshot must never detach a view
+            // that is already owned by another container.
+            guard view.superview === self else { continue }
             view.removeFromSuperview()
             view.hasContainer = false
         }
@@ -300,16 +317,22 @@ final class LayoutBarContainer: NSView {
             arrangedViews.removeAll()
             return
         }
+        // Thumbnail refreshes below can trigger an immediate size-only layout,
+        // which normally resets this flag. Preserve the caller's animation
+        // choice for the actual ordered reconciliation that follows.
+        let shouldAnimateReconciledLayout = shouldAnimateNextLayoutPass
         var newViews = [LayoutBarArrangedView]()
         let itemIdentifiers = items.map(\.uniqueIdentifier)
         let badgeIndex = appState.itemManager.newItemsBadgeIndex(in: section, itemIdentifiers: itemIdentifiers)
         for item in items {
-            if let existingView = arrangedViews.first(where: {
-                if case let .item(existingItem) = $0.kind {
-                    return existingItem == item
-                }
-                return false
-            }) {
+            if let existingView = arrangedViews.lazy
+                .compactMap({ $0 as? LayoutBarItemView })
+                .first(where: { Self.canReuseItemView(representing: $0.item, for: item) })
+            {
+                // Keep the view's last stable thumbnail through reconciliation.
+                // A capture that completed while this row was frozen may still
+                // be a transient crop from the physical system move; the fresh
+                // post-thaw image-cache pass will publish the settled image.
                 newViews.append(existingView)
             } else {
                 let view = LayoutBarItemView(appState: appState, item: item)
@@ -322,7 +345,35 @@ final class LayoutBarContainer: NSView {
             let insertionIndex = badgeIndex.clamped(to: newViews.startIndex ... newViews.endIndex)
             newViews.insert(badgeView, at: insertionIndex)
         }
+
+        // Observation can publish the same ordered cache more than once while
+        // a move settles. Avoid re-targeting animator proxies for a no-op.
+        guard !arrangedViews.elementsEqual(newViews, by: { $0 === $1 }) else {
+            // Before this no-op guard existed, assigning the identical array
+            // still completed a layout pass and reset this flag.
+            shouldAnimateNextLayoutPass = true
+            return
+        }
+        shouldAnimateNextLayoutPass = shouldAnimateReconciledLayout
         arrangedViews = newViews
+    }
+
+    /// Whether an existing view still represents the same live status-item
+    /// window after a cache refresh.
+    ///
+    /// Full `MenuBarItem` equality includes origin and on-screen state, both of
+    /// which necessarily change during a move. Ignore only those transient
+    /// fields; every value retained by `LayoutBarItemView` must still match.
+    static nonisolated func canReuseItemView(
+        representing existingItem: MenuBarItem,
+        for refreshedItem: MenuBarItem
+    ) -> Bool {
+        existingItem.windowID == refreshedItem.windowID &&
+            existingItem.tag == refreshedItem.tag &&
+            existingItem.ownerPID == refreshedItem.ownerPID &&
+            existingItem.sourcePID == refreshedItem.sourcePID &&
+            existingItem.bounds.size == refreshedItem.bounds.size &&
+            existingItem.title == refreshedItem.title
     }
 
     /// Updates the positions of the container's arranged views using the
@@ -374,6 +425,7 @@ final class LayoutBarContainer: NSView {
                         in: arrangedViews,
                         excludingBadge: excludeBadge
                     )
+                    transferArrangedViewFromSourceIfNeeded(sourceView)
                     arrangedViews.insert(sourceView, at: insertionIndex)
                 }
                 return .move
@@ -408,13 +460,54 @@ final class LayoutBarContainer: NSView {
                 arrangedViews.move(fromOffsets: [sourceIndex], toOffset: targetIndex)
             } else {
                 // source view is being dragged from another container,
-                // so just insert it
+                // so transfer array ownership before adopting the NSView.
+                // NSView.addSubview moves the view between superviews, but it
+                // cannot remove the stale reference from the source's
+                // arrangedViews; leaving that reference lets the source
+                // detach the icon from this destination during reconciliation.
+                transferArrangedViewFromSourceIfNeeded(sourceView)
                 arrangedViews.insert(sourceView, at: destinationIndex)
             }
             return .move
         case .ended:
             return .move
         }
+    }
+
+    private func transferArrangedViewFromSourceIfNeeded(_ view: LayoutBarArrangedView) {
+        guard let sourceContainer = view.oldContainerInfo?.container,
+              sourceContainer !== self
+        else {
+            return
+        }
+        sourceContainer.removeArrangedViewForTransfer(view)
+    }
+
+    private func removeArrangedViewForTransfer(_ view: LayoutBarArrangedView) {
+        guard let index = arrangedViews.firstIndex(of: view) else { return }
+        shouldAnimateNextLayoutPass = false
+        arrangedViews.remove(at: index)
+    }
+
+    /// Returns a cancelled drag's original view to this container before
+    /// cache-driven updates resume. Restoring the existing instance first is
+    /// important: thawing this row while the view still belongs to another
+    /// row makes the old cache construct a replacement, briefly duplicating
+    /// the icon when the detached drag view is inserted afterward.
+    func restoreArrangedViewAfterCancelledDrag(
+        _ view: LayoutBarArrangedView,
+        from currentContainer: LayoutBarContainer?,
+        at originalIndex: Int
+    ) {
+        if let currentContainer, currentContainer !== self {
+            currentContainer.removeArrangedViewForTransfer(view)
+        }
+
+        shouldAnimateNextLayoutPass = false
+        var restoredViews = arrangedViews.filter { $0 !== view }
+        let insertionIndex = originalIndex.clamped(to: restoredViews.startIndex ... restoredViews.endIndex)
+        restoredViews.insert(view, at: insertionIndex)
+        arrangedViews = restoredViews
     }
 
     static func enabledDropTargets(

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -121,6 +121,35 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         )
     }
 
+    /// Whether a cache observation may replace the thumbnail currently shown
+    /// by the layout editor.
+    ///
+    /// A system move temporarily relocates the real status-item window. Live
+    /// capture can observe it under the notch or between sections and publish
+    /// a transient thumbnail while the drag UI is intentionally frozen. Keep
+    /// the last stable thumbnail until the container thaws.
+    static nonisolated func shouldUpdateCachedImage(
+        hasContainer: Bool,
+        containerAllowsUpdates: Bool
+    ) -> Bool {
+        !hasContainer || containerAllowsUpdates
+    }
+
+    /// Opacity used for the captured icon.
+    ///
+    /// The dragged view remains in the arranged views as the drop placeholder.
+    /// Keeping a dimmed snapshot there avoids a blank slot while the dragging
+    /// image follows the pointer.
+    static nonisolated func iconFraction(
+        isDraggingPlaceholder: Bool,
+        isEnabled: Bool
+    ) -> CGFloat {
+        if isDraggingPlaceholder {
+            return 0.45
+        }
+        return isEnabled ? 1.0 : 0.67
+    }
+
     override var kind: Kind {
         .item(effectiveItem)
     }
@@ -271,7 +300,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
                     guard let self else { return }
                     guard !MenuBarItemImageCache.CapturedImage.isVisuallyEqual(previous, image) else { continue }
                     previous = image
-                    self.cachedImage = image
+                    self.updateCachedImageIfAllowed(image)
                 }
             }
 
@@ -442,26 +471,33 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     }
 
     override func draw(_: NSRect) {
+        // A trigger-owned item draws slightly dimmed so the badge reads as a
+        // state marker rather than a rendering bug.
+        let fraction: CGFloat = if !isDraggingPlaceholder && isTriggerControlled {
+            Metrics.triggerControlledFraction
+        } else {
+            Self.iconFraction(
+                isDraggingPlaceholder: isDraggingPlaceholder,
+                isEnabled: isEnabled
+            )
+        }
+        // When the user prefers app icons, the placeholder — which resolves
+        // app icons — draws instead of the captured glyph.
+        if !usesAppIcon, let capturedImage = cachedImage?.nsImage {
+            capturedImage.draw(
+                in: bounds,
+                from: .zero,
+                operation: .sourceOver,
+                fraction: fraction
+            )
+        } else {
+            drawPlaceholder(fraction: fraction)
+        }
+
+        // Keep status badges out of the drag placeholder; the dimmed icon is
+        // enough to preserve identity without making the slot visually busy.
         if !isDraggingPlaceholder {
-            let triggerControlled = isTriggerControlled
-            if !usesAppIcon, let capturedImage = cachedImage?.nsImage {
-                let fraction: CGFloat = if triggerControlled {
-                    Metrics.triggerControlledFraction
-                } else if isEnabled {
-                    1.0
-                } else {
-                    0.67
-                }
-                capturedImage.draw(
-                    in: bounds,
-                    from: .zero,
-                    operation: .sourceOver,
-                    fraction: fraction
-                )
-            } else {
-                drawPlaceholder()
-            }
-            if triggerControlled {
+            if isTriggerControlled {
                 drawTriggerBadge()
             }
             if Bridging.isProcessUnresponsive(item.ownerPID) {
@@ -488,6 +524,10 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         super.mouseDragged(with: event)
         didBeginDraggingForCurrentClick = true
         tooltipController.cancel()
+
+        guard canBeginDraggingFromCurrentContainer else {
+            return
+        }
 
         // #905 fallback: before refusing an `unresolvedControlCenterPlaceholder`
         // drag, attempt to re-tag the slot with its app-owned identity (when
@@ -535,6 +575,17 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         draggingItem.setDraggingFrame(bounds, contents: draggingImage())
 
         beginDraggingSession(with: [draggingItem], event: event, source: self)
+    }
+
+    private func updateCachedImageIfAllowed(_ image: MenuBarItemImageCache.CapturedImage?) {
+        let container = superview as? LayoutBarContainer
+        guard Self.shouldUpdateCachedImage(
+            hasContainer: container != nil,
+            containerAllowsUpdates: container?.canSetArrangedViews ?? true
+        ) else {
+            return
+        }
+        cachedImage = image
     }
 
     private func preferredSize(for image: MenuBarItemImageCache.CapturedImage?) -> CGSize {
@@ -620,7 +671,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         )
     }
 
-    private func drawPlaceholder() {
+    private func drawPlaceholder(fraction: CGFloat) {
         let placeholderRect = bounds.insetBy(
             dx: Metrics.placeholderHorizontalInset,
             dy: Metrics.placeholderVerticalInset
@@ -630,10 +681,10 @@ final class LayoutBarItemView: LayoutBarArrangedView {
             xRadius: Metrics.placeholderCornerRadius,
             yRadius: Metrics.placeholderCornerRadius
         )
-        NSColor.quaternaryLabelColor.withAlphaComponent(0.35).setFill()
+        NSColor.quaternaryLabelColor.withAlphaComponent(0.35 * fraction).setFill()
         backgroundPath.fill()
 
-        NSColor.separatorColor.withAlphaComponent(0.6).setStroke()
+        NSColor.separatorColor.withAlphaComponent(0.6 * fraction).setStroke()
         backgroundPath.lineWidth = 1
         backgroundPath.stroke()
 
@@ -641,21 +692,11 @@ final class LayoutBarItemView: LayoutBarArrangedView {
             return
         }
 
-        // #981: if the placeholder fell back to the generic symbol at init
-        // because the owning app was not launchable yet, try the app icon
-        // again now. The view is reused across cache refreshes when the
-        // item's identity is stable, so this is the one place a later
-        // resolution surfaces. One lookup per resolution; the flag stops
-        // repeat work once an icon is in hand.
         if !placeholderResolvedFromApp,
            let icon = Self.resolvedAppIcon(for: item)
         {
             self.placeholderImage = icon
             placeholderResolvedFromApp = true
-            // Draw the resolved icon in this pass. Assigning only the stored
-            // property left the local binding above holding the generic
-            // symbol, so the icon swap waited on an unrelated invalidation
-            // that never comes for items the image cache can't capture.
             placeholderImage = icon
         }
 
@@ -683,14 +724,14 @@ final class LayoutBarItemView: LayoutBarArrangedView {
                 in: iconRect,
                 from: .zero,
                 operation: .sourceOver,
-                fraction: isEnabled ? 0.8 : 0.5
+                fraction: (isEnabled ? 0.8 : 0.5) * fraction
             )
         } else {
             placeholderImage.draw(
                 in: iconRect,
                 from: .zero,
                 operation: .sourceOver,
-                fraction: isEnabled ? 0.9 : 0.5
+                fraction: (isEnabled ? 0.9 : 0.5) * fraction
             )
         }
     }

--- a/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarItemView.swift
@@ -299,8 +299,12 @@ final class LayoutBarItemView: LayoutBarArrangedView {
                 for await image in changes {
                     guard let self else { return }
                     guard !MenuBarItemImageCache.CapturedImage.isVisuallyEqual(previous, image) else { continue }
+                    // Advance `previous` only when the image was applied: if
+                    // the container is frozen and drops it, recording it here
+                    // would make a republished copy dedupe as unchanged and
+                    // strand the stale thumbnail.
+                    guard self.updateCachedImageIfAllowed(image) else { continue }
                     previous = image
-                    self.updateCachedImageIfAllowed(image)
                 }
             }
 
@@ -473,7 +477,7 @@ final class LayoutBarItemView: LayoutBarArrangedView {
     override func draw(_: NSRect) {
         // A trigger-owned item draws slightly dimmed so the badge reads as a
         // state marker rather than a rendering bug.
-        let fraction: CGFloat = if !isDraggingPlaceholder && isTriggerControlled {
+        let fraction: CGFloat = if !isDraggingPlaceholder, isTriggerControlled {
             Metrics.triggerControlledFraction
         } else {
             Self.iconFraction(
@@ -577,15 +581,17 @@ final class LayoutBarItemView: LayoutBarArrangedView {
         beginDraggingSession(with: [draggingItem], event: event, source: self)
     }
 
-    private func updateCachedImageIfAllowed(_ image: MenuBarItemImageCache.CapturedImage?) {
+    @discardableResult
+    private func updateCachedImageIfAllowed(_ image: MenuBarItemImageCache.CapturedImage?) -> Bool {
         let container = superview as? LayoutBarContainer
         guard Self.shouldUpdateCachedImage(
             hasContainer: container != nil,
             containerAllowsUpdates: container?.canSetArrangedViews ?? true
         ) else {
-            return
+            return false
         }
         cachedImage = image
+        return true
     }
 
     private func preferredSize(for image: MenuBarItemImageCache.CapturedImage?) -> CGSize {

--- a/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarNewItemsBadgeView.swift
@@ -19,13 +19,17 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
 
     /// Returns text attributes adapted to the menu bar background brightness.
     /// When the background is bright, uses dark text; otherwise uses light text.
-    private var textAttributes: [NSAttributedString.Key: Any] {
+    private func textAttributes(opacity: CGFloat = 1) -> [NSAttributedString.Key: Any] {
         let isBright = isBrightForActiveScreen()
         let foregroundColor: NSColor = isBright ? .black : .white
         return [
             .font: NSFont.systemFont(ofSize: 11, weight: .semibold),
-            .foregroundColor: foregroundColor,
+            .foregroundColor: foregroundColor.withAlphaComponent(opacity),
         ]
+    }
+
+    static nonisolated func contentOpacity(isDraggingPlaceholder: Bool) -> CGFloat {
+        isDraggingPlaceholder ? 0.45 : 1
     }
 
     override var kind: Kind {
@@ -59,10 +63,7 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
     }
 
     override func draw(_: NSRect) {
-        guard !isDraggingPlaceholder else {
-            return
-        }
-
+        let opacity = Self.contentOpacity(isDraggingPlaceholder: isDraggingPlaceholder)
         let isBright = isBrightForActiveScreen()
         let pillPath = NSBezierPath(roundedRect: bounds, xRadius: Metrics.cornerRadius, yRadius: Metrics.cornerRadius)
 
@@ -70,16 +71,16 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
         let fillColor: NSColor = isBright ? .black : .white
         let strokeColor: NSColor = isBright ? .black : .white
 
-        fillColor.withAlphaComponent(0.25).setFill()
+        fillColor.withAlphaComponent(0.25 * opacity).setFill()
         pillPath.fill()
 
-        strokeColor.withAlphaComponent(0.65).setStroke()
+        strokeColor.withAlphaComponent(0.65 * opacity).setStroke()
         pillPath.lineWidth = Metrics.borderWidth
         pillPath.stroke()
 
         let title = NSAttributedString(
             string: String(localized: "New Items"),
-            attributes: textAttributes
+            attributes: textAttributes(opacity: opacity)
         )
         let titleSize = title.size()
         let titleOrigin = CGPoint(
@@ -97,6 +98,10 @@ final class LayoutBarNewItemsBadgeView: LayoutBarArrangedView {
 
     override func mouseDragged(with event: NSEvent) {
         super.mouseDragged(with: event)
+
+        guard canBeginDraggingFromCurrentContainer else {
+            return
+        }
 
         let pasteboardItem = NSPasteboardItem()
         pasteboardItem.setData(Data(), forType: .layoutBarItem)

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -13,9 +13,13 @@ import Observation
 /// A Cocoa view that manages the menu bar layout interface.
 final class LayoutBarPaddingView: NSView {
     private static let diagLog = DiagLog(category: "LayoutBarPaddingView")
+    private static let stabilizationRecoveryTimeout: Duration = .seconds(45)
 
     private let container: LayoutBarContainer
     private var isStabilizing = false
+    private var stabilizationGeneration = 0
+    private var stabilizationTask: Task<Void, Never>?
+    private weak var acceptedDraggingSource: LayoutBarArrangedView?
 
     private var notchView: NotchIndicatorView?
     private var notchWidthConstraint: NSLayoutConstraint?
@@ -31,6 +35,7 @@ final class LayoutBarPaddingView: NSView {
 
     deinit {
         averageColorInfoObservationTask?.cancel()
+        stabilizationTask?.cancel()
     }
 
     /// The layout view's arranged views.
@@ -73,7 +78,15 @@ final class LayoutBarPaddingView: NSView {
     }
 
     override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard !isStabilizing else { return [] }
+        guard !isStabilizing,
+              let sourceView = sender.draggingSource as? LayoutBarArrangedView,
+              Self.canAcceptDrag(
+                  containerAllowsUpdates: container.canSetArrangedViews,
+                  beganInContainer: sourceView.beganDragging(in: container),
+                  alreadyAccepted: acceptedDraggingSource === sourceView
+              )
+        else { return [] }
+        acceptedDraggingSource = sourceView
         // Freeze the destination's arrangedViews so that the cache refresh
         // triggered while the system move is in flight cannot overwrite the
         // mid-drag visual state. updateNewItemsPlacement at the end of move()
@@ -85,26 +98,46 @@ final class LayoutBarPaddingView: NSView {
 
     override func draggingExited(_ sender: NSDraggingInfo?) {
         guard !isStabilizing else { return }
+        guard let acceptedDraggingSource else { return }
         if let sender {
+            guard sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource else {
+                return
+            }
             container.updateArrangedViewsForDrag(with: sender, phase: .exited)
         }
+
+        // A pointer can cross one or more rows before it reaches the final
+        // destination. Each entered row is frozen above, so thaw a row as
+        // soon as it is no longer participating in the drag. Keep only the
+        // original source frozen; refreshing it now would reinsert a duplicate
+        // item behind the dragging image.
+        if !acceptedDraggingSource.beganDragging(in: container) {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+        self.acceptedDraggingSource = nil
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        guard !isStabilizing else { return [] }
+        guard !isStabilizing,
+              sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource
+        else { return [] }
         return container.updateArrangedViewsForDrag(with: sender, phase: .updated)
     }
 
     override func draggingEnded(_ sender: NSDraggingInfo) {
-        guard !isStabilizing else { return }
+        guard !isStabilizing,
+              sender.draggingSource as? LayoutBarArrangedView === acceptedDraggingSource
+        else { return }
         container.updateArrangedViewsForDrag(with: sender, phase: .ended)
     }
 
     override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
-        guard let draggingSource = sender.draggingSource as? LayoutBarArrangedView else {
-            container.canSetArrangedViews = true
+        guard let draggingSource = sender.draggingSource as? LayoutBarArrangedView,
+              acceptedDraggingSource === draggingSource
+        else {
             return false
         }
+        defer { acceptedDraggingSource = nil }
 
         if case let .item(draggingItem) = draggingSource.kind,
            draggingItem.tag == .visibleControlItem,
@@ -124,7 +157,7 @@ final class LayoutBarPaddingView: NSView {
             container.updateArrangedViewsForDrag(with: sender, phase: .exited)
             draggingSource.hasContainer = false
 
-            container.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
             return false
         }
 
@@ -135,8 +168,8 @@ final class LayoutBarPaddingView: NSView {
                 arrangedViews: arrangedViews
             )
             draggingSource.oldContainerInfo = nil
-            container.canSetArrangedViews = true
-            sourceContainer?.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             if let appState = container.appState {
                 sourceContainer?.setArrangedViews(items: appState.itemManager.itemCache.managedItems(for: sourceContainer?.section ?? container.section))
                 if sourceContainer !== container {
@@ -189,16 +222,16 @@ final class LayoutBarPaddingView: NSView {
                 willMove = true
                 Task {
                     guard case let .item(draggingItem) = draggingSource.kind else {
-                        self.container.canSetArrangedViews = true
-                        sourceContainer?.canSetArrangedViews = true
+                        self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                        sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                         return
                     }
                     if let destination = await self.liveFallbackDestinationForDraggedItem() {
                         self.move(items: draggedUnit, startingWith: draggingItem, to: destination, sourceContainer: sourceContainer)
                     } else {
                         Self.diagLog.error("No target item for layout bar drag")
-                        self.container.canSetArrangedViews = true
-                        sourceContainer?.canSetArrangedViews = true
+                        self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                        sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                     }
                 }
             } else if case let .item(draggingItem) = draggingSource.kind {
@@ -215,8 +248,8 @@ final class LayoutBarPaddingView: NSView {
                             self.move(items: draggedUnit, startingWith: draggingItem, to: destination, sourceContainer: sourceContainer)
                         } else {
                             Self.diagLog.error("No target item for layout bar drag")
-                            self.container.canSetArrangedViews = true
-                            sourceContainer?.canSetArrangedViews = true
+                            self.container.resumeArrangedViewUpdatesWithoutAnimation()
+                            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                         }
                     }
                 }
@@ -226,7 +259,11 @@ final class LayoutBarPaddingView: NSView {
         // Only re-enable view updates here if no move was initiated.
         // When a move IS initiated, the move() Task re-enables after stabilization.
         if !willMove {
-            container.canSetArrangedViews = true
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            if sourceContainer !== container {
+                sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            }
+            draggingSource.oldContainerInfo = nil
         }
 
         return true
@@ -270,7 +307,6 @@ final class LayoutBarPaddingView: NSView {
                 return
             }
             isStabilizing = true
-            await MainActor.run { self.showOverlay(true) }
             guard await (try? Task.sleep(for: .milliseconds(150))) != nil else {
                 await resetStabilizingStateIfNeeded(sourceContainer: sourceContainer)
                 return
@@ -347,7 +383,8 @@ final class LayoutBarPaddingView: NSView {
                         of: last,
                         to: lastTarget,
                         expectedSection: container.section,
-                        appState: appState
+                        appState: appState,
+                        generation: stabilizationGeneration
                     ) {
                         appState.itemManager.recordExternalMoveOperation()
                     } else {
@@ -442,27 +479,58 @@ final class LayoutBarPaddingView: NSView {
         await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
     }
 
+    /// A frozen row accepts only the drag that already owns that freeze. This
+    /// prevents a second cross-row move from being reconciled by the first
+    /// move's eventual thaw.
+    static nonisolated func canAcceptDrag(
+        containerAllowsUpdates: Bool,
+        beganInContainer: Bool,
+        alreadyAccepted: Bool
+    ) -> Bool {
+        containerAllowsUpdates || beganInContainer || alreadyAccepted
+    }
+
     private func move(
         item: MenuBarItem,
         to destination: MenuBarItemManager.MoveDestination,
         sourceContainer: LayoutBarContainer? = nil
     ) {
         guard let appState = container.appState else {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
             return
         }
+        guard !isStabilizing else {
+            container.resumeArrangedViewUpdatesWithoutAnimation()
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+            return
+        }
+        isStabilizing = true
+        stabilizationGeneration &+= 1
+        let generation = stabilizationGeneration
+
         // Explicit strong captures: the move must complete even if the view
         // is torn down mid-drag; only the longer-lived watchdog below holds
         // weak references.
-        Task { [self, appState] in
-            guard !isStabilizing else { return }
-            isStabilizing = true
-            await MainActor.run { self.showOverlay(true) }
+        stabilizationTask = Task { [self, appState] in
+            var didValidateUserMove = false
+            @MainActor
+            func acceptValidatedUserMove() {
+                // Clear an unfinished automatic-batch latch only after the
+                // editor move has reached its requested settled placement.
+                appState.itemManager.recordExternalMoveOperation()
+                didValidateUserMove = true
+            }
+
             // Increased delay to allow macOS to settle after operations like Reset Layout.
             // Prevents transient errors when dragging items immediately after reset.
-            // A cancelled sleep must not leave the overlay up and isStabilizing
+            // A cancelled sleep must not leave the layouts frozen or isStabilizing
             // stuck true (the watchdog that would reset them hasn't started yet).
             guard await (try? Task.sleep(for: .milliseconds(150))) != nil else {
-                await resetStabilizingStateIfNeeded()
+                _ = await resetStabilizingStateIfNeeded(
+                    generation: generation,
+                    sourceContainer: sourceContainer
+                )
                 return
             }
 
@@ -515,13 +583,11 @@ final class LayoutBarPaddingView: NSView {
                             "Skipping drag of \(item.logString): destination divider \(targetItem.logString) is parked offscreen (\(targetBounds.map { "minX=\($0.minX)" } ?? "no window bounds")); section is collapsed"
                         )
                         await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                        _ = await self.resetStabilizingStateIfNeeded(
+                            generation: generation,
+                            sourceContainer: sourceContainer
+                        )
                         await MainActor.run {
-                            self.isStabilizing = false
-                            self.showOverlay(false)
-                            self.container.canSetArrangedViews = true
-                            if sourceContainer !== self.container {
-                                sourceContainer?.canSetArrangedViews = true
-                            }
                             let alert = NSAlert()
                             alert.alertStyle = .warning
                             alert.messageText = String(localized: "Couldn't move \(item.displayName) right now.")
@@ -533,12 +599,45 @@ final class LayoutBarPaddingView: NSView {
                 }
             }
 
-            let watchdogTask = Task { [weak self, weak appState, revealedSections] in
-                try? await Task.sleep(for: MenuBarItemManager.layoutWatchdogTimeout + .seconds(1))
+            let watchdogTask = Task { [weak self, weak appState, weak sourceContainer, revealedSections] in
+                try? await Task.sleep(for: Self.stabilizationRecoveryTimeout)
                 guard let self, !Task.isCancelled else { return }
-                await recoverFromUnreturnedMove(revealedSections: revealedSections, appState: appState)
+                guard await self.resetStabilizingStateIfNeeded(
+                    generation: generation,
+                    sourceContainer: sourceContainer,
+                    cancelOwningTask: true
+                ) else { return }
+                guard let appState else { return }
+                // A drag that revealed a collapsed section (#988, #1010)
+                // must re-conceal it even when the move never returned: the
+                // completion path that re-conceals has not run and may never
+                // run. The reset above thawed the bars; park the divider
+                // back and give the spacer a beat before the closing cache
+                // pass records the settled bar.
+                if !revealedSections.isEmpty {
+                    await MainActor.run {
+                        for section in revealedSections {
+                            section.updateControlItemState(for: nil)
+                        }
+                    }
+                    try? await Task.sleep(for: .milliseconds(250))
+                }
+                // The owner task's cancellation runs its defer and cancels
+                // this watchdog. Launch recovery independently so that mutual
+                // cancellation cannot abort it, and retry until the old cache
+                // owner actually releases CacheGate instead of issuing a
+                // one-shot refresh that will probably be dropped.
+                Task { [weak appState] in
+                    guard let appState else { return }
+                    guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+                        return
+                    }
+                    await appState.imageCache.updateCacheWithoutChecks(
+                        sections: MenuBarSection.Name.allCases
+                    )
+                }
             }
-
+            defer { watchdogTask.cancel() }
             do {
                 try await appState.itemManager.move(
                     item: item,
@@ -546,34 +645,156 @@ final class LayoutBarPaddingView: NSView {
                     skipInputPause: true,
                     options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
                 )
-                // Record the user move before stabilization so the save
-                // gate's cooldown exemption is armed when stabilizePlacement's
-                // own cache pass reaches it. Recording it only after stabilize
-                // returned meant the first cache pass inside stabilize hit
-                // the 5s move cooldown with no user-move exemption, so the
-                // save was skipped; by the time the exemption armed, the
-                // mid-transition cache gate had re-armed and no accepting
-                // pass coincided with the cooldown window. The drag never
-                // saved (#983). move() threw no error, so the user's drag
-                // did land; the rescue-and-retry catch block below still
-                // owns the case where macOS didn't settle it.
-                appState.itemManager.recordExternalMoveOperation()
+                guard isCurrentStabilization(generation) else { return }
                 appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
-                _ = await stabilizePlacement(
+                if await stabilizePlacement(
                     of: item,
                     to: destination,
                     expectedSection: container.section,
-                    appState: appState
-                )
+                    appState: appState,
+                    generation: generation
+                ), isCurrentStabilization(generation) {
+                    acceptValidatedUserMove()
+                }
             } catch MenuBarItemManager.EventError.menuTrackingActive {
                 // A menu bar item's menu (Wi-Fi picker, input method panel,
                 // etc.) was open and the move was deferred to avoid tearing
                 // down the user's interaction. This isn't a failure worth
                 // alerting on — log only.
                 Self.diagLog.info("Move deferred, a menu bar item menu was open")
+            } catch MenuBarItemManager.EventError.moveEngineBusy {
+                // Another move held the bar for the whole wait. Nothing was
+                // tried, so nothing failed; the editor snaps the item back
+                // and the user can drag again once the bar is free.
+                Self.diagLog.info("Move deferred, another move held the bar")
             } catch {
+                guard isCurrentStabilization(generation) else { return }
                 Self.diagLog.error("Error moving menu bar item: \(error)")
-                await recoverFromFailedMove(of: item, to: destination, error: error, appState: appState)
+                // The system event-driven move sometimes throws cannotComplete
+                // after macOS has already settled the item into the requested
+                // slot: the click sequence bounces the item past the target
+                // and back during verification, but a subsequent reconciliation
+                // lands it where the user asked. Resample the cache after a
+                // short settle window and only show the alert when the item
+                // is NOT in the position the user actually dragged it to;
+                // showing it for a move that visibly worked is a false alarm.
+                try? await Task.sleep(for: .milliseconds(250))
+                guard isCurrentStabilization(generation) else { return }
+                _ = await appState.itemManager.refreshCacheAfterLayoutEditorMove()
+                guard isCurrentStabilization(generation) else { return }
+                let reachedPosition = didItemReachIntendedPosition(
+                    item: item,
+                    destination: destination,
+                    expectedSection: container.section,
+                    cache: appState.itemManager.itemCache
+                )
+                let isBlocked = if reachedPosition {
+                    false
+                } else {
+                    await appState.itemManager.isItemCurrentlyBlocked(item)
+                }
+                guard isCurrentStabilization(generation) else { return }
+                let action = MenuBarItemManager.classifyHiddenDragFailure(
+                    reachedPosition: reachedPosition,
+                    isBlocked: isBlocked,
+                    controlItemsMissing: appState.itemManager.areControlItemsMissing
+                )
+                switch action {
+                case .suppress:
+                    Self.diagLog.info("Move verification failed but \(item.logString) reached intended position in \(container.section.logString); suppressing alert")
+                    acceptValidatedUserMove()
+                case .rescueAndRetry:
+                    // The item is stuck at the x=-1 sentinel. Rescue it to
+                    // the visible section, let macOS settle, then retry the
+                    // original move exactly once (no loop). Only if that
+                    // retry also fails do we alert, and with a calm message
+                    // rather than the raw error, matching the safe-harbor
+                    // behavior of restoreBlockedItemsToVisible.
+                    Self.diagLog.warning("\(item.logString) is blocked (x=-1); attempting one rescue-and-retry before alerting")
+                    _ = await appState.itemManager.rescueBlockedItemToVisible(item)
+                    guard isCurrentStabilization(generation) else { return }
+                    try? await Task.sleep(for: .milliseconds(250))
+                    guard isCurrentStabilization(generation) else { return }
+                    _ = await appState.itemManager.refreshCacheAfterLayoutEditorMove()
+                    guard isCurrentStabilization(generation) else { return }
+                    do {
+                        try await appState.itemManager.move(
+                            item: item,
+                            to: destination,
+                            skipInputPause: true,
+                            options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
+                        )
+                        guard isCurrentStabilization(generation) else { return }
+                        appState.itemManager.removeTemporarilyShownItemFromCache(with: item.tag)
+                        if await stabilizePlacement(
+                            of: item,
+                            to: destination,
+                            expectedSection: container.section,
+                            appState: appState,
+                            generation: generation
+                        ), isCurrentStabilization(generation) {
+                            acceptValidatedUserMove()
+                        }
+                    } catch MenuBarItemManager.EventError.menuTrackingActive {
+                        // Same deferral the outer catch handles: the user
+                        // opened a menu bar item's menu while the retry was
+                        // in flight. Nothing failed, so don't alert.
+                        Self.diagLog.info("Rescue-and-retry deferred, a menu bar item menu was open")
+                    } catch {
+                        guard isCurrentStabilization(generation) else { return }
+                        Self.diagLog.error("Rescue-and-retry failed for \(item.logString): \(error)")
+                        let alert = NSAlert()
+                        alert.alertStyle = .warning
+                        alert.messageText = container.section == .alwaysHidden
+                            ? String(localized: "Couldn't move \(item.displayName) to the always-hidden section.")
+                            : String(localized: "Couldn't move \(item.displayName) to the hidden section.")
+                        alert.informativeText = String(localized: "The item was left in the visible section so it isn't stuck offscreen. Try dragging it again in a moment.")
+                        let report = await MoveFailureDiagnosticReport.generate(
+                            for: .init(
+                                item: item,
+                                destination: destination,
+                                expectedSection: container.section,
+                                error: error,
+                                note: "The item was stuck at x=-1; a rescue to the visible section and one retry of the move also failed."
+                            ),
+                            appState: appState
+                        )
+                        guard isCurrentStabilization(generation) else { return }
+                        report.run(alert, in: window)
+                    }
+                case .alertControlItemsMissing:
+                    let alert = NSAlert()
+                    alert.alertStyle = .warning
+                    alert.messageText = String(localized: "Couldn't move the item right now.")
+                    alert.informativeText = String(localized: "\(Constants.displayName) can't locate its hidden-section divider right now. It is attempting recovery in the background — try again in a few seconds.")
+                    let report = await MoveFailureDiagnosticReport.generate(
+                        for: .init(
+                            item: item,
+                            destination: destination,
+                            expectedSection: container.section,
+                            error: error,
+                            note: "The hidden-section divider could not be located; recovery was started in the background."
+                        ),
+                        appState: appState
+                    )
+                    guard isCurrentStabilization(generation) else { return }
+                    report.run(alert, in: window)
+                case .alertGeneric:
+                    // Generated before the alert shows so the "Save Diagnostic
+                    // Report…" button has the bar as it was at the failure,
+                    // not as it settles while the alert is up.
+                    let report = await MoveFailureDiagnosticReport.generate(
+                        for: .init(
+                            item: item,
+                            destination: destination,
+                            expectedSection: container.section,
+                            error: error
+                        ),
+                        appState: appState
+                    )
+                    guard isCurrentStabilization(generation) else { return }
+                    report.run(NSAlert(error: error), in: window)
+                }
             }
             if !revealedSections.isEmpty {
                 // Re-conceal the sections that were revealed for the drag
@@ -591,13 +812,24 @@ final class LayoutBarPaddingView: NSView {
                 // closing cache pass records the settled bar.
                 try? await Task.sleep(for: .milliseconds(250))
             }
-            watchdogTask.cancel()
-            if let appState = container.appState {
-                await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+            guard isCurrentStabilization(generation) else { return }
+            let didRefresh = await appState.itemManager.refreshCacheAfterLayoutEditorMove(
+                forcePersistSavedOrder: didValidateUserMove
+            )
+            guard isCurrentStabilization(generation) else { return }
+            if !didRefresh {
+                Self.diagLog.error(
+                    "Thawing Layout editor after post-move cache refresh timed out"
+                )
             }
-            await MainActor.run {
+            let didThawCurrentMove = await MainActor.run {
+                guard self.isStabilizing,
+                      self.stabilizationGeneration == generation
+                else {
+                    return false
+                }
                 self.isStabilizing = false
-                self.showOverlay(false)
+                self.stabilizationTask = nil
                 // Update the badge anchor BEFORE re-enabling view updates, using
                 // the current visual arrangement from the drag. This ensures the
                 // didSet refresh uses the correct anchor position.
@@ -615,10 +847,23 @@ final class LayoutBarPaddingView: NSView {
                 // the dragging session). Without resetting the source, its
                 // arrangedViews would stay frozen at the mid-drag snapshot
                 // until the next drag originated from that container.
-                self.container.canSetArrangedViews = true
+                self.container.resumeArrangedViewUpdatesWithoutAnimation()
                 if sourceContainer !== self.container {
-                    sourceContainer?.canSetArrangedViews = true
+                    sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
                 }
+                return true
+            }
+
+            // Thumbnail capture is allowed to lag behind geometry. The moved
+            // view retains its last stable image, so holding both rows frozen
+            // while capture retries only makes the editor feel stuck.
+            if didThawCurrentMove {
+                await MainActor.run {
+                    appState.imageCache.performCacheCleanup()
+                }
+                await appState.imageCache.updateCacheWithoutChecks(
+                    sections: MenuBarSection.Name.allCases
+                )
             }
         }
     }
@@ -691,7 +936,8 @@ final class LayoutBarPaddingView: NSView {
                     of: item,
                     to: destination,
                     expectedSection: container.section,
-                    appState: appState
+                    appState: appState,
+                    generation: stabilizationGeneration
                 )
             } catch MenuBarItemManager.EventError.menuTrackingActive {
                 // Same deferral the outer catch handles: the user
@@ -731,15 +977,28 @@ final class LayoutBarPaddingView: NSView {
         expectedSection: MenuBarSection.Name,
         cache: MenuBarItemManager.ItemCache
     ) -> Bool {
-        let sectionItems = cache[expectedSection]
-        guard let itemIndex = sectionItems.firstIndex(where: { $0.tag == item.tag }) else {
+        Self.itemReachedIntendedPosition(
+            item: item,
+            destination: destination,
+            sectionItems: cache[expectedSection]
+        )
+    }
+
+    /// Whether `item` sits in `sectionItems` where `destination` asked for
+    /// it. Pure, so the identity rule below can be tested.
+    static nonisolated func itemReachedIntendedPosition(
+        item: MenuBarItem,
+        destination: MenuBarItemManager.MoveDestination,
+        sectionItems: [MenuBarItem]
+    ) -> Bool {
+        guard let itemIndex = sectionItems.firstIndex(where: { Self.isSameItem($0, item) }) else {
             return false
         }
         let target = destination.targetItem
         if target.isControlItem {
             return true
         }
-        guard let targetIndex = sectionItems.firstIndex(where: { $0.tag == target.tag }) else {
+        guard let targetIndex = sectionItems.firstIndex(where: { Self.isSameItem($0, target) }) else {
             return false
         }
         return switch destination {
@@ -752,7 +1011,6 @@ final class LayoutBarPaddingView: NSView {
     private func resetStabilizingStateIfNeeded(sourceContainer: LayoutBarContainer? = nil) async {
         if isStabilizing {
             isStabilizing = false
-            showOverlay(false)
             container.canSetArrangedViews = true
             // The source bar is frozen by the dragging session, so an abnormal
             // exit has to thaw it too or it stays at its mid-drag snapshot
@@ -763,8 +1021,49 @@ final class LayoutBarPaddingView: NSView {
         }
     }
 
-    private func showOverlay(_ visible: Bool) {
-        container.alphaValue = visible ? 0.6 : 1.0
+    /// Whether a cached item is the item that was dragged.
+    ///
+    /// The dragged item's tag is a snapshot. The cache refreshed after the
+    /// move can name the same window differently — a provisional
+    /// `com.apple.controlcenter:Item-0` resolves to its app's identifier
+    /// once the source process is known — and an exact tag comparison then
+    /// misses the item that just landed, which re-drags it (the move engine
+    /// finds it already in place and cancels) and, on the failure path,
+    /// alerts for a move that worked. The window is what moved: match it
+    /// first, and fall back to the tag without its window for a window that
+    /// was recreated in between.
+    static nonisolated func isSameItem(_ cached: MenuBarItem, _ dragged: MenuBarItem) -> Bool {
+        cached.windowID == dragged.windowID || cached.tag.matchesIgnoringWindowID(dragged.tag)
+    }
+
+    /// Whether the async continuation still belongs to the move that owns the
+    /// frozen editor rows. The recovery watchdog invalidates the generation
+    /// and cancels that task before reopening the editor, so a slow old move
+    /// cannot resume later and reorder the bar over a newer drag.
+    private func isCurrentStabilization(_ generation: Int) -> Bool {
+        isStabilizing && stabilizationGeneration == generation && !Task.isCancelled
+    }
+
+    @MainActor
+    private func resetStabilizingStateIfNeeded(
+        generation: Int,
+        sourceContainer: LayoutBarContainer? = nil,
+        cancelOwningTask: Bool = false
+    ) async -> Bool {
+        guard isStabilizing, stabilizationGeneration == generation else {
+            return false
+        }
+        if cancelOwningTask {
+            stabilizationTask?.cancel()
+            stabilizationGeneration &+= 1
+        }
+        stabilizationTask = nil
+        isStabilizing = false
+        container.resumeArrangedViewUpdatesWithoutAnimation()
+        if sourceContainer !== container {
+            sourceContainer?.resumeArrangedViewUpdatesWithoutAnimation()
+        }
+        return true
     }
 
     private func containsNewItemsBadge() -> Bool {
@@ -822,7 +1121,13 @@ final class LayoutBarPaddingView: NSView {
     }
 
     private func liveFallbackDestinationForDraggedItem() async -> MenuBarItemManager.MoveDestination? {
-        let items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+        // This fallback only needs the section's control item. Resolving every
+        // item's source process can block on Accessibility for many seconds,
+        // leaving both drag rows frozen before move() can start its watchdog.
+        let items = await MenuBarItem.getMenuBarItems(
+            option: .activeSpace,
+            resolveSourcePID: false
+        )
         return switch container.section {
         case .visible:
             nil
@@ -1003,18 +1308,25 @@ final class LayoutBarPaddingView: NSView {
         of item: MenuBarItem,
         to destination: MenuBarItemManager.MoveDestination,
         expectedSection: MenuBarSection.Name,
-        appState: AppState
+        appState: AppState,
+        generation: Int
     ) async -> Bool {
-        // First refresh caches and verify placement.
-        await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+        guard isCurrentStabilization(generation) else { return false }
+        // A dropped refresh is not evidence. Keep the drag projection frozen
+        // until this move owns and completes a fast geometry cache pass.
+        guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+            return false
+        }
+        guard isCurrentStabilization(generation) else { return false }
 
         func isInExpectedSection() -> Bool {
-            appState.itemManager.itemCache[expectedSection].contains { $0.tag == item.tag }
+            appState.itemManager.itemCache[expectedSection].contains { Self.isSameItem($0, item) }
         }
 
         if !isInExpectedSection() {
             // Allow macOS a brief moment to settle, then retry once.
             try? await Task.sleep(for: .milliseconds(120))
+            guard isCurrentStabilization(generation) else { return false }
             do {
                 try await appState.itemManager.move(
                     item: item,
@@ -1022,17 +1334,17 @@ final class LayoutBarPaddingView: NSView {
                     skipInputPause: true,
                     options: .init(watchdogTimeout: MenuBarItemManager.layoutWatchdogTimeout)
                 )
-                await appState.itemManager.cacheItemsRegardless(skipRecentMoveCheck: true)
+                guard isCurrentStabilization(generation) else { return false }
+                guard await appState.itemManager.refreshCacheAfterLayoutEditorMove() else {
+                    return false
+                }
+                guard isCurrentStabilization(generation) else { return false }
             } catch {
+                guard isCurrentStabilization(generation) else { return false }
                 Self.diagLog.error("Stabilize move failed: \(error)")
             }
         }
 
-        // Refresh images so icons show immediately in the UI without clearing to avoid temporary gaps.
-        await MainActor.run {
-            appState.imageCache.performCacheCleanup()
-        }
-        await appState.imageCache.updateCacheWithoutChecks(sections: MenuBarSection.Name.allCases)
         return isInExpectedSection()
     }
 

--- a/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarPaddingView.swift
@@ -158,6 +158,15 @@ final class LayoutBarPaddingView: NSView {
             draggingSource.hasContainer = false
 
             container.resumeArrangedViewUpdatesWithoutAnimation()
+            // The dragging session froze the source row too, and the refusal
+            // starts no move task that would thaw it later. Resume it like
+            // every other refusal path; `oldContainerInfo` stays so the drag
+            // session's end can restore the original view to its old slot.
+            if let sourceContainer = draggingSource.oldContainerInfo?.container,
+               sourceContainer !== container
+            {
+                sourceContainer.resumeArrangedViewUpdatesWithoutAnimation()
+            }
             return false
         }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItem+Enumeration.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItem+Enumeration.swift
@@ -164,9 +164,9 @@ nonisolated extension MenuBarItem {
     }
 
     @MainActor
-    private static func assignStableInstanceIndices(
+    static func assignStableInstanceIndices(
         to items: inout [MenuBarItem],
-        using windows: [WindowInfo]
+        using windowsByID: [CGWindowID: WindowInfo]
     ) {
         // Final pass: assign instance indices to allow individual identification
         // of items with the same (namespace, title). Sort by windowID within each
@@ -181,15 +181,16 @@ nonisolated extension MenuBarItem {
         for (_, indices) in groups where indices.count > 1 {
             let sorted = indices.sorted { items[$0].windowID < items[$1].windowID }
             for (instanceIndex, itemIndex) in sorted.enumerated() where instanceIndex > 0 {
+                guard let window = windowsByID[items[itemIndex].windowID] else { continue }
                 if let sourcePID = items[itemIndex].sourcePID {
                     items[itemIndex] = MenuBarItem(
-                        uncheckedItemWindow: windows[itemIndex],
+                        uncheckedItemWindow: window,
                         sourcePID: sourcePID,
                         instanceIndex: instanceIndex
                     )
                 } else {
                     items[itemIndex] = MenuBarItem(
-                        uncheckedItemWindow: windows[itemIndex],
+                        uncheckedItemWindow: window,
                         sourcePID: nil,
                         instanceIndex: instanceIndex
                     )
@@ -219,7 +220,10 @@ nonisolated extension MenuBarItem {
             return MenuBarItem(uncheckedItemWindow: window, sourcePID: nil)
         }
 
-        assignStableInstanceIndices(to: &items, using: windows)
+        assignStableInstanceIndices(
+            to: &items,
+            using: Dictionary(windows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
+        )
         let nilPIDCount = items.count(where: { $0.sourcePID == nil })
         diagLog.debug(
             "getMenuBarItemsExperimental: created \(items.count) items without sourcePID resolution, \(nilPIDCount) unresolved"
@@ -376,7 +380,10 @@ nonisolated extension MenuBarItem {
             }
         }
 
-        assignStableInstanceIndices(to: &items, using: windows)
+        assignStableInstanceIndices(
+            to: &items,
+            using: Dictionary(windows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
+        )
 
         let nilPIDItems = items.filter { $0.sourcePID == nil }
         if !nilPIDItems.isEmpty {

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemEventTypes.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemEventTypes.swift
@@ -46,7 +46,7 @@ nonisolated enum MenuBarItemEventType {
     // MARK: Subtypes
 
     /// Subtype for menu bar item move events.
-    enum MoveSubtype {
+    enum MoveSubtype: Equatable {
         case mouseDown
         case mouseDragged
         case mouseUp

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+CacheGate.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+CacheGate.swift
@@ -11,7 +11,23 @@ import Cocoa
 // MARK: - Cache Gate
 
 extension MenuBarItemManager {
-    enum LayoutResetTarget: Sendable {
+    /// Records whether one specific cache attempt actually observed the menu
+    /// bar. Layout-editor moves use this to distinguish an accepted cache pass
+    /// from one dropped by ``CacheGate`` while another pass was in flight.
+    @MainActor
+    final class CacheAttempt {
+        private(set) var didCompleteCycle = false
+
+        func recordCompletion(
+            cyclesAtEntry: Int,
+            cyclesAtExit: Int,
+            snapshotRemainedCurrent: Bool = true
+        ) {
+            didCompleteCycle = cyclesAtExit > cyclesAtEntry && snapshotRemainedCurrent
+        }
+    }
+
+    enum LayoutResetTarget {
         case visible
         case hidden
         case alwaysHidden

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -458,7 +458,11 @@ extension MenuBarItemManager {
 
             switch decision {
             case let .move(item, destination):
-                var didAcceptCurrentMove = false
+                // Reset the per-move flag: the recorder box outlives the
+                // loop, and a stale `true` from an earlier accepted move
+                // would misreport this iteration's own preflight rejection
+                // as a failed accepted move.
+                attemptRecorder.didAcceptCurrentMove = false
                 let targetSection: MenuBarSection.Name = {
                     if case let .section(section) = entry.kind {
                         return section

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -38,6 +38,15 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Reference box recording whether a queued move was accepted by its
+    /// preflight. ``MoveOptions/shouldBegin`` escapes the call frame — it is
+    /// stored in the options struct — so a captured local cannot be mutated
+    /// from inside the closure.
+    private final class MoveAttemptAcceptanceRecorder {
+        var didAcceptMoveAttempt = false
+        var didAcceptCurrentMove = false
+    }
+
     /// Relocates any newly appearing items that macOS placed to the left
     /// of our control items back into the visible section.
     ///
@@ -52,6 +61,7 @@ extension MenuBarItemManager {
         recentWindowIDs: Set<CGWindowID>,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard appState != nil else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
@@ -161,28 +171,28 @@ extension MenuBarItemManager {
 
         case let .systemItem(systemItem):
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: systemItem,
                     to: .rightOfItem(controlItems.hidden),
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale system-item relocation for \(systemItem.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -202,10 +212,10 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.info(
                     "Skipping new-item relocation for Thaw spacer \(candidate.logString)"
                 )
-                // Nothing was relocated: reporting true would make the caller
-                // treat this cycle as interrupted and schedule an extra
+                // Nothing was relocated: reporting an attempt would make the
+                // caller treat this cycle as interrupted and schedule an extra
                 // recache for a no-op. The spacer is already marked known.
-                return false
+                return .noAttempt
             }
 
             let destination = newItemsMoveDestination(for: controlItems, among: items)
@@ -222,28 +232,28 @@ extension MenuBarItemManager {
                 return .noAttempt
             }
 
-            var didAcceptMoveAttempt = false
+            let attemptRecorder = MoveAttemptAcceptanceRecorder()
             do {
                 try await move(
                     item: candidate,
                     to: destination,
                     skipInputPause: true,
-                    shouldBegin: {
-                        let shouldBegin = shouldBeginMove?() ?? true
+                    options: .init(shouldBegin: {
+                        let shouldBegin = beginMove?() ?? true
                         if shouldBegin {
-                            didAcceptMoveAttempt = true
+                            attemptRecorder.didAcceptMoveAttempt = true
                         }
                         return shouldBegin
-                    }
+                    })
                 )
             } catch EventError.moveSuperseded {
                 MenuBarItemManager.diagLog.debug(
                     "Skipping stale new-item relocation for \(candidate.logString)"
                 )
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+                return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
             return .completed
 
@@ -272,6 +282,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         // The destination is the right of H_ctrl. When the divider itself is
         // parked offscreen, that destination is in the parked zone: the drag
         // strands the chevron beside it, invisible to the user (#958's
@@ -289,28 +300,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             try await move(
                 item: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug(
                 "Skipping stale Thaw-icon relocation for \(thawIcon.logString)"
             )
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
         return .completed
     }
@@ -331,6 +342,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocatePendingItems: skipping for provisional AX-frame correlation"
@@ -367,7 +379,7 @@ extension MenuBarItemManager {
             }
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         var didCompleteMove = false
         var didFailAcceptedMove = false
         func outcome() -> CacheDrivenMoveOutcome {
@@ -377,7 +389,7 @@ extension MenuBarItemManager {
             if didCompleteMove {
                 return .completed
             }
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
 
         // Iterate a snapshot of the dict keys so promotions of waitForRelaunch
@@ -467,27 +479,27 @@ extension MenuBarItemManager {
                         item: item,
                         to: destination,
                         skipInputPause: true,
-                        shouldBegin: {
-                            let shouldBegin = shouldBeginMove?() ?? true
+                        options: .init(shouldBegin: {
+                            let shouldBegin = beginMove?() ?? true
                             if shouldBegin {
-                                didAcceptMoveAttempt = true
-                                didAcceptCurrentMove = true
+                                attemptRecorder.didAcceptMoveAttempt = true
+                                attemptRecorder.didAcceptCurrentMove = true
                             }
                             return shouldBegin
-                        }
+                        })
                     )
                     pendingRelocations.removeValue(forKey: tagIdentifier)
                     pendingReturnDestinations.removeValue(forKey: tagIdentifier)
                     didCompleteMove = true
                 } catch EventError.moveSuperseded {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.debug(
                         "Stopping stale pending-item relocations before moving \(item.logString)"
                     )
                     persistPendingRelocations()
                     return outcome()
                 } catch {
-                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    didFailAcceptedMove = didFailAcceptedMove || attemptRecorder.didAcceptCurrentMove
                     MenuBarItemManager.diagLog.error(
                         """
                         Failed to relocate \(item.logString) back to \
@@ -536,6 +548,7 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         shouldBeginMove: (@MainActor () -> Bool)? = nil
     ) async -> CacheDrivenMoveOutcome {
+        let beginMove = shouldBeginMove
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Skipping control item order enforcement for provisional AX-frame correlation"
@@ -565,28 +578,28 @@ extension MenuBarItemManager {
             return .noAttempt
         }
 
-        var didAcceptMoveAttempt = false
+        let attemptRecorder = MoveAttemptAcceptanceRecorder()
         do {
             MenuBarItemManager.diagLog.debug("Control items have incorrect order")
             try await move(
                 item: alwaysHidden,
                 to: .leftOfItem(hidden),
                 skipInputPause: true,
-                shouldBegin: {
-                    let shouldBegin = shouldBeginMove?() ?? true
+                options: .init(shouldBegin: {
+                    let shouldBegin = beginMove?() ?? true
                     if shouldBegin {
-                        didAcceptMoveAttempt = true
+                        attemptRecorder.didAcceptMoveAttempt = true
                     }
                     return shouldBegin
-                }
+                })
             )
             return .completed
         } catch EventError.moveSuperseded {
             MenuBarItemManager.diagLog.debug("Skipping stale control-item order enforcement")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
-            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+            return attemptRecorder.didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ControlItemOrder.swift
@@ -14,22 +14,50 @@ import Cocoa
 // MARK: - Control Item Order
 
 extension MenuBarItemManager {
+    /// Result of one cache-driven move helper.
+    ///
+    /// A failed attempt still needs one authoritative cache read because
+    /// synthetic events may have changed position before verification failed.
+    /// It must not immediately rerun the same automatic helper, however, or a
+    /// persistent refusal becomes an unbounded recache/retry chain.
+    enum CacheDrivenMoveOutcome: Equatable {
+        case noAttempt
+        case completed
+        case failedAttempt
+
+        var needsAuthoritativeRecache: Bool {
+            self != .noAttempt
+        }
+
+        var shouldSuppressAutomaticMovesDuringRecache: Bool {
+            self == .failedAttempt
+        }
+
+        var shouldSuppressSavedOrderPersistenceDuringRecache: Bool {
+            self == .failedAttempt
+        }
+    }
+
     /// Relocates any newly appearing items that macOS placed to the left
     /// of our control items back into the visible section.
     ///
-    /// Returns true if a relocation was performed.
+    /// Returns whether no move began, a move completed, or an accepted move
+    /// later failed. Even a failed attempt may have displaced the item, so
+    /// callers must follow every accepted attempt with an authoritative
+    /// recache without persisting that possibly partial geometry.
     func relocateNewLeftmostItems(
         _ items: [MenuBarItem],
         controlItems: ControlItemPair,
         previousWindowIDs: [CGWindowID],
-        recentWindowIDs: Set<CGWindowID>
-    ) async -> Bool {
-        guard appState != nil else { return false }
+        recentWindowIDs: Set<CGWindowID>,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
+        guard appState != nil else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocateNewLeftmostItems: skipping for provisional AX-frame correlation"
             )
-            return false
+            return .noAttempt
         }
 
         if suppressNextNewLeftmostItemRelocation {
@@ -43,7 +71,7 @@ extension MenuBarItemManager {
             knownItemIdentifiers.formUnion(identifiers)
             persistKnownItemIdentifiers()
             suppressNextNewLeftmostItemRelocation = false
-            return false
+            return .noAttempt
         }
 
         // During startup settling, the first cache pass may have items tagged
@@ -78,9 +106,13 @@ extension MenuBarItemManager {
                 items: items,
                 hiddenBounds: bestBounds(for: controlItems.hidden)
             ) {
-                return await relocateThawIcon(thawIcon, controlItems: controlItems)
+                return await relocateThawIcon(
+                    thawIcon,
+                    controlItems: controlItems,
+                    shouldBeginMove: shouldBeginMove
+                )
             }
-            return false
+            return .noAttempt
         }
 
         // Cached hidden / always-hidden tags from the prior cache cycle.
@@ -121,21 +153,38 @@ extension MenuBarItemManager {
 
         switch decision {
         case let .thawIcon(thawIcon):
-            return await relocateThawIcon(thawIcon, controlItems: controlItems)
+            return await relocateThawIcon(
+                thawIcon,
+                controlItems: controlItems,
+                shouldBeginMove: shouldBeginMove
+            )
 
         case let .systemItem(systemItem):
             MenuBarItemManager.diagLog.info("Relocating non-hideable system item \(systemItem.logString) to visible section")
+            var didAcceptMoveAttempt = false
             do {
                 try await move(
                     item: systemItem,
                     to: .rightOfItem(controlItems.hidden),
-                    skipInputPause: true
+                    skipInputPause: true,
+                    shouldBegin: {
+                        let shouldBegin = shouldBeginMove?() ?? true
+                        if shouldBegin {
+                            didAcceptMoveAttempt = true
+                        }
+                        return shouldBegin
+                    }
                 )
+            } catch EventError.moveSuperseded {
+                MenuBarItemManager.diagLog.debug(
+                    "Skipping stale system-item relocation for \(systemItem.logString)"
+                )
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate system item \(systemItem.logString): \(error)")
-                return false
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
-            return true
+            return .completed
 
         case let .newHideableItem(candidate, identifierToMark):
             // Track this item so future cache cycles don't treat it as new.
@@ -170,20 +219,33 @@ extension MenuBarItemManager {
             // it requires Bridging.
             guard Bridging.getWindowBounds(for: candidate.windowID) != nil else {
                 MenuBarItemManager.diagLog.warning("Skipping relocation for \(candidate.logString); no valid bounds, likely transient")
-                return false
+                return .noAttempt
             }
 
+            var didAcceptMoveAttempt = false
             do {
                 try await move(
                     item: candidate,
                     to: destination,
-                    skipInputPause: true
+                    skipInputPause: true,
+                    shouldBegin: {
+                        let shouldBegin = shouldBeginMove?() ?? true
+                        if shouldBegin {
+                            didAcceptMoveAttempt = true
+                        }
+                        return shouldBegin
+                    }
                 )
+            } catch EventError.moveSuperseded {
+                MenuBarItemManager.diagLog.debug(
+                    "Skipping stale new-item relocation for \(candidate.logString)"
+                )
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             } catch {
                 MenuBarItemManager.diagLog.error("Failed to relocate \(candidate.logString): \(error)")
-                return false
+                return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
             }
-            return true
+            return .completed
 
         case let .noop(reason):
             switch reason {
@@ -198,7 +260,7 @@ extension MenuBarItemManager {
             case .noNewCandidate, .noLeftmostItems:
                 break
             }
-            return false
+            return .noAttempt
         }
     }
 
@@ -207,8 +269,9 @@ extension MenuBarItemManager {
     /// planner path, which reach the same decision from different inputs.
     private func relocateThawIcon(
         _ thawIcon: MenuBarItem,
-        controlItems: ControlItemPair
-    ) async -> Bool {
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         // The destination is the right of H_ctrl. When the divider itself is
         // parked offscreen, that destination is in the parked zone: the drag
         // strands the chevron beside it, invisible to the user (#958's
@@ -223,20 +286,33 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "Skipping Thaw icon relocation, the hidden divider is parked offscreen (minX=\(controlItems.hidden.bounds.minX)); moving the icon beside it would strand both"
             )
-            return false
+            return .noAttempt
         }
         MenuBarItemManager.diagLog.info("Relocating Thaw icon \(thawIcon.logString) to visible section")
+        var didAcceptMoveAttempt = false
         do {
             try await move(
                 item: thawIcon,
                 to: .rightOfItem(controlItems.hidden),
-                skipInputPause: true
+                skipInputPause: true,
+                shouldBegin: {
+                    let shouldBegin = shouldBeginMove?() ?? true
+                    if shouldBegin {
+                        didAcceptMoveAttempt = true
+                    }
+                    return shouldBegin
+                }
             )
+        } catch EventError.moveSuperseded {
+            MenuBarItemManager.diagLog.debug(
+                "Skipping stale Thaw-icon relocation for \(thawIcon.logString)"
+            )
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Failed to relocate Thaw icon \(thawIcon.logString): \(error)")
-            return false
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
-        return true
+        return .completed
     }
 
     /// Relocates items whose apps quit while they were temporarily shown
@@ -247,20 +323,23 @@ extension MenuBarItemManager {
     /// back, the icon will reappear in the visible section on relaunch.
     /// This method checks for such items and moves them back.
     ///
-    /// Returns `true` if any items were relocated.
+    /// Returns whether no move began, a move completed, or an accepted move
+    /// later failed. A failed accepted attempt can still leave position-only
+    /// geometry that the normal window-ID change detector cannot observe.
     func relocatePendingItems(
         _ items: [MenuBarItem],
-        controlItems: ControlItemPair
-    ) async -> Bool {
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "relocatePendingItems: skipping for provisional AX-frame correlation"
             )
-            return false
+            return .noAttempt
         }
 
         guard !pendingRelocations.isEmpty else {
-            return false
+            return .noAttempt
         }
 
         // Don't interfere with items that are currently temporarily shown ;
@@ -288,7 +367,18 @@ extension MenuBarItemManager {
             }
         }
 
-        var didRelocate = false
+        var didAcceptMoveAttempt = false
+        var didCompleteMove = false
+        var didFailAcceptedMove = false
+        func outcome() -> CacheDrivenMoveOutcome {
+            if didFailAcceptedMove {
+                return .failedAttempt
+            }
+            if didCompleteMove {
+                return .completed
+            }
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
+        }
 
         // Iterate a snapshot of the dict keys so promotions of waitForRelaunch
         // sentinels mid-loop don't disturb iteration. The planner is called
@@ -356,6 +446,7 @@ extension MenuBarItemManager {
 
             switch decision {
             case let .move(item, destination):
+                var didAcceptCurrentMove = false
                 let targetSection: MenuBarSection.Name = {
                     if case let .section(section) = entry.kind {
                         return section
@@ -372,11 +463,31 @@ extension MenuBarItemManager {
                     """
                 )
                 do {
-                    try await move(item: item, to: destination, skipInputPause: true)
+                    try await move(
+                        item: item,
+                        to: destination,
+                        skipInputPause: true,
+                        shouldBegin: {
+                            let shouldBegin = shouldBeginMove?() ?? true
+                            if shouldBegin {
+                                didAcceptMoveAttempt = true
+                                didAcceptCurrentMove = true
+                            }
+                            return shouldBegin
+                        }
+                    )
                     pendingRelocations.removeValue(forKey: tagIdentifier)
                     pendingReturnDestinations.removeValue(forKey: tagIdentifier)
-                    didRelocate = true
+                    didCompleteMove = true
+                } catch EventError.moveSuperseded {
+                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                    MenuBarItemManager.diagLog.debug(
+                        "Stopping stale pending-item relocations before moving \(item.logString)"
+                    )
+                    persistPendingRelocations()
+                    return outcome()
                 } catch {
+                    didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
                     MenuBarItemManager.diagLog.error(
                         """
                         Failed to relocate \(item.logString) back to \
@@ -410,7 +521,7 @@ extension MenuBarItemManager {
         }
 
         persistPendingRelocations()
-        return didRelocate
+        return outcome()
     }
 
     /// Returns the best-known bounds for a menu bar item.
@@ -421,12 +532,15 @@ extension MenuBarItemManager {
     /// Enforces the order of the given control items, ensuring that the
     /// control item for the always-hidden section is positioned to the
     /// left of control item for the hidden section.
-    func enforceControlItemOrder(controlItems: ControlItemPair) async {
+    func enforceControlItemOrder(
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Skipping control item order enforcement for provisional AX-frame correlation"
             )
-            return
+            return .noAttempt
         }
 
         let hidden = controlItems.hidden
@@ -435,7 +549,7 @@ extension MenuBarItemManager {
             let alwaysHidden = controlItems.alwaysHidden,
             bestBounds(for: hidden).maxX <= bestBounds(for: alwaysHidden).minX
         else {
-            return
+            return .noAttempt
         }
 
         // Moving AH_ctrl to the left of a parked H_ctrl drops the entire
@@ -448,14 +562,31 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "Skipping control item order enforcement, the hidden divider is parked offscreen (minX=\(hidden.bounds.minX))"
             )
-            return
+            return .noAttempt
         }
 
+        var didAcceptMoveAttempt = false
         do {
             MenuBarItemManager.diagLog.debug("Control items have incorrect order")
-            try await move(item: alwaysHidden, to: .leftOfItem(hidden), skipInputPause: true)
+            try await move(
+                item: alwaysHidden,
+                to: .leftOfItem(hidden),
+                skipInputPause: true,
+                shouldBegin: {
+                    let shouldBegin = shouldBeginMove?() ?? true
+                    if shouldBegin {
+                        didAcceptMoveAttempt = true
+                    }
+                    return shouldBegin
+                }
+            )
+            return .completed
+        } catch EventError.moveSuperseded {
+            MenuBarItemManager.diagLog.debug("Skipping stale control-item order enforcement")
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         } catch {
             MenuBarItemManager.diagLog.error("Error enforcing control item order: \(error)")
+            return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
@@ -336,11 +336,19 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Returns the dynamic delay still required between move operations.
+    nonisolated func moveOperationBufferDuration() async -> Duration {
+        guard let timestamp = await lastMoveOperationTimestamp else {
+            return .zero
+        }
+        return max(.milliseconds(25) - timestamp.duration(to: .now), .zero)
+    }
+
     /// Waits between move operations for a dynamic amount of time,
     /// based on the timestamp of the last move operation.
     nonisolated func waitForMoveOperationBuffer() async throws {
-        if let timestamp = await lastMoveOperationTimestamp {
-            let buffer = max(.milliseconds(25) - timestamp.duration(to: .now), .zero)
+        let buffer = await moveOperationBufferDuration()
+        if buffer > .zero {
             MenuBarItemManager.diagLog.debug("Move operation buffer: \(buffer)")
             do {
                 try await Task.sleep(for: buffer)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+EventHelpers.swift
@@ -78,6 +78,9 @@ extension MenuBarItemManager {
         /// the move as a whole ran past its deadline. Whatever reply came
         /// back after that describes a press that was no longer down.
         case moveTimedOut(MenuBarItem)
+        /// The planned endpoints do not form a safe transport on the selected
+        /// display. No synthetic press was posted.
+        case unsafeMovePath(MenuBarItem)
 
         var description: String {
             switch self {
@@ -117,6 +120,8 @@ extension MenuBarItemManager {
                 "\(Self.self).moveEngineBusy(item: \(item.tag))"
             case let .moveTimedOut(item):
                 "\(Self.self).moveTimedOut(item: \(item.tag))"
+            case let .unsafeMovePath(item):
+                "\(Self.self).unsafeMovePath(item: \(item.tag))"
             }
         }
 
@@ -158,6 +163,8 @@ extension MenuBarItemManager {
                 "Another move was still in progress when \"\(item.displayName)\" was to be moved"
             case let .moveTimedOut(item):
                 "Moving \"\(item.displayName)\" took too long and was stopped"
+            case let .unsafeMovePath(item):
+                "The path for moving \"\(item.displayName)\" is no longer safe"
             }
         }
 
@@ -202,7 +209,7 @@ extension MenuBarItemManager {
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
                  .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
                  .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
-                 .moveEngineBusy, .moveTimedOut:
+                 .moveEngineBusy, .moveTimedOut, .unsafeMovePath:
                 false
             }
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -1728,6 +1728,7 @@ extension MenuBarItemManager {
         // can produce wrong matches when AX positions lag behind CG updates.
         // A cached PID from a previous stable cycle is more trustworthy.
         var provisionalSourcePIDSeeds = enumeration.appliedSourcePIDSeeds
+        var didReconcileSourcePID = false
         if resolveSourcePID {
             let previousBaselines = cacheActor.cachedSourcePIDBaselines
             var attemptedPIDs = Set<pid_t>()
@@ -1790,7 +1791,17 @@ extension MenuBarItemManager {
                     title: item.title,
                     isOnScreen: item.isOnScreen
                 )
+                didReconcileSourcePID = true
             }
+        }
+
+        // The reconciliation above can change an item's namespace while
+        // preserving its instanceIndex. If another live item already holds
+        // that (namespace, title, instanceIndex) identity, two items collide
+        // and windowless tag matching can select the wrong one. Regroup the
+        // instance indices over the reconciled namespaces.
+        if didReconcileSourcePID {
+            MenuBarItem.assignStableInstanceIndices(to: &items, using: enumeration.windowsByID)
         }
 
         // When sourcePID resolution changes an item's identifier (e.g. from

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -2012,7 +2012,40 @@ extension MenuBarItemManager {
 
         guard snapshotIsCurrent("before control-item order enforcement") else { return }
         if !suppressAutomaticMoves {
-            await enforceControlItemOrder(controlItems: controlItems)
+            let controlItemOrderOutcome = await enforceControlItemOrder(
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("control-item order move preflight")
+                }
+            )
+            if controlItemOrderOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Control-item reorder attempt reached moveGate; scheduling authoritative recache"
+                )
+                // A pure position change does not change the window-ID set, so
+                // cacheItemsIfNeeded cannot discover it. Hand the waiter to an
+                // explicit post-settle cycle instead of leaving itemCache at
+                // the geometry observed before the divider move.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || controlItemOrderOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || controlItemOrderOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || controlItemOrderOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
+            }
         }
 
         guard !Task.isCancelled else {
@@ -2120,27 +2153,38 @@ extension MenuBarItemManager {
         }
 
         if !suppressAutomaticMoves {
-            if await relocateNewLeftmostItems(
+            let newLeftmostOutcome = await relocateNewLeftmostItems(
                 items,
                 controlItems: controlItems,
                 previousWindowIDs: previousWindowIDs,
-                recentWindowIDs: recentWindowIDs
-            ) {
-                MenuBarItemManager.diagLog.debug("Relocated new leftmost items; scheduling recache")
+                recentWindowIDs: recentWindowIDs,
+                shouldBeginMove: {
+                    snapshotIsCurrent("new-item relocation move preflight")
+                }
+            )
+            if newLeftmostOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "New-leftmost relocation attempt reached moveGate; scheduling authoritative recache"
+                )
                 // Ownership transfers to the nested recache: the waiter must not
                 // be told the cache is settled until the second cycle finishes.
                 ownsWaiter = false
                 Task { [weak self] in
                     try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
                     // Carry the caller policy across the hand-off: this recache
-                    // is where the launch restore actually runs after the move.
+                    // is where the launch restore actually runs after a completed
+                    // relocation. A failed accepted attempt gets one read-and-
+                    // publish pass with movers suppressed so it cannot retry-loop.
                     await self?.cacheItemsRegardless(
                         skipRecentMoveCheck: true,
                         resolveSourcePID: resolveSourcePID,
                         reuseCachedIdentities: reuseCachedIdentities,
-                        skipSavedLayoutApply: skipSavedLayoutApply,
-                        suppressAutomaticMoves: suppressAutomaticMoves,
-                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || newLeftmostOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || newLeftmostOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || newLeftmostOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
                         bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
                         forcePersistSavedOrder: forcePersistSavedOrder,
                         waiterToken: waiterToken
@@ -2152,8 +2196,17 @@ extension MenuBarItemManager {
         guard snapshotIsCurrent("after new-item relocation check") else { return }
 
         if !suppressAutomaticMoves {
-            if await relocatePendingItems(items, controlItems: controlItems) {
-                MenuBarItemManager.diagLog.debug("Relocated pending temporarily-shown items; scheduling recache")
+            let pendingRelocationOutcome = await relocatePendingItems(
+                items,
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("pending-item relocation move preflight")
+                }
+            )
+            if pendingRelocationOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Pending-item relocation attempt reached moveGate; scheduling authoritative recache"
+                )
                 // Ownership transfers to the nested recache: the waiter must not
                 // be told the cache is settled until the second cycle finishes.
                 ownsWaiter = false
@@ -2163,9 +2216,12 @@ extension MenuBarItemManager {
                         skipRecentMoveCheck: true,
                         resolveSourcePID: resolveSourcePID,
                         reuseCachedIdentities: reuseCachedIdentities,
-                        skipSavedLayoutApply: skipSavedLayoutApply,
-                        suppressAutomaticMoves: suppressAutomaticMoves,
-                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || pendingRelocationOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || pendingRelocationOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || pendingRelocationOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
                         bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
                         forcePersistSavedOrder: forcePersistSavedOrder,
                         waiterToken: waiterToken
@@ -2232,7 +2288,10 @@ extension MenuBarItemManager {
                     controlItems: controlItems,
                     currentDisplayID: displayID,
                     bypassMoveCooldown: true,
-                    resolvedIdentitiesOnly: true
+                    resolvedIdentitiesOnly: true,
+                    shouldBegin: {
+                        snapshotIsCurrent("early saved-layout apply preflight")
+                    }
                 )
                 // Spend the one attempt only on a dispatch that happened. The
                 // flag used to be set before the call, so an apply rejected by
@@ -2286,7 +2345,10 @@ extension MenuBarItemManager {
                 ),
                 controlItems: controlItems,
                 currentDisplayID: displayID,
-                bypassMoveCooldown: bypassSavedLayoutCooldown
+                bypassMoveCooldown: bypassSavedLayoutCooldown,
+                shouldBegin: {
+                    snapshotIsCurrent("saved-layout apply preflight")
+                }
             )
             if didApplySavedLayout {
                 return
@@ -2427,7 +2489,41 @@ extension MenuBarItemManager {
         // and self-gates on every in-flight mover.
         guard snapshotIsCurrent("before notch-overflow rebalance") else { return }
         if !suppressAutomaticMoves {
-            await rebalanceNotchOverflowIfNeeded(items: items, controlItems: controlItems)
+            let notchRebalanceOutcome = await rebalanceNotchOverflowIfNeeded(
+                items: items,
+                controlItems: controlItems,
+                shouldBeginMove: {
+                    snapshotIsCurrent("notch-overflow move preflight")
+                }
+            )
+            if notchRebalanceOutcome.needsAuthoritativeRecache {
+                MenuBarItemManager.diagLog.debug(
+                    "Notch-overflow rebalance attempted item moves; scheduling authoritative recache"
+                )
+                // The cache above describes the pre-ejection geometry. Position
+                // moves keep their window IDs, so the change detector cannot
+                // discover the stale reading; explicitly hand the waiter and
+                // caller policy to a fresh post-settle cycle.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply
+                            || notchRebalanceOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressAutomaticMoves: suppressAutomaticMoves
+                            || notchRebalanceOutcome.shouldSuppressAutomaticMovesDuringRecache,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence
+                            || notchRebalanceOutcome.shouldSuppressSavedOrderPersistenceDuringRecache,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
+            }
         }
     }
 

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+ItemCache.swift
@@ -748,8 +748,13 @@ extension MenuBarItemManager {
 
     static nonisolated func shouldCountControlItemLookupFailure(
         hostUptime: Duration?,
+        suppressAutomaticMoves: Bool = false,
         grace: Duration = controlCenterRelaunchGrace
     ) -> Bool {
+        // Layout-editor refreshes are read-and-publish passes. They must not
+        // advance the recovery episode or reach its status-item rebuild and
+        // automatic-recache side effects.
+        guard !suppressAutomaticMoves else { return false }
         guard let hostUptime else { return true }
         return hostUptime >= grace
     }
@@ -880,8 +885,13 @@ extension MenuBarItemManager {
     private func uncheckedCacheItems(
         items: [MenuBarItem],
         controlItems: ControlItemPair,
-        displayID: CGDirectDisplayID?
+        displayID: CGDirectDisplayID?,
+        suppressAutomaticMoves: Bool,
+        suppressSavedOrderPersistence: Bool,
+        forcePersistSavedOrder: Bool,
+        snapshotIsCurrent: () -> Bool
     ) async {
+        guard snapshotIsCurrent() else { return }
         MenuBarItemManager.diagLog.debug("uncheckedCacheItems: processing \(items.count) items for caching")
         var context = CacheContext(controlItems: controlItems, displayID: displayID)
 
@@ -971,15 +981,23 @@ extension MenuBarItemManager {
         // Discard a pass whose divider geometry disagrees with the section's
         // logical state. Keeping the previous cache costs one cycle; accepting
         // the mixture reclassifies a whole section (#851).
-        if cacheChanged,
-           !itemCache.managedItems.isEmpty,
-           let section = await midTransitionSection(in: context)
+        if Self.shouldEvaluateSavedOrderPersistence(
+            cacheChanged: cacheChanged,
+            forcePersistSavedOrder: forcePersistSavedOrder
+        ),
+            !itemCache.managedItems.isEmpty,
+            let section = await midTransitionSection(in: context)
         {
             MenuBarItemManager.diagLog.debug(
                 "Not updating menu bar item cache: \(section.logString) is mid expand/collapse, keeping last-known-good cache"
             )
             return
         }
+
+        // `midTransitionSection` can suspend while a user move completes.
+        // Never publish or persist the observation it was validating if that
+        // move made the underlying geometry obsolete in the meantime.
+        guard snapshotIsCurrent() else { return }
 
         // The always-hidden divider is what tells always-hidden items apart
         // from hidden ones. If this cycle resolved the hidden divider but
@@ -1017,18 +1035,23 @@ extension MenuBarItemManager {
             )
         )
 
-        if recoverCollapsedHiddenSectionIfNeeded(
-            hiddenSectionHasRoom: hiddenSectionHasRoom,
-            controlItems: context.controlItems,
-            // The dividers are excluded: a rebuild that only has the two
-            // control items to place cannot strand anything on the wrong
-            // side of the one it is rebuilding.
-            managedItemCount: context.cache.managedItems.count(where: { !$0.isControlItem })
-        ) {
+        if !suppressAutomaticMoves,
+           recoverCollapsedHiddenSectionIfNeeded(
+               hiddenSectionHasRoom: hiddenSectionHasRoom,
+               controlItems: context.controlItems,
+               // The dividers are excluded: a rebuild that only has the two
+               // control items to place cannot strand anything on the wrong
+               // side of the one it is rebuilding.
+               managedItemCount: context.cache.managedItems.count(where: { !$0.isControlItem })
+           )
+        {
             return
         }
 
-        guard cacheChanged else {
+        guard Self.shouldEvaluateSavedOrderPersistence(
+            cacheChanged: cacheChanged,
+            forcePersistSavedOrder: forcePersistSavedOrder
+        ) else {
             MenuBarItemManager.diagLog.debug("Not updating menu bar item cache, as items haven't changed")
             // Still an observed cycle: the settling stability check needs
             // exactly these stable, no-op reads to count toward its early
@@ -1043,11 +1066,17 @@ extension MenuBarItemManager {
         // produced the standing cache and this one (#958).
         let previousCacheDisplayID = itemCache.displayID
 
-        itemCache = context.cache
+        if cacheChanged {
+            itemCache = context.cache
 
-        // Remember what the resolved items are called, so the next launch can
-        // label them before its own source-PID scan lands (#956).
-        MenuBarItemNameMemory.remember(itemCache.managedItems)
+            // Remember what the resolved items are called, so the next launch
+            // can label them before its own source-PID scan lands (#956).
+            MenuBarItemNameMemory.remember(itemCache.managedItems)
+        } else {
+            MenuBarItemManager.diagLog.debug(
+                "Menu bar item cache is unchanged; evaluating saved-order persistence for a validated Layout-editor move"
+            )
+        }
 
         // Reset isRestoringItemOrder if it's been stuck for too long (10 seconds).
         // This prevents stale flags from blocking saves after user manual moves.
@@ -1090,7 +1119,8 @@ extension MenuBarItemManager {
         // wreckage, not a layout anyone chose. Recording it hands the next
         // pass a target it just moved, which is how a failed apply turns
         // into a bar that drifts a little further on every retry (#900).
-        if context.controlItems.canRepositionControlItems,
+        if !suppressSavedOrderPersistence,
+           context.controlItems.canRepositionControlItems,
            LayoutSolver.shouldPersistSavedOrder(
                LayoutSolver.SavedOrderGate(
                    isRestoringItemOrder: isRestoringItemOrder,
@@ -1147,6 +1177,10 @@ extension MenuBarItemManager {
             } else {
                 saveSectionOrder(from: context.cache)
             }
+        } else if suppressSavedOrderPersistence {
+            MenuBarItemManager.diagLog.warning(
+                "Skipping saveSectionOrder; this cache refresh follows a failed automatic move attempt"
+            )
         } else if !context.controlItems.canRepositionControlItems {
             MenuBarItemManager.diagLog.warning(
                 "Skipping saveSectionOrder; control items resolved only by provisional AX-frame correlation"
@@ -1201,8 +1235,21 @@ extension MenuBarItemManager {
                 "Skipping saveSectionOrder; the last bulk apply left planned moves unenacted, so the current arrangement is partial"
             )
         }
-        MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
+        if cacheChanged {
+            MenuBarItemManager.diagLog.debug("Updated menu bar item cache: visible=\(context.cache[.visible].count), hidden=\(context.cache[.hidden].count), alwaysHidden=\(context.cache[.alwaysHidden].count)")
+        }
         completedCacheCycles += 1
+    }
+
+    /// Whether a completed cache read must continue through the saved-order
+    /// persistence gates. A validated Layout-editor move may already have
+    /// published its settled geometry during validation, so its final refresh
+    /// must not stop merely because the cache value is identical.
+    static nonisolated func shouldEvaluateSavedOrderPersistence(
+        cacheChanged: Bool,
+        forcePersistSavedOrder: Bool
+    ) -> Bool {
+        cacheChanged || forcePersistSavedOrder
     }
 
     /// Rebuilds the hidden divider after repeated, authoritative evidence
@@ -1501,12 +1548,17 @@ extension MenuBarItemManager {
         _ currentItemWindowIDs: [CGWindowID]? = nil,
         skipRecentMoveCheck: Bool = false,
         resolveSourcePID: Bool = true,
+        reuseCachedIdentities: Bool = false,
         skipSavedLayoutApply: Bool = false,
+        suppressAutomaticMoves: Bool = false,
+        suppressSavedOrderPersistence: Bool = false,
         bypassSavedLayoutCooldown: Bool = false,
-        waiterToken: Int? = nil
+        forcePersistSavedOrder: Bool = false,
+        waiterToken: Int? = nil,
+        cacheAttempt: CacheAttempt? = nil
     ) async {
         MenuBarItemManager.diagLog.debug(
-            "cacheItemsRegardless: entering (skipRecentMoveCheck=\(skipRecentMoveCheck), hasCurrentItemWindowIDs=\(currentItemWindowIDs != nil), resolveSourcePID=\(resolveSourcePID), skipSavedLayoutApply=\(skipSavedLayoutApply), bypassSavedLayoutCooldown=\(bypassSavedLayoutCooldown))"
+            "cacheItemsRegardless: entering (skipRecentMoveCheck=\(skipRecentMoveCheck), hasCurrentItemWindowIDs=\(currentItemWindowIDs != nil), resolveSourcePID=\(resolveSourcePID), reuseCachedIdentities=\(reuseCachedIdentities), skipSavedLayoutApply=\(skipSavedLayoutApply), suppressAutomaticMoves=\(suppressAutomaticMoves), suppressSavedOrderPersistence=\(suppressSavedOrderPersistence), bypassSavedLayoutCooldown=\(bypassSavedLayoutCooldown), forcePersistSavedOrder=\(forcePersistSavedOrder))"
         )
 
         guard skipRecentMoveCheck || !lastMoveOperationOccurred(within: .seconds(1)) else {
@@ -1527,6 +1579,28 @@ extension MenuBarItemManager {
             return
         }
         defer { Task { await cacheGate.end() } }
+
+        // Capture this only after the gate is ours. A cycle that was already
+        // in progress when this call arrived must not make an editor refresh
+        // look successful after this call itself was dropped.
+        let completedCyclesAtGateEntry = completedCacheCycles
+        let moveTimestampAtGateEntry = lastMoveOperationTimestamp
+        func snapshotIsCurrent(_ stage: String) -> Bool {
+            guard lastMoveOperationTimestamp == moveTimestampAtGateEntry else {
+                MenuBarItemManager.diagLog.debug(
+                    "cacheItemsRegardless: discarding stale snapshot at \(stage) because an item moved during this pass"
+                )
+                return false
+            }
+            return true
+        }
+        defer {
+            cacheAttempt?.recordCompletion(
+                cyclesAtEntry: completedCyclesAtGateEntry,
+                cyclesAtExit: completedCacheCycles,
+                snapshotRemainedCurrent: lastMoveOperationTimestamp == moveTimestampAtGateEntry
+            )
+        }
 
         // Ownership of the waiter (if any) defaults to this call. Some
         // paths below (relocation hand-offs) hand ownership to a nested
@@ -1579,6 +1653,17 @@ extension MenuBarItemManager {
             }
         }
 
+        // Layout-editor reconciliation only needs fresh geometry. Reuse a
+        // confirmed identity for the same live window so that its fast cache
+        // pass can skip the occasionally slow AX source-PID scan without
+        // turning every icon into a new Control Center placeholder.
+        if reuseCachedIdentities {
+            items = Self.reusingCachedIdentities(
+                in: items,
+                from: itemCache.managedItems
+            )
+        }
+
         MenuBarItemManager.diagLog.debug("cacheItemsRegardless: getMenuBarItems returned \(items.count) items")
 
         // Drop System Status Item Clone windows before any downstream
@@ -1625,6 +1710,12 @@ extension MenuBarItemManager {
             )
             return
         }
+
+        // Enumeration is the slow portion of this pass. If any move landed
+        // while it was suspended, everything below was computed from the old
+        // bar and must be read-discard: do not update continuity ledgers,
+        // publish cache state, restore layout, or launch an automatic move.
+        guard snapshotIsCurrent("after item enumeration") else { return }
 
         // Recorded only after clones and ghost windows are dropped, so their
         // throwaway windowIDs never enter the continuity history.
@@ -1748,6 +1839,7 @@ extension MenuBarItemManager {
             self.pruneMoveOperationTimeouts(keeping: Set(items.map(\.tag)))
             self.pruneClickOperationTimeouts(keeping: Set(items.map(\.tag)))
         }
+        guard snapshotIsCurrent("after cache pruning") else { return }
 
         // Obtain window IDs from the actual ControlItem objects so the
         // fallback lookup in ControlItemPair can match by window ID when
@@ -1769,6 +1861,7 @@ extension MenuBarItemManager {
             hiddenControlItemWindowID: hiddenControlItemWID,
             alwaysHiddenControlItemWindowID: alwaysHiddenControlItemWID
         ) else {
+            guard snapshotIsCurrent("before control-item recovery") else { return }
             // Recovery path (#754): a failed lookup here used to wipe
             // itemCache and commit the just-fetched window-ID snapshot to
             // the change detector, which together made the failure
@@ -1785,21 +1878,28 @@ extension MenuBarItemManager {
             // gone (e.g. their windowNumber no longer matches any
             // enumerated CG window ID), not that this one cycle raced a
             // transient WindowServer update.
-            if Self.resetControlItemLookupEpisodeIfHostChanged(
-                previous: lastObservedControlCenterGeneration,
-                current: observedControlCenterGeneration,
-                failureStreak: &controlItemLookupFailureStreak,
-                alreadyRebuilt: &didRebuildControlItemsForCurrentFailureEpisode
-            ) {
+            if !suppressAutomaticMoves,
+               Self.resetControlItemLookupEpisodeIfHostChanged(
+                   previous: lastObservedControlCenterGeneration,
+                   current: observedControlCenterGeneration,
+                   failureStreak: &controlItemLookupFailureStreak,
+                   alreadyRebuilt: &didRebuildControlItemsForCurrentFailureEpisode
+               )
+            {
                 lastControlItemLookupFailureAt = nil
                 lastObservedControlCenterGeneration = observedControlCenterGeneration
             }
             let hostUptime = Self.controlCenterUptime(
                 generation: observedControlCenterGeneration
             )
-            guard Self.shouldCountControlItemLookupFailure(hostUptime: hostUptime) else {
+            guard Self.shouldCountControlItemLookupFailure(
+                hostUptime: hostUptime,
+                suppressAutomaticMoves: suppressAutomaticMoves
+            ) else {
                 MenuBarItemManager.diagLog.info(
-                    "cacheItemsRegardless: divider lookup failed \(hostUptime.map { "\(Int($0.milliseconds / 1000)) s" } ?? "?") after Control Center launched; waiting for re-hosting to finish"
+                    suppressAutomaticMoves
+                        ? "cacheItemsRegardless: Missing control item during Layout-editor refresh; not advancing recovery or scheduling an automatic recache. Items remaining: \(items.count)"
+                        : "cacheItemsRegardless: Missing control item for hidden section \(hostUptime.map { "\(Int($0.milliseconds / 1000)) s" } ?? "?") after Control Center launched; not counting it toward a rebuild while the bar is being re-hosted. Items remaining: \(items.count)"
                 )
                 await MainActor.run {
                     self.areControlItemsMissing = true
@@ -1855,6 +1955,7 @@ extension MenuBarItemManager {
         await MainActor.run {
             self.areControlItemsMissing = false
         }
+        guard snapshotIsCurrent("after control-item discovery") else { return }
 
         MenuBarItemManager.diagLog.debug("cacheItemsRegardless: found control items, hidden windowID=\(controlItems.hidden.windowID), alwaysHidden=\(controlItems.alwaysHidden.map { "\($0.windowID)" } ?? "nil")")
 
@@ -1868,7 +1969,7 @@ extension MenuBarItemManager {
         // a provisional correlation says nothing either way, the same rule
         // the parked-divider streak applies — and a disabled section's
         // absent divider is intentional, not a loss to recover from.
-        if controlItems.canRepositionControlItems {
+        if !suppressAutomaticMoves, controlItems.canRepositionControlItems {
             if appState?.settings.advanced.enableAlwaysHiddenSection == true {
                 if controlItems.alwaysHidden == nil {
                     missingAlwaysHiddenDividerStreak += 1
@@ -1909,12 +2010,16 @@ extension MenuBarItemManager {
             return
         }
 
-        await enforceControlItemOrder(controlItems: controlItems)
+        guard snapshotIsCurrent("before control-item order enforcement") else { return }
+        if !suppressAutomaticMoves {
+            await enforceControlItemOrder(controlItems: controlItems)
+        }
 
         guard !Task.isCancelled else {
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: cancelled before relocateNewLeftmostItems")
             return
         }
+        guard snapshotIsCurrent("after control-item order enforcement") else { return }
 
         // App-relaunch detection: uniqueIdentifier is namespace:title
         // (windowID-independent and stable across restarts), so a
@@ -1944,7 +2049,8 @@ extension MenuBarItemManager {
         // determined (transient bounds during in-flight moves) fall
         // through to the drop path, preserving the original
         // conservative behaviour for ambiguous cases.
-        if let activeLayout = activeProfileLayout,
+        if !suppressAutomaticMoves,
+           let activeLayout = activeProfileLayout,
            !activeProfileItemIdentifiers.isEmpty,
            !previousWindowIDs.isEmpty
         {
@@ -2013,55 +2119,81 @@ extension MenuBarItemManager {
             }
         }
 
-        if await relocateNewLeftmostItems(
-            items,
-            controlItems: controlItems,
-            previousWindowIDs: previousWindowIDs,
-            recentWindowIDs: recentWindowIDs
-        ) {
-            MenuBarItemManager.diagLog.debug("Relocated new leftmost items; scheduling recache")
-            // Ownership transfers to the nested recache: the waiter must not
-            // be told the cache is settled until the second cycle finishes.
-            ownsWaiter = false
-            Task { [weak self] in
-                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                // Carry the bypass across the hand-off: this recache is where the
-                // launch restore actually runs, and the move it is retrying behind
-                // was stamped by the relocation just above.
-                await self?.cacheItemsRegardless(
-                    skipRecentMoveCheck: true,
-                    bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
-                    waiterToken: waiterToken
-                )
+        if !suppressAutomaticMoves {
+            if await relocateNewLeftmostItems(
+                items,
+                controlItems: controlItems,
+                previousWindowIDs: previousWindowIDs,
+                recentWindowIDs: recentWindowIDs
+            ) {
+                MenuBarItemManager.diagLog.debug("Relocated new leftmost items; scheduling recache")
+                // Ownership transfers to the nested recache: the waiter must not
+                // be told the cache is settled until the second cycle finishes.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    // Carry the caller policy across the hand-off: this recache
+                    // is where the launch restore actually runs after the move.
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply,
+                        suppressAutomaticMoves: suppressAutomaticMoves,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
             }
-            return
         }
+        guard snapshotIsCurrent("after new-item relocation check") else { return }
 
-        if await relocatePendingItems(items, controlItems: controlItems) {
-            MenuBarItemManager.diagLog.debug("Relocated pending temporarily-shown items; scheduling recache")
-            // Ownership transfers to the nested recache: the waiter must not
-            // be told the cache is settled until the second cycle finishes.
-            ownsWaiter = false
-            Task { [weak self] in
-                try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
-                await self?.cacheItemsRegardless(
-                    skipRecentMoveCheck: true,
-                    bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
-                    waiterToken: waiterToken
-                )
+        if !suppressAutomaticMoves {
+            if await relocatePendingItems(items, controlItems: controlItems) {
+                MenuBarItemManager.diagLog.debug("Relocated pending temporarily-shown items; scheduling recache")
+                // Ownership transfers to the nested recache: the waiter must not
+                // be told the cache is settled until the second cycle finishes.
+                ownsWaiter = false
+                Task { [weak self] in
+                    try? await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+                    await self?.cacheItemsRegardless(
+                        skipRecentMoveCheck: true,
+                        resolveSourcePID: resolveSourcePID,
+                        reuseCachedIdentities: reuseCachedIdentities,
+                        skipSavedLayoutApply: skipSavedLayoutApply,
+                        suppressAutomaticMoves: suppressAutomaticMoves,
+                        suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                        bypassSavedLayoutCooldown: bypassSavedLayoutCooldown,
+                        forcePersistSavedOrder: forcePersistSavedOrder,
+                        waiterToken: waiterToken
+                    )
+                }
+                return
             }
-            return
         }
+        guard snapshotIsCurrent("after pending-item relocation check") else { return }
 
         // Skip all restore logic during the startup settling period.
         // The settling period prevents cascading icon moves when many apps
         // load at login or restart in quick succession (app update checks).
         // A final cacheItemsRegardless() after the period ends handles restore.
         guard !isInStartupSettling else {
-            await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
+            await uncheckedCacheItems(
+                items: items,
+                controlItems: controlItems,
+                displayID: displayID,
+                suppressAutomaticMoves: suppressAutomaticMoves,
+                suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+                forcePersistSavedOrder: forcePersistSavedOrder,
+                snapshotIsCurrent: { snapshotIsCurrent("startup cache publish") }
+            )
+            guard snapshotIsCurrent("after startup cache publish") else { return }
             // Absorb items that appear during settling into the profile
             // snapshot so they aren't treated as late arrivals afterwards.
-            if activeProfileLayout != nil {
+            if !suppressAutomaticMoves, activeProfileLayout != nil {
                 for item in items where !item.isControlItem {
                     profileSortedItemIdentifiers.insert(item.uniqueIdentifier)
                 }
@@ -2085,7 +2217,11 @@ extension MenuBarItemManager {
             // then the entire reorder as a visible sequence. Cascading
             // re-applies, which is what the cooldown guards against, cannot
             // happen here: this runs once per settling period.
-            if !skipSavedLayoutApply, !didAttemptEarlySavedLayoutApply {
+            if !skipSavedLayoutApply,
+               !suppressAutomaticMoves,
+               lastMoveOperationTimestamp == moveTimestampAtGateEntry,
+               !didAttemptEarlySavedLayoutApply
+            {
                 let didApply = await applySavedLayout(
                     items: items,
                     previousCycle: PreviousCacheCycle(
@@ -2108,6 +2244,12 @@ extension MenuBarItemManager {
                     )
                     return
                 }
+            } else if !skipSavedLayoutApply,
+                      lastMoveOperationTimestamp != moveTimestampAtGateEntry
+            {
+                MenuBarItemManager.diagLog.debug(
+                    "cacheItemsRegardless: skipping early saved-layout apply because an item moved during this cache pass"
+                )
             }
 
             MenuBarItemManager.diagLog.debug("cacheItemsRegardless: startup settling active, skipping restore")
@@ -2131,7 +2273,10 @@ extension MenuBarItemManager {
         // even when the visible item count is stable),
         // windowIDsChanged fires on every iteration and the bar enters
         // an infinite no-op apply loop.
-        if !skipSavedLayoutApply {
+        if !skipSavedLayoutApply,
+           !suppressAutomaticMoves,
+           lastMoveOperationTimestamp == moveTimestampAtGateEntry
+        {
             let didApplySavedLayout = await applySavedLayout(
                 items: items,
                 previousCycle: PreviousCacheCycle(
@@ -2146,9 +2291,25 @@ extension MenuBarItemManager {
             if didApplySavedLayout {
                 return
             }
+        } else if !skipSavedLayoutApply,
+                  lastMoveOperationTimestamp != moveTimestampAtGateEntry
+        {
+            MenuBarItemManager.diagLog.debug(
+                "cacheItemsRegardless: skipping saved-layout apply because an item moved during this cache pass"
+            )
         }
 
-        await uncheckedCacheItems(items: items, controlItems: controlItems, displayID: displayID)
+        guard snapshotIsCurrent("before cache publish") else { return }
+        await uncheckedCacheItems(
+            items: items,
+            controlItems: controlItems,
+            displayID: displayID,
+            suppressAutomaticMoves: suppressAutomaticMoves,
+            suppressSavedOrderPersistence: suppressSavedOrderPersistence,
+            forcePersistSavedOrder: forcePersistSavedOrder,
+            snapshotIsCurrent: { snapshotIsCurrent("cache publish") }
+        )
+        guard snapshotIsCurrent("after cache publish") else { return }
 
         // Persist the resolved (possibly corrected) sourcePIDs for the next
         // cache cycle so transient resolution errors can be detected.
@@ -2231,7 +2392,8 @@ extension MenuBarItemManager {
         }
 
         // Detect late-arriving items that belong to the active profile.
-        if activeProfileLayout != nil,
+        if !suppressAutomaticMoves,
+           activeProfileLayout != nil,
            !activeProfileItemIdentifiers.isEmpty
         {
             await MainActor.run {
@@ -2263,7 +2425,89 @@ extension MenuBarItemManager {
         // Keep the visible row inside the beside-notch budget regardless of
         // whether a profile is active. Runs last so it sees the settled cache,
         // and self-gates on every in-flight mover.
-        await rebalanceNotchOverflowIfNeeded(items: items, controlItems: controlItems)
+        guard snapshotIsCurrent("before notch-overflow rebalance") else { return }
+        if !suppressAutomaticMoves {
+            await rebalanceNotchOverflowIfNeeded(items: items, controlItems: controlItems)
+        }
+    }
+
+    /// Returns a fresh-geometry reading with previously confirmed identities
+    /// restored for windows that are demonstrably the same live status item.
+    static nonisolated func reusingCachedIdentities(
+        in freshItems: [MenuBarItem],
+        from cachedItems: [MenuBarItem]
+    ) -> [MenuBarItem] {
+        let cachedByWindowID = Dictionary(
+            cachedItems.lazy.map { ($0.windowID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        return freshItems.map { freshItem in
+            guard freshItem.sourcePID == nil,
+                  let cachedItem = cachedByWindowID[freshItem.windowID],
+                  let cachedSourcePID = cachedItem.sourcePID,
+                  cachedItem.ownerPID == freshItem.ownerPID,
+                  cachedItem.title == freshItem.title
+            else {
+                return freshItem
+            }
+
+            return MenuBarItem(
+                tag: cachedItem.tag,
+                windowID: freshItem.windowID,
+                ownerPID: freshItem.ownerPID,
+                sourcePID: cachedSourcePID,
+                bounds: freshItem.bounds,
+                title: freshItem.title,
+                isOnScreen: freshItem.isOnScreen
+            )
+        }
+    }
+
+    /// Performs the authoritative cache pass required before the Layout
+    /// editor may thaw its source and destination rows after a user move.
+    ///
+    /// Ordinary background refreshes deliberately drop when ``CacheGate`` is
+    /// busy. An editor move cannot: thawing from the old cache duplicates or
+    /// removes the transferred icon until a later timer happens to repair it.
+    /// Retry discrete attempts so the gate is released between each one and
+    /// nested relocation recaches cannot deadlock this caller.
+    func refreshCacheAfterLayoutEditorMove(
+        timeout: Duration = .seconds(30),
+        forcePersistSavedOrder: Bool = false
+    ) async -> Bool {
+        let deadline = ContinuousClock.now + timeout
+
+        while !Task.isCancelled {
+            let attempt = CacheAttempt()
+            await cacheItemsRegardless(
+                skipRecentMoveCheck: true,
+                resolveSourcePID: false,
+                reuseCachedIdentities: true,
+                skipSavedLayoutApply: true,
+                suppressAutomaticMoves: true,
+                forcePersistSavedOrder: forcePersistSavedOrder,
+                cacheAttempt: attempt
+            )
+            if attempt.didCompleteCycle {
+                return true
+            }
+
+            guard ContinuousClock.now < deadline else {
+                MenuBarItemManager.diagLog.error(
+                    "Layout editor cache refresh timed out before an authoritative cycle completed"
+                )
+                return false
+            }
+
+            do {
+                try await Task.sleep(for: MenuBarItemManager.uiSettleDelay)
+            } catch {
+                return false
+            }
+        }
+
+        return false
     }
 
     /// Caches the current menu bar items, if the items have changed

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1463,7 +1463,6 @@ extension MenuBarItemManager {
             )
         }
 
-
         // Divider-order gate (#1027). The room gate above catches dividers
         // collapsed onto one coordinate; this catches them drifted into
         // foreign sections, which leaves the same room between them and so

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -11,6 +11,32 @@ import Cocoa
 // MARK: Layout Reset
 
 extension MenuBarItemManager {
+    /// Tracks which move timestamp belongs to a multi-item automatic apply.
+    ///
+    /// Before the first move, the cache snapshot's preflight owns the verdict.
+    /// After each move releases `moveGate`, the batch adopts the timestamp seen
+    /// while it still owned that gate. The next item therefore accepts changes
+    /// made by this batch and rejects a user move that lands between items.
+    nonisolated struct BatchMovePreflightState {
+        private var didFinishMove = false
+        private var expectedTimestamp: ContinuousClock.Instant?
+
+        func shouldBeginMove(
+            currentTimestamp: ContinuousClock.Instant?,
+            initialPreflight: () -> Bool
+        ) -> Bool {
+            guard didFinishMove else {
+                return initialPreflight()
+            }
+            return currentTimestamp == expectedTimestamp
+        }
+
+        mutating func recordMoveGateExit(timestamp: ContinuousClock.Instant?) {
+            didFinishMove = true
+            expectedTimestamp = timestamp
+        }
+    }
+
     /// Errors that can occur during a layout reset.
     enum LayoutResetError: LocalizedError {
         case missingAppState
@@ -109,7 +135,7 @@ extension MenuBarItemManager {
                     }
                     MenuBarItemManager.diagLog.info("Recovered hidden section control item after re-enabling always-hidden section")
                     prepareLayoutStateForReset()
-                    await enforceControlItemOrder(controlItems: retryControlItems)
+                    _ = await enforceControlItemOrder(controlItems: retryControlItems)
                     return try await resetLayoutWithControlItems(
                         controlItems: retryControlItems,
                         items: items,
@@ -138,7 +164,7 @@ extension MenuBarItemManager {
         // authoritative; a provisional lookup must leave the saved layout intact.
         prepareLayoutStateForReset()
 
-        await enforceControlItemOrder(controlItems: controlItems)
+        _ = await enforceControlItemOrder(controlItems: controlItems)
 
         return try await resetLayoutWithControlItems(
             controlItems: controlItems,
@@ -796,7 +822,8 @@ extension MenuBarItemManager {
         _ spec: ProfileLayoutSpec,
         source: ApplySource = .profile,
         automatic: Bool = false,
-        duringSettling: Bool = false
+        duringSettling: Bool = false,
+        shouldBegin: (@MainActor () -> Bool)? = nil
     ) async {
         let pinnedHidden = spec.pinnedHidden
         let pinnedAlwaysHidden = spec.pinnedAlwaysHidden
@@ -870,6 +897,12 @@ extension MenuBarItemManager {
         // during the settling wait (a newer apply has replaced us via
         // applyProfile's layoutTask?.cancel()).
         if Task.isCancelled {
+            return
+        }
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: skipping automatic apply superseded during its idle wait"
+            )
             return
         }
 
@@ -946,6 +979,14 @@ extension MenuBarItemManager {
         // and reshuffling the bar. This fetch is independent of the cache
         // path, so it needs its own filter.
         items.removeAll(where: \.isSystemClone)
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded during item discovery"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
 
         // Skip the bulk apply while the majority of items have no resolved
         // sourcePID — uniqueIdentifier (used to match items against
@@ -964,7 +1005,16 @@ extension MenuBarItemManager {
         // Never drag items while a menu bar item menu is tracking — a synthetic
         // Cmd-drag would tear down the user's interaction (Wi-Fi picker, input
         // methods). State is unwound so a subsequent apply can retry cleanly.
-        if await isAnyMenuBarItemMenuOpen() {
+        let menuIsOpen = await isAnyMenuBarItemMenuOpen()
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded during its menu check"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
+        if menuIsOpen {
             MenuBarItemManager.diagLog.info("applyProfileLayout: skipping, a menu bar item menu is open")
             clearProfileState(source: source, items: items)
             return
@@ -1384,6 +1434,36 @@ extension MenuBarItemManager {
             return
         }
 
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: abandoning automatic apply superseded while planning"
+            )
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+            return
+        }
+
+        // Each actual move validates the expected timestamp only after it
+        // acquires moveGate. After an owned attempt, the callback advances the
+        // expectation while the gate is still held. A user move that wins the
+        // gate during an inter-item sleep therefore invalidates the next move,
+        // while this batch's own timestamp updates remain accepted.
+        var batchMovePreflight = BatchMovePreflightState()
+        func shouldBeginBatchMove() -> Bool {
+            batchMovePreflight.shouldBeginMove(
+                currentTimestamp: lastMoveOperationTimestamp,
+                initialPreflight: {
+                    shouldBegin?() ?? true
+                }
+            )
+        }
+        func didFinishBatchMove() {
+            batchMovePreflight.recordMoveGateExit(
+                timestamp: lastMoveOperationTimestamp
+            )
+        }
+
+
         // Divider-order gate (#1027). The room gate above catches dividers
         // collapsed onto one coordinate; this catches them drifted into
         // foreign sections, which leaves the same room between them and so
@@ -1490,6 +1570,17 @@ extension MenuBarItemManager {
                 )
             }
             recordBulkApplyOutcome(unenactedMoveCount: unenactedMoveCount)
+            clearProfileState(source: source, items: items)
+            scheduleDeferredCacheRefresh()
+        }
+
+        /// A manual move that wins moveGate supersedes an automatic plan; it
+        /// is not a failed batch and must not back off an item or trip the
+        /// automatic-apply circuit breaker.
+        func finishSupersededApply(items: [MenuBarItem]) {
+            MenuBarItemManager.diagLog.info(
+                "applyProfileLayout: user move superseded the automatic plan; leaving the user's arrangement authoritative"
+            )
             clearProfileState(source: source, items: items)
             scheduleDeferredCacheRefresh()
         }
@@ -1664,6 +1755,10 @@ extension MenuBarItemManager {
             )
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var allFreshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &allFreshItemsCopy,
@@ -1785,11 +1880,21 @@ extension MenuBarItemManager {
                             MenuBarItemManager.diagLog.debug("Profile layout: moving H_ctrl → \(dest.logString)")
                             didAttemptHCtrl = true
                             do {
-                                try await move(item: hItem, to: dest, skipInputPause: true)
+                                try await move(
+                                    item: hItem,
+                                    to: dest,
+                                    skipInputPause: true,
+                                    shouldBegin: shouldBeginBatchMove,
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                )
                                 movedCount += 1
                                 failureLedger.recordSuccess(for: hItem)
                                 try? await Task.sleep(for: .milliseconds(200))
                             } catch {
+                                if case EventError.moveSuperseded = error {
+                                    finishSupersededApply(items: allFreshItems)
+                                    return
+                                }
                                 unenactedMoveCount += 1
                                 // A move cancelled by a newer apply says nothing
                                 // about the divider, and recording it would earn
@@ -1897,7 +2002,13 @@ extension MenuBarItemManager {
                         "Profile layout: moving \(item.logString) → \(dest.logString) to fix the H_ctrl boundary"
                     )
                     do {
-                        try await move(item: item, to: dest, skipInputPause: true)
+                        try await move(
+                            item: item,
+                            to: dest,
+                            skipInputPause: true,
+                            shouldBegin: shouldBeginBatchMove,
+                            didFinishWhileHoldingGate: didFinishBatchMove
+                        )
                         movedCount += 1
                         didCrossHiddenBoundary = true
                         failureLedger.recordSuccess(for: item)
@@ -1908,6 +2019,10 @@ extension MenuBarItemManager {
                         // the previous arrangement says it should.
                         try? await Task.sleep(for: .milliseconds(200))
                     } catch {
+                        if case EventError.moveSuperseded = error {
+                            finishSupersededApply(items: allFreshItems)
+                            return
+                        }
                         unenactedMoveCount += 1
                         // A move cancelled by a newer apply says nothing about
                         // the item, and recording it would earn a backoff
@@ -1936,6 +2051,10 @@ extension MenuBarItemManager {
         // (and its per-item fallback) is still warranted.
         if didAttemptHCtrl || didCrossHiddenBoundary {
             var postMoveItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: postMoveItems)
+                return
+            }
             postMoveItems.removeAll(where: \.isSystemClone)
             var postMoveItemsCopy = postMoveItems
             if let postMoveControl = ControlItemPair(
@@ -2015,6 +2134,10 @@ extension MenuBarItemManager {
             )
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var allFreshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &allFreshItemsCopy,
@@ -2096,10 +2219,20 @@ extension MenuBarItemManager {
             if let dest, !Task.isCancelled {
                 MenuBarItemManager.diagLog.debug("Profile layout: moving AH_ctrl → \(dest.logString)")
                 do {
-                    try await move(item: ahItem, to: dest, skipInputPause: true)
+                    try await move(
+                        item: ahItem,
+                        to: dest,
+                        skipInputPause: true,
+                        shouldBegin: shouldBeginBatchMove,
+                        didFinishWhileHoldingGate: didFinishBatchMove
+                    )
                     movedCount += 1
                     try? await Task.sleep(for: .milliseconds(200))
                 } catch {
+                    if case EventError.moveSuperseded = error {
+                        finishSupersededApply(items: allFreshItems)
+                        return
+                    }
                     unenactedMoveCount += 1
                     MenuBarItemManager.diagLog.error("Profile layout: failed to move AH_ctrl: \(error)")
                 }
@@ -2123,6 +2256,10 @@ extension MenuBarItemManager {
             // the LCS pass below only re-sorts concealed sections when
             // enforceConcealedSectionOrder is on, and it defaults off.
             let freshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: freshItems)
+                return
+            }
             var freshItemsCopy = freshItems
             if let freshControl = ControlItemPair(
                 items: &freshItemsCopy,
@@ -2192,10 +2329,20 @@ extension MenuBarItemManager {
                             let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
                         else { continue }
                         do {
-                            try await move(item: item, to: .leftOfItem(ahItem), skipInputPause: true)
+                            try await move(
+                                item: item,
+                                to: .leftOfItem(ahItem),
+                                skipInputPause: true,
+                                shouldBegin: shouldBeginBatchMove,
+                                didFinishWhileHoldingGate: didFinishBatchMove
+                            )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
                         } catch {
+                            if case EventError.moveSuperseded = error {
+                                finishSupersededApply(items: freshItems)
+                                return
+                            }
                             unenactedMoveCount += 1
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to AH failed for \(uid): \(error)"
@@ -2222,10 +2369,20 @@ extension MenuBarItemManager {
                             let item = freshItems.first(where: { $0.uniqueIdentifier == uid && isProfileItem($0) })
                         else { continue }
                         do {
-                            try await move(item: item, to: .rightOfItem(ahItem), skipInputPause: true)
+                            try await move(
+                                item: item,
+                                to: .rightOfItem(ahItem),
+                                skipInputPause: true,
+                                shouldBegin: shouldBeginBatchMove,
+                                didFinishWhileHoldingGate: didFinishBatchMove
+                            )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
                         } catch {
+                            if case EventError.moveSuperseded = error {
+                                finishSupersededApply(items: freshItems)
+                                return
+                            }
                             unenactedMoveCount += 1
                             MenuBarItemManager.diagLog.error(
                                 "Profile layout: per-item move to hidden failed for \(uid): \(error)"
@@ -2244,6 +2401,10 @@ extension MenuBarItemManager {
             // Re-fetch items and rebuild section assignments after
             // the control item move changed section boundaries.
             items = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: items)
+                return
+            }
             var itemsCopy2 = items
             guard let freshControl = ControlItemPair(
                 items: &itemsCopy2,
@@ -2359,6 +2520,10 @@ extension MenuBarItemManager {
             }
 
             let allFreshItems = await MenuBarItem.getMenuBarItems(option: .activeSpace)
+            guard shouldBeginBatchMove() else {
+                finishSupersededApply(items: allFreshItems)
+                return
+            }
             var freshItemsCopy = allFreshItems
             guard let freshControl = ControlItemPair(
                 items: &freshItemsCopy,
@@ -2432,12 +2597,22 @@ extension MenuBarItemManager {
             }
 
             do {
-                try await move(item: item, to: dest, skipInputPause: true)
+                try await move(
+                    item: item,
+                    to: dest,
+                    skipInputPause: true,
+                    shouldBegin: shouldBeginBatchMove,
+                    didFinishWhileHoldingGate: didFinishBatchMove
+                )
                 movedCount += 1
                 consecutiveMoveFailures = 0
                 failureLedger.recordSuccess(for: item)
                 try? await Task.sleep(for: .milliseconds(200))
             } catch {
+                if case EventError.moveSuperseded = error {
+                    finishSupersededApply(items: allFreshItems)
+                    return
+                }
                 // The loop head's rule extends to a move that was in flight
                 // when the cancellation arrived: the failure is the newer
                 // apply's takeover, not the item's. Recording it would earn
@@ -3232,8 +3407,13 @@ extension MenuBarItemManager {
         controlItems: ControlItemPair,
         currentDisplayID: CGDirectDisplayID? = nil,
         bypassMoveCooldown: Bool = false,
-        resolvedIdentitiesOnly: Bool = false
+        resolvedIdentitiesOnly: Bool = false,
+        shouldBegin: (@MainActor () -> Bool)? = nil
     ) async -> Bool {
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug("applySavedLayout: skipping superseded cache snapshot")
+            return false
+        }
         // Each guard logs a distinct reason so a "Thaw stopped
         // restoring my layout" bug report can be diagnosed from the
         // first set of logs. Order is significant: the cheap state
@@ -3379,7 +3559,14 @@ extension MenuBarItemManager {
         // Never drag items while a menu bar item menu is tracking — a synthetic
         // Cmd-drag would tear down the user's interaction (Wi-Fi picker, input
         // methods). The change gate stays armed, so the next cache cycle retries.
-        if await isAnyMenuBarItemMenuOpen() {
+        let menuIsOpen = await isAnyMenuBarItemMenuOpen()
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug(
+                "applySavedLayout: skipping, a user move superseded the snapshot during the menu check"
+            )
+            return false
+        }
+        if menuIsOpen {
             MenuBarItemManager.diagLog.info("applySavedLayout: skipping, a menu bar item menu is open")
             return false
         }
@@ -3561,6 +3748,13 @@ extension MenuBarItemManager {
 
         MenuBarItemManager.diagLog.info("applySavedLayout: dispatching bulk apply (\(trigger))")
 
+        guard shouldBegin?() ?? true else {
+            MenuBarItemManager.diagLog.debug(
+                "applySavedLayout: skipping, a user move superseded the snapshot before dispatch"
+            )
+            return false
+        }
+
         // The shared body uses itemOrder as the per-section ordered
         // identifier list, which is structurally identical to
         // savedSectionOrder. Pass the saved order through unchanged.
@@ -3590,7 +3784,8 @@ extension MenuBarItemManager {
             ),
             source: .savedOrder,
             automatic: true,
-            duringSettling: resolvedIdentitiesOnly
+            duringSettling: resolvedIdentitiesOnly,
+            shouldBegin: shouldBegin
         )
         if bulkApplyCompletionGeneration != completionGenerationBeforeApply,
            lastCompletedBulkApplyUnenactedMoveCount == 0

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1883,8 +1883,13 @@ extension MenuBarItemManager {
                                     item: hItem,
                                     to: dest,
                                     skipInputPause: true,
-                                    shouldBegin: shouldBeginBatchMove,
-                                    didFinishWhileHoldingGate: didFinishBatchMove
+                                    options: .init(
+
+                                        shouldBegin: shouldBeginBatchMove,
+
+                                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                                    )
                                 )
                                 movedCount += 1
                                 failureLedger.recordSuccess(for: hItem)
@@ -2005,8 +2010,13 @@ extension MenuBarItemManager {
                             item: item,
                             to: dest,
                             skipInputPause: true,
-                            shouldBegin: shouldBeginBatchMove,
-                            didFinishWhileHoldingGate: didFinishBatchMove
+                            options: .init(
+
+                                shouldBegin: shouldBeginBatchMove,
+
+                                didFinishWhileHoldingGate: didFinishBatchMove
+
+                            )
                         )
                         movedCount += 1
                         didCrossHiddenBoundary = true
@@ -2222,8 +2232,13 @@ extension MenuBarItemManager {
                         item: ahItem,
                         to: dest,
                         skipInputPause: true,
-                        shouldBegin: shouldBeginBatchMove,
-                        didFinishWhileHoldingGate: didFinishBatchMove
+                        options: .init(
+
+                            shouldBegin: shouldBeginBatchMove,
+
+                            didFinishWhileHoldingGate: didFinishBatchMove
+
+                        )
                     )
                     movedCount += 1
                     try? await Task.sleep(for: .milliseconds(200))
@@ -2332,8 +2347,13 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .leftOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+
+                                    shouldBegin: shouldBeginBatchMove,
+
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2372,8 +2392,13 @@ extension MenuBarItemManager {
                                 item: item,
                                 to: .rightOfItem(ahItem),
                                 skipInputPause: true,
-                                shouldBegin: shouldBeginBatchMove,
-                                didFinishWhileHoldingGate: didFinishBatchMove
+                                options: .init(
+
+                                    shouldBegin: shouldBeginBatchMove,
+
+                                    didFinishWhileHoldingGate: didFinishBatchMove
+
+                                )
                             )
                             movedCount += 1
                             try? await Task.sleep(for: .milliseconds(100))
@@ -2600,8 +2625,13 @@ extension MenuBarItemManager {
                     item: item,
                     to: dest,
                     skipInputPause: true,
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+
+                        shouldBegin: shouldBeginBatchMove,
+
+                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                    )
                 )
                 movedCount += 1
                 consecutiveMoveFailures = 0

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+LayoutApply.swift
@@ -1884,11 +1884,8 @@ extension MenuBarItemManager {
                                     to: dest,
                                     skipInputPause: true,
                                     options: .init(
-
                                         shouldBegin: shouldBeginBatchMove,
-
                                         didFinishWhileHoldingGate: didFinishBatchMove
-
                                     )
                                 )
                                 movedCount += 1
@@ -2011,11 +2008,8 @@ extension MenuBarItemManager {
                             to: dest,
                             skipInputPause: true,
                             options: .init(
-
                                 shouldBegin: shouldBeginBatchMove,
-
                                 didFinishWhileHoldingGate: didFinishBatchMove
-
                             )
                         )
                         movedCount += 1
@@ -2233,11 +2227,8 @@ extension MenuBarItemManager {
                         to: dest,
                         skipInputPause: true,
                         options: .init(
-
                             shouldBegin: shouldBeginBatchMove,
-
                             didFinishWhileHoldingGate: didFinishBatchMove
-
                         )
                     )
                     movedCount += 1
@@ -2348,11 +2339,8 @@ extension MenuBarItemManager {
                                 to: .leftOfItem(ahItem),
                                 skipInputPause: true,
                                 options: .init(
-
                                     shouldBegin: shouldBeginBatchMove,
-
                                     didFinishWhileHoldingGate: didFinishBatchMove
-
                                 )
                             )
                             movedCount += 1
@@ -2393,11 +2381,8 @@ extension MenuBarItemManager {
                                 to: .rightOfItem(ahItem),
                                 skipInputPause: true,
                                 options: .init(
-
                                     shouldBegin: shouldBeginBatchMove,
-
                                     didFinishWhileHoldingGate: didFinishBatchMove
-
                                 )
                             )
                             movedCount += 1
@@ -2626,11 +2611,8 @@ extension MenuBarItemManager {
                     to: dest,
                     skipInputPause: true,
                     options: .init(
-
                         shouldBegin: shouldBeginBatchMove,
-
                         didFinishWhileHoldingGate: didFinishBatchMove
-
                     )
                 )
                 movedCount += 1

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -2277,7 +2277,6 @@ extension MenuBarItemManager {
                     return
                 }
 
-
                 let outcome = try await postMoveEvents(
                     item: item,
                     destination: destination,

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -196,6 +196,90 @@ extension MenuBarItemManager {
         return .parked
     }
 
+    /// Signals that the absolute budget shared by an entire move transaction
+    /// has been exhausted.
+    nonisolated struct MoveDeadlineExceeded: Error, Equatable {}
+
+    /// One absolute budget shared by admission, gate waiting, event transport,
+    /// layout settling, and retries. Every nested wait receives only the time
+    /// still available to the transaction.
+    nonisolated struct MoveTransactionBudget {
+        typealias Elapsed = @Sendable () -> Duration
+        typealias Sleeper = @Sendable (Duration) async throws -> Void
+
+        let limit: Duration
+        private let elapsedProvider: Elapsed
+        private let sleeper: Sleeper
+
+        init(limit: Duration) {
+            let startedAt = ContinuousClock.now
+            self.init(
+                limit: limit,
+                elapsed: { startedAt.duration(to: .now) },
+                sleeper: { try await Task.sleep(for: $0) }
+            )
+        }
+
+        init(
+            limit: Duration,
+            elapsed: @escaping Elapsed,
+            sleeper: @escaping Sleeper
+        ) {
+            self.limit = limit
+            elapsedProvider = elapsed
+            self.sleeper = sleeper
+        }
+
+        var elapsed: Duration {
+            elapsedProvider()
+        }
+
+        func remaining() throws -> Duration {
+            let value = limit - elapsed
+            guard value > .zero else {
+                throw MoveDeadlineExceeded()
+            }
+            return value
+        }
+
+        func timeout(for requested: Duration, repeating count: Int = 1) throws -> Duration {
+            let repetitions = max(1, count)
+            let value = try min(requested, remaining() / repetitions)
+            guard value > .zero else {
+                throw MoveDeadlineExceeded()
+            }
+            return value
+        }
+
+        func run<Value>(
+            maximum: Duration,
+            repeating count: Int = 1,
+            operation: (Duration) async throws -> Value
+        ) async throws -> Value {
+            let allowance = try timeout(for: maximum, repeating: count)
+            do {
+                let value = try await operation(allowance)
+                _ = try remaining()
+                return value
+            } catch {
+                if elapsed >= limit {
+                    throw MoveDeadlineExceeded()
+                }
+                throw error
+            }
+        }
+
+        func sleep(for duration: Duration) async throws {
+            let available = try remaining()
+            guard available >= duration else {
+                try await sleeper(available)
+                throw MoveDeadlineExceeded()
+            }
+            try await sleeper(duration)
+            _ = try remaining()
+        }
+    }
+
     /// Classifies a horizontal menu-bar path without consulting AppKit.
     static nonisolated func horizontalPathDisposition(
         sourceX: CGFloat,
@@ -452,6 +536,10 @@ extension MenuBarItemManager {
     /// gate; task-local ownership lets that nested move pass through safely.
     @TaskLocal private static var holdsMoveGate = false
 
+    /// Nested recovery moves inherit their parent's absolute deadline rather
+    /// than silently receiving another full transaction budget.
+    @TaskLocal private static var currentMoveBudget: MoveTransactionBudget?
+
     private static let moveGateTimeout: Duration = .seconds(15)
 
     /// User activity can defer one move without retaining the app-wide move
@@ -493,6 +581,83 @@ extension MenuBarItemManager {
         }
         try await $holdsMoveGate.withValue(true) {
             try await operation()
+        }
+    }
+
+    /// Polls until two consecutive readings agree, or the bounded poll count
+    /// is exhausted. The value and confirmation bit are returned separately
+    /// so a caller never mistakes a last, still-changing sample for settled.
+    static nonisolated func settledReading<Value: Equatable>(
+        maxPolls: Int,
+        read: () async -> Value,
+        wait: () async -> Void
+    ) async -> (value: Value, settled: Bool) {
+        var previous = await read()
+        var polls = 1
+        while polls < maxPolls {
+            await wait()
+            let current = await read()
+            polls += 1
+            if current == previous {
+                return (current, true)
+            }
+            previous = current
+        }
+        return (previous, false)
+    }
+
+    /// Waits for the exact source and destination windows to stop moving
+    /// before judging their ordinal relationship. Control Center animates bar
+    /// reflow after release, so an immediate read can reject a correct drop.
+    nonisolated func waitForLayoutToSettle(
+        item: MenuBarItem,
+        target: MenuBarItem,
+        interval: Duration = .milliseconds(25),
+        maxPolls: Int = 24
+    ) async {
+        let outcome = await Self.settledReading(
+            maxPolls: maxPolls,
+            read: {
+                [Bridging.getWindowBounds(for: item.windowID), Bridging.getWindowBounds(for: target.windowID)]
+            },
+            wait: { await self.eventSleep(for: interval) }
+        )
+        if !outcome.settled {
+            MenuBarItemManager.diagLog.debug(
+                "Layout still changing after \(maxPolls) polls while moving \(item.logString) relative to \(target.logString); verifying anyway"
+            )
+        }
+    }
+
+    /// Layout settling constrained by the transaction's absolute deadline.
+    nonisolated func waitForLayoutToSettle(
+        item: MenuBarItem,
+        target: MenuBarItem,
+        budget: MoveTransactionBudget,
+        interval: Duration = .milliseconds(25),
+        maxPolls: Int = 24
+    ) async throws {
+        var previous = [
+            Bridging.getWindowBounds(for: item.windowID),
+            Bridging.getWindowBounds(for: target.windowID),
+        ]
+        var polls = 1
+        while polls < maxPolls {
+            try await budget.sleep(for: interval)
+            let current = [
+                Bridging.getWindowBounds(for: item.windowID),
+                Bridging.getWindowBounds(for: target.windowID),
+            ]
+            polls += 1
+            if current == previous {
+                return
+            }
+            previous = current
+        }
+        if maxPolls > 1 {
+            MenuBarItemManager.diagLog.debug(
+                "Layout still changing after \(maxPolls) polls while moving \(item.logString) relative to \(target.logString); verifying anyway"
+            )
         }
     }
 
@@ -891,21 +1056,20 @@ extension MenuBarItemManager {
         item: MenuBarItem,
         destination: MoveDestination,
         on displayID: CGDirectDisplayID,
+        budget: MoveTransactionBudget,
         warpCursorAfter: Bool = true
     ) async throws -> MoveEventsOutcome {
         var acquiredSemaphore = false
         do {
-            try await eventSemaphore.wait(timeout: .milliseconds(3500))
+            try await budget.run(maximum: .milliseconds(3500)) { timeout in
+                try await eventSemaphore.wait(timeout: timeout)
+            }
             acquiredSemaphore = true
         } catch is SimpleSemaphore.TimeoutError {
-            MenuBarItemManager.diagLog.error("eventSemaphore timed out (3.5s) in postMoveEvents, retrying once")
-            do {
-                try await eventSemaphore.wait(timeout: .milliseconds(3500))
-                acquiredSemaphore = true
-            } catch is SimpleSemaphore.TimeoutError {
-                MenuBarItemManager.diagLog.error("postMoveEvents: eventSemaphore retry also timed out; giving up on \(item.logString)")
-                throw EventError.cannotComplete
-            }
+            MenuBarItemManager.diagLog.error(
+                "eventSemaphore timed out while moving \(item.logString); preserving the transaction deadline"
+            )
+            throw EventError.cannotComplete
         }
         defer {
             if acquiredSemaphore {
@@ -1019,9 +1183,6 @@ extension MenuBarItemManager {
         if ownsCursorVisibility {
             MouseHelpers.hideCursor()
         }
-        if warpIsOnScreen {
-            await eventSleep(for: .milliseconds(20))
-        }
         // Keep an off-screen teleport's stamped press at the off-screen
         // destination. Redirecting it to the notch midpoint made the real
         // status-item window visibly jump to the center before the release.
@@ -1036,6 +1197,9 @@ extension MenuBarItemManager {
                 MouseHelpers.showCursor()
             }
             lastMoveOperationTimestamp = .now
+        }
+        if warpIsOnScreen {
+            try await budget.sleep(for: .milliseconds(20))
         }
 
         // The cursor-registration wait is the final intentional await before
@@ -1113,10 +1277,11 @@ extension MenuBarItemManager {
         MenuBarItemManager.diagLog.info(
             "Move strategy: \(strategy) for \(liveItem.logString); press at (\(eventLocations.press.x),\(eventLocations.press.y)), release at (\(eventLocations.release.x),\(eventLocations.release.y))"
         )
-        let releaseGuard = makePressReleaseGuard(
+        let releaseGuard = try makePressReleaseGuard(
             for: liveItem,
             mouseUp: mouseUp,
-            eventPID: eventPID
+            eventPID: eventPID,
+            budget: budget
         )
 
         // From here the press may be down; a deadline guard posts a matching
@@ -1133,19 +1298,24 @@ extension MenuBarItemManager {
                     openingEvent: mouseDown,
                     releaseGuard: releaseGuard,
                     destination: destination,
-                    on: displayID
+                    on: displayID,
+                    budget: budget
                 )
             } else {
-                try await scrombleEvent(
-                    mouseDown,
-                    item: liveItem,
-                    timeout: timeout
-                )
-                itemOrigin = try await waitForMoveEventResponse(
-                    from: liveItem,
-                    initialOrigin: itemOrigin,
-                    timeout: timeout
-                )
+                try await budget.run(maximum: timeout) { allowance in
+                    try await scrombleEvent(
+                        mouseDown,
+                        item: liveItem,
+                        timeout: allowance
+                    )
+                }
+                itemOrigin = try await budget.run(maximum: timeout) { allowance in
+                    try await waitForMoveEventResponse(
+                        from: liveItem,
+                        initialOrigin: itemOrigin,
+                        timeout: allowance
+                    )
+                }
 
                 // Reflow after the opening press can move the target edge.
                 // Release against a freshly validated endpoint snapshot.
@@ -1176,38 +1346,46 @@ extension MenuBarItemManager {
                 ) else {
                     throw EventError.eventCreationFailure(releaseEndpoints.source)
                 }
-                try await scrombleEvent(
-                    liveMouseUp,
-                    item: releaseEndpoints.source,
-                    timeout: timeout,
-                    repeating: 2 // Double mouse up prevents invalid item state.
-                )
+                try await budget.run(maximum: timeout, repeating: 2) { allowance in
+                    try await scrombleEvent(
+                        liveMouseUp,
+                        item: releaseEndpoints.source,
+                        timeout: allowance,
+                        repeating: 2 // Double mouse up prevents invalid item state.
+                    )
+                }
                 releaseGuard.recordReleaseAttempt(delivered: true)
-                itemOrigin = try await waitForMoveEventResponse(
-                    from: releaseEndpoints.source,
-                    initialOrigin: itemOrigin,
-                    timeout: timeout
-                )
+                itemOrigin = try await budget.run(maximum: timeout) { allowance in
+                    try await waitForMoveEventResponse(
+                        from: releaseEndpoints.source,
+                        initialOrigin: itemOrigin,
+                        timeout: allowance
+                    )
+                }
             }
         } catch {
             let attemptError = error
-            do {
-                MenuBarItemManager.diagLog.warning("Move events failed, posting fallback")
-                try await scrombleEvent(
-                    mouseUp,
-                    item: liveItem,
-                    timeout: .milliseconds(100), // Fixed timeout for fallback.
-                    repeating: 2 // Double mouse up prevents invalid item state.
-                )
-                releaseGuard.recordReleaseAttempt(delivered: true)
-            } catch let fallbackError {
-                // Keep the guard armed so its independent raw post remains
-                // the final release path.
-                MenuBarItemManager.diagLog.error("Fallback failed with error: \(fallbackError)")
+            if releaseGuard.state == .armed, budget.elapsed < budget.limit {
+                do {
+                    MenuBarItemManager.diagLog.warning("Move events failed, posting fallback")
+                    try await budget.run(maximum: .milliseconds(100), repeating: 2) { allowance in
+                        try await scrombleEvent(
+                            mouseUp,
+                            item: liveItem,
+                            timeout: allowance,
+                            repeating: 2 // Double mouse up prevents invalid item state.
+                        )
+                    }
+                    releaseGuard.recordReleaseAttempt(delivered: true)
+                } catch let fallbackError {
+                    // Keep the guard armed so its independent raw post remains
+                    // the final release path.
+                    MenuBarItemManager.diagLog.error("Fallback failed with error: \(fallbackError)")
+                }
             }
             timeout = Self.nextMoveOperationTimeout(after: timeout, outcome: .ownerDidNotRespond)
             updateMoveOperationTimeout(timeout, for: liveItem)
-            if releaseGuard.didFire {
+            if releaseGuard.didFire || budget.elapsed >= budget.limit {
                 throw EventError.moveTimedOut(item)
             }
             throw attemptError
@@ -1254,7 +1432,8 @@ extension MenuBarItemManager {
         openingEvent: CGEvent,
         releaseGuard: PressReleaseGuard,
         destination: MoveDestination,
-        on displayID: CGDirectDisplayID
+        on displayID: CGDirectDisplayID,
+        budget: MoveTransactionBudget
     ) async throws -> CGPoint {
         guard steps.last?.subtype == .mouseUp else {
             throw EventError.eventCreationFailure(item)
@@ -1295,17 +1474,21 @@ extension MenuBarItemManager {
                 }
                 event = liveEvent
             }
-            try await scrombleEvent(event, item: liveItem, timeout: timeout)
+            try await budget.run(maximum: timeout) { allowance in
+                try await scrombleEvent(event, item: liveItem, timeout: allowance)
+            }
             responseItem = liveItem
             if step.subtype == .mouseDragged {
-                await eventSleep(for: .milliseconds(8))
+                try await budget.sleep(for: .milliseconds(8))
             }
         }
-        itemOrigin = try await waitForMoveEventResponse(
-            from: responseItem,
-            initialOrigin: startOrigin,
-            timeout: timeout
-        )
+        itemOrigin = try await budget.run(maximum: timeout) { allowance in
+            try await waitForMoveEventResponse(
+                from: responseItem,
+                initialOrigin: startOrigin,
+                timeout: allowance
+            )
+        }
 
         // Reflow can move the anchor while the button is held. Re-resolve and
         // validate the exact release edge instead of using the planned one.
@@ -1340,18 +1523,20 @@ extension MenuBarItemManager {
         ) else {
             throw EventError.eventCreationFailure(releaseEndpoints.source)
         }
-        try await scrombleEvent(
-            releaseEvent,
-            item: releaseEndpoints.source,
-            timeout: timeout,
-            repeating: 2
-        )
+        try await budget.run(maximum: timeout, repeating: 2) { allowance in
+            try await scrombleEvent(
+                releaseEvent,
+                item: releaseEndpoints.source,
+                timeout: allowance,
+                repeating: 2
+            )
+        }
         releaseGuard.recordReleaseAttempt(delivered: true)
 
         // A revert returns to the start and therefore cannot be awaited as an
         // origin change after release. Give the drop one short settling beat
         // and re-resolve the exact source before reading its resting origin.
-        await eventSleep(for: .milliseconds(30))
+        try await budget.sleep(for: .milliseconds(30))
         let restingEndpoints = try await resolveCurrentMoveEndpoints(
             source: item,
             destination: destination.targetItem,
@@ -1520,6 +1705,10 @@ extension MenuBarItemManager {
         var didFinishWhileHoldingGate: (@MainActor () -> Void)?
     }
 
+    /// The whole move yields the gate before the cursor watchdog and queued
+    /// callers give up, even when each individual attempt remains bounded.
+    static nonisolated let moveDeadline: Duration = .seconds(8)
+
     /// How long a synthetic press may remain down before its guard releases it.
     static nonisolated func pressReleaseDeadline(for timeout: Duration) -> Duration {
         (timeout * 6).clamped(min: .milliseconds(1500), max: .seconds(3))
@@ -1648,12 +1837,150 @@ extension MenuBarItemManager {
     private func makePressReleaseGuard(
         for item: MenuBarItem,
         mouseUp: CGEvent,
-        eventPID: pid_t
-    ) -> PressReleaseGuard {
-        return PressReleaseGuard(
-            deadline: Self.pressReleaseDeadline(for: getMoveOperationTimeout(for: item)),
+        eventPID: pid_t,
+        budget: MoveTransactionBudget
+    ) throws -> PressReleaseGuard {
+        return try PressReleaseGuard(
+            deadline: min(
+                Self.pressReleaseDeadline(for: getMoveOperationTimeout(for: item)),
+                budget.remaining()
+            ),
             events: PressReleaseEvents(mouseUp: mouseUp, pid: eventPID),
             item: item
+        )
+    }
+
+    private static func isControlCenterOwned(_ item: MenuBarItem) -> Bool {
+        item.owningApplication?.bundleIdentifier == MenuBarItemTag.Namespace.controlCenter.description
+    }
+
+    /// Supplies the live ownership inputs to the pure failure-attribution rule.
+    func ledgerFailureKind(for error: any Error, item: MenuBarItem) -> MenuBarItemFailureLedger.FailureKind {
+        guard let error = error as? EventError else {
+            return .other
+        }
+        return Self.ledgerFailureKind(
+            for: error,
+            ownerIsControlCenter: Self.isControlCenterOwned(item),
+            hasProvisionalIdentity: item.hasProvisionalIdentity
+        )
+    }
+
+    private func recordLanding(of item: MenuBarItem) {
+        failureLedger.recordSuccess(for: item)
+        clearRefusedMove(of: item)
+    }
+
+    private func logStop(
+        _ reason: MovePolicy.StopReason,
+        attempt: Int,
+        item: MenuBarItem,
+        destination: MoveDestination,
+        state: MovePolicy.State,
+        maxAttempts: Int,
+        error: (any Error)?
+    ) {
+        switch reason {
+        case .refusedByMacOS:
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(item.logString) returned to its starting origin after consecutive releases; abandoning the move"
+            )
+        case .targetMoved:
+            let planned = state.plannedTargetMinX.map { String(format: "%.0f", $0) } ?? "?"
+            let current = state.latestTargetMinX.map { String(format: "%.0f", $0) } ?? "?"
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(destination.targetItem.logString) moved from minX=\(planned) to minX=\(current); abandoning the stale move"
+            )
+        case .targetRetreating:
+            let history = state.targetMinXHistory.map { String(format: "%.0f", $0) }.joined(separator: " → ")
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(destination.targetItem.logString) retreated on every recent attempt (\(history)); abandoning the move"
+            )
+        case .ownerUnresponsive:
+            MenuBarItemManager.diagLog.warning("Attempt \(attempt): \(item.logString) owner is unresponsive")
+        case .ownerAlwaysSilent:
+            MenuBarItemManager.diagLog.warning("Attempt \(attempt): \(item.logString) repeated its standing silent-owner failure")
+        case .ownerSilent, .other:
+            MenuBarItemManager.diagLog.debug(
+                "Attempt \(attempt) failed: \(error.map { "\($0)" } ?? "unknown error")"
+            )
+        case .itemGone:
+            MenuBarItemManager.diagLog.warning("Attempt \(attempt): \(item.logString) no longer reports bounds")
+        case .destinationGone:
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(destination.targetItem.logString) no longer reports bounds"
+            )
+        case .superseded:
+            MenuBarItemManager.diagLog.debug("move: superseded during attempt \(attempt) for \(item.logString)")
+        case .overran:
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): the press on \(item.logString) outlived its deadline"
+            )
+        case .unsafePath:
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(item.logString) has no safe transport to the selected destination"
+            )
+        case .budgetExhausted:
+            MenuBarItemManager.diagLog.error(
+                "move: all \(maxAttempts) attempt(s) exhausted without verifying \(item.logString) reached \(destination.logString)"
+            )
+        }
+    }
+
+    private func isAtDestination(
+        _ item: MenuBarItem,
+        for destination: MoveDestination,
+        on displayID: CGDirectDisplayID
+    ) async -> Bool {
+        await (try? itemHasCorrectPosition(item: item, for: destination, on: displayID)) ?? false
+    }
+
+    /// Rechecks plausible landings against a settled bar, then records and
+    /// throws the policy's precise terminal verdict.
+    private func concludeFailedMove(
+        reason: MovePolicy.StopReason,
+        item: MenuBarItem,
+        destination: MoveDestination,
+        on displayID: CGDirectDisplayID,
+        attempts: Int,
+        budget: MoveTransactionBudget,
+        lastError: (any Error)?
+    ) async throws {
+        if reason.deservesFinalLandingCheck, budget.elapsed < budget.limit {
+            do {
+                try await waitForLayoutToSettle(
+                    item: item,
+                    target: destination.targetItem,
+                    budget: budget
+                )
+            } catch is MoveDeadlineExceeded {
+                throw EventError.moveTimedOut(item)
+            }
+            if await isAtDestination(item, for: destination, on: displayID) {
+                MenuBarItemManager.diagLog.info(
+                    "Move landed: \(item.logString) after \(attempts) attempt(s); confirmed after stopping for \(reason.logString)"
+                )
+                recordLanding(of: item)
+                return
+            }
+        }
+        if reason == .budgetExhausted {
+            await validateItemPositionAfterMove(item: item, destination: destination, on: displayID)
+        }
+        if reason == .refusedByMacOS {
+            noteRefusedMove(of: item)
+        }
+        if reason.isFiledAgainstOwner, let lastError {
+            failureLedger.recordFailure(for: item, kind: ledgerFailureKind(for: lastError, item: item))
+        }
+        MenuBarItemManager.diagLog.info(
+            "Move verdict: \(reason.logString) for \(item.logString) after \(attempts) attempt(s) in \(Int(budget.elapsed.milliseconds)) ms"
+        )
+        throw Self.moveError(
+            for: reason,
+            item: item,
+            destinationItem: destination.targetItem,
+            lastError: lastError
         )
     }
 
@@ -1671,16 +1998,22 @@ extension MenuBarItemManager {
         skipInputPause: Bool = false,
         options: MoveOptions = .init()
     ) async throws {
+        let budget = Self.currentMoveBudget ?? MoveTransactionBudget(limit: Self.moveDeadline)
+
         // Admission waits for a bounded input lull before taking the app-wide
         // permit. Nested recovery moves already own the gate.
         if !Self.holdsMoveGate {
             do {
                 try await Self.performWithMoveGate(
+                    timeoutProvider: {
+                        try budget.timeout(for: Self.moveGateTimeout)
+                    },
                     waitBeforeGate: {
                         guard !skipInputPause else {
                             return
                         }
-                        let waitTask = Task(timeout: Self.moveInputPauseLimit) {
+                        let allowance = try budget.timeout(for: Self.moveInputPauseLimit)
+                        let waitTask = Task(timeout: allowance) {
                             try await self.waitForUserToPauseInput(
                                 for: options.requiredInputPause,
                                 timeout: options.inputPauseTimeout,
@@ -1699,8 +2032,9 @@ extension MenuBarItemManager {
                         } catch let error as EventError {
                             throw error
                         } catch {
+                            _ = try budget.remaining()
                             MenuBarItemManager.diagLog.debug(
-                                "move: input did not pause within \(Self.moveInputPauseLimit) for \(item.logString)"
+                                "move: input did not pause within \(allowance) for \(item.logString)"
                             )
                             throw EventError.cannotComplete
                         }
@@ -1721,20 +2055,31 @@ extension MenuBarItemManager {
                         }
                         var nestedOptions = options
                         nestedOptions.didFinishWhileHoldingGate = nil
-                        try await self.move(
-                            item: item,
-                            to: destination,
-                            on: displayID,
-                            skipInputPause: true,
-                            options: nestedOptions
-                        )
+                        _ = try budget.remaining()
+                        try await Self.$currentMoveBudget.withValue(budget) {
+                            try await self.move(
+                                item: item,
+                                to: destination,
+                                on: displayID,
+                                skipInputPause: true,
+                                options: nestedOptions
+                            )
+                        }
                     }
                 )
+            } catch is MoveDeadlineExceeded {
+                throw EventError.moveTimedOut(item)
             } catch is SimpleSemaphore.TimeoutError {
-                MenuBarItemManager.diagLog.error(
-                    "move: another move has held the bar for \(Self.moveGateTimeout); giving up on \(item.logString)"
-                )
+                if budget.elapsed >= budget.limit {
+                    throw EventError.moveTimedOut(item)
+                }
+                MenuBarItemManager.diagLog.error("move: another move held the bar until admission timed out for \(item.logString)")
                 throw EventError.moveEngineBusy(item)
+            } catch {
+                if budget.elapsed >= budget.limit {
+                    throw EventError.moveTimedOut(item)
+                }
+                throw error
             }
             return
         }
@@ -1786,7 +2131,7 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.warning("move: menu still open after wait; deferring move of \(item.logString)")
                 throw EventError.menuTrackingActive(item)
             }
-            try await Task.sleep(for: .milliseconds(250))
+            try await budget.sleep(for: .milliseconds(250))
         }
 
         // Allow right-of-item moves to proceed even when the item is at x=-1.
@@ -1828,7 +2173,18 @@ extension MenuBarItemManager {
             appState.hidEventManager.startAll()
         }
 
-        try await waitForMoveOperationBuffer()
+        let initialBuffer = await moveOperationBufferDuration()
+        if initialBuffer > .zero {
+            try await budget.sleep(for: initialBuffer)
+        }
+
+        // The buffer itself is an await; require the same exact endpoints
+        // again before the first verification or event.
+        let bufferedEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: resolvedDisplayID
+        )
 
         MenuBarItemManager.diagLog.info(
             """
@@ -1837,8 +2193,9 @@ extension MenuBarItemManager {
             """
         )
 
-        guard try await !itemHasCorrectPosition(item: item, for: destination, on: resolvedDisplayID) else {
+        guard !Self.endpointsHaveCorrectPosition(bufferedEndpoints, for: destination) else {
             MenuBarItemManager.diagLog.debug("Item has correct position, cancelling move")
+            recordLanding(of: item)
             return
         }
 
@@ -1861,11 +2218,13 @@ extension MenuBarItemManager {
         // sees a brief cursor flash. The floor stays at 10 s so ordinary
         // moves keep their safety net against genuinely stuck states.
         if options.hideCursorAcrossAttempts {
-            MouseHelpers.hideCursor(
-                watchdogTimeout: options.watchdogTimeout ?? Self.cursorHideWatchdogTimeout(
+            let cursorWatchdog = min(
+                options.watchdogTimeout ?? Self.cursorHideWatchdogTimeout(
                     maxAttempts: max(1, options.maxMoveAttempts)
-                )
+                ),
+                try budget.remaining()
             )
+            MouseHelpers.hideCursor(watchdogTimeout: cursorWatchdog)
         }
         defer {
             if let mouseLocation {
@@ -1874,33 +2233,18 @@ extension MenuBarItemManager {
             }
         }
 
-        // Tracks whether any postMoveEvents attempt produced observable
-        // displacement. Only consulted on retries when the item being
-        // moved is a zero-width control item (section divider), where
-        // a position match can coincide with bounds drifting onto the
-        // target externally; ordinary items skip this gate.
-        var anyMoveEventsSucceeded = false
+        var policyState = MovePolicy.State(plannedTargetMinX: bufferedEndpoints.target.bounds.minX)
+        let configuration = MovePolicy.Configuration(
+            maxAttempts: max(1, maxMoveAttempts),
+            displayWidth: CGDisplayBounds(resolvedDisplayID).width,
+            itemIsControlItem: item.isControlItem,
+            ownerHasSilentRecord: failureLedger.isUnresponsive(item)
+        )
+        var lastError: (any Error)?
+        var stopReason: MovePolicy.StopReason?
 
-        // Baseline for the stale-plan check in the retry path. The destination
-        // was chosen against the bar as it looked when this move was planned;
-        // if the target itself travels a long way while we are dragging, the
-        // plan describes an arrangement that no longer exists.
-        let plannedTargetBounds = try? exactMoveBounds(for: destination.targetItem, isDestination: true)
-
-        // Where the target has sat at the end of each failed attempt. A
-        // single nudge is expected; a run of them in one direction is the
-        // move pushing its own anchor. See `targetIsRetreating`.
-        var targetMinXHistory: [CGFloat] = plannedTargetBounds.map { [$0.minX] } ?? []
-
-        let maxAttempts = max(1, options.maxMoveAttempts)
-        for n in 1 ... maxAttempts {
-            var attemptMouseLocation: CGPoint?
-            defer {
-                if let attemptMouseLocation {
-                    MouseHelpers.restoreCursorPosition(to: attemptMouseLocation)
-                    MouseHelpers.showCursor()
-                }
-            }
+        attemptLoop: while stopReason == nil {
+            let n = policyState.attempts + 1
             guard !Task.isCancelled else {
                 MenuBarItemManager.diagLog.debug("move: cancelled before attempt \(n) for \(item.logString)")
                 throw EventError.cannotComplete
@@ -1909,208 +2253,126 @@ extension MenuBarItemManager {
                 MenuBarItemManager.diagLog.debug("move: superseded before attempt \(n) for \(item.logString)")
                 throw EventError.moveSuperseded(item)
             }
+            guard MovePolicy.mayStartAnotherAttempt(elapsed: budget.elapsed, deadline: budget.limit) else {
+                MenuBarItemManager.diagLog.warning(
+                    "move: \(item.logString) has been moving for \(Int(budget.elapsed.milliseconds)) ms; not starting attempt \(n)"
+                )
+                stopReason = .overran
+                break attemptLoop
+            }
+
+            let observation: MovePolicy.Observation
+            var attemptStrategy: MoveStrategy?
+            lastError = nil
             do {
-                if try await itemHasCorrectPosition(item: item, for: destination, on: resolvedDisplayID) {
-                    // On the first iteration trust the position match
-                    // unconditionally. On retries, the only case where the
-                    // match can be a coincidence is when the item being
-                    // moved is itself a zero-width control item; gate
-                    // those on observed displacement, accept all others.
-                    if n == 1 || anyMoveEventsSucceeded || !item.isControlItem {
-                        MenuBarItemManager.diagLog.debug("Item has correct position, finished with move")
-                        return
-                    }
-                    MenuBarItemManager.diagLog.debug(
-                        "Position match without observable displacement on attempt \(n); treating as false positive on a zero-width control item and retrying"
-                    )
+                if try await itemHasCorrectPosition(item: item, for: destination, on: resolvedDisplayID),
+                   MovePolicy.trustsPositionMatch(
+                       attempt: n,
+                       anyEventsSucceeded: policyState.anyEventsSucceeded,
+                       itemIsControlItem: item.isControlItem
+                   )
+                {
+                    MenuBarItemManager.diagLog.debug("Item has correct position, finished with move")
+                    recordLanding(of: item)
+                    return
                 }
-                if !options.hideCursorAcrossAttempts {
-                    attemptMouseLocation = try getMouseLocation()
-                    MouseHelpers.hideCursor(watchdogTimeout: options.watchdogTimeout ?? .seconds(2))
-                }
+
+
                 let outcome = try await postMoveEvents(
                     item: item,
                     destination: destination,
                     on: resolvedDisplayID,
-                    warpCursorAfter: false // move() owns the single warp in its defer
+                    budget: budget,
+                    warpCursorAfter: false
                 )
-                // postMoveEvents only returns without throwing when both
-                // waitForMoveEventResponse calls observed origin changes,
-                // i.e. our drag actually displaced the item.
-                anyMoveEventsSucceeded = true
-                // Verify the item actually reached the correct position.
-                let landedOnDestination = try await itemHasCorrectPosition(
+                attemptStrategy = outcome.strategy
+                try await waitForLayoutToSettle(
                     item: item,
-                    for: destination,
+                    target: destination.targetItem,
+                    budget: budget
+                )
+                let settledEndpoints = try await resolveCurrentMoveEndpoints(
+                    source: item,
+                    destination: destination.targetItem,
                     on: resolvedDisplayID
                 )
-                // `postMoveEvents` only observes displacement. Let this
-                // single post-event landing check decide whether the next
-                // attempt earns a shorter budget or keeps it unchanged;
-                // querying Window Server in both places made misses look like
-                // successful moves (#889).
+                let landed = Self.endpointsHaveCorrectPosition(settledEndpoints, for: destination)
                 updateMoveOperationTimeout(
                     Self.nextMoveOperationTimeout(
                         after: outcome.timeout,
-                        outcome: landedOnDestination ? .landed : .displacedWithoutLanding
+                        outcome: landed ? .landed : .displacedWithoutLanding
                     ),
                     for: item
                 )
-                if landedOnDestination {
-                    // Logged at info so the warm-up attempt cost can be read
-                    // straight off a field log: grep "Move landed" and compare
-                    // the attempt counts.
-                    MenuBarItemManager.diagLog.info(
-                        "Move landed: \(item.logString) after \(n) attempt(s)"
+                observation = landed
+                    ? .landed
+                    : .displaced(
+                        revertedToStart: outcome.revertedToStart,
+                        targetMinX: settledEndpoints.target.bounds.minX
                     )
-                    MenuBarItemManager.diagLog.debug("Attempt \(n) succeeded and verified, finished with move")
-                    failureLedger.recordSuccess(for: item)
-                    // Validate that item didn't get stuck when moving to hidden section
-                    await validateItemPositionAfterMove(item: item, destination: destination, on: resolvedDisplayID)
-                    return
-                }
-                // Retrying against a target that has already moved re-plans
-                // each attempt against different geometry and drags the item
-                // somewhere new every time, which is what leaves a failed
-                // batch with a fresh partial arrangement on every pass (#900).
-                // Stop instead and let the next cache tick re-plan against a
-                // settled bar.
-                let currentTargetBounds = try? exactMoveBounds(
-                    for: destination.targetItem,
-                    isDestination: true
-                )
-                if let currentTargetBounds {
-                    targetMinXHistory.append(currentTargetBounds.minX)
-                }
-                if let plannedTargetBounds,
-                   let currentTargetBounds,
-                   Self.destinationIsStale(
-                       plannedTargetMinX: plannedTargetBounds.minX,
-                       currentTargetMinX: currentTargetBounds.minX,
-                       displayWidth: CGDisplayBounds(resolvedDisplayID).width
-                   )
-                {
-                    MenuBarItemManager.diagLog.warning(
-                        """
-                        Attempt \(n): \(destination.targetItem.logString) moved from \
-                        minX=\(plannedTargetBounds.minX) to minX=\(currentTargetBounds.minX) \
-                        during the drag, abandoning the stale move
-                        """
-                    )
-                    throw EventError.staleDestination(item)
-                }
-                // Small steps that never trip the stale threshold still walk
-                // the anchor across the bar if they all go the same way, and
-                // when the anchor is one of Thaw's dividers that ends in a
-                // zero-width hidden section (#924, #927). Stop and let the
-                // next cache tick re-plan against a settled bar.
-                if Self.targetIsRetreating(recentTargetMinX: targetMinXHistory) {
-                    MenuBarItemManager.diagLog.warning(
-                        """
-                        Attempt \(n): \(destination.targetItem.logString) has retreated on every \
-                        recent attempt (minX \(targetMinXHistory.map { String(format: "%.0f", $0) }.joined(separator: " → "))) \
-                        while \(item.logString) did not land; abandoning rather than pushing it further
-                        """
-                    )
-                    throw EventError.staleDestination(item)
-                }
-                MenuBarItemManager.diagLog.debug("Attempt \(n) events succeeded but item not at destination, retrying")
-                if n < maxAttempts {
-                    guard options.shouldProceed?() ?? true else {
-                        throw EventError.moveSuperseded(item)
-                    }
-                    try await waitForMoveOperationBuffer()
-                    continue
-                }
+            } catch is MoveDeadlineExceeded {
+                lastError = EventError.moveTimedOut(item)
+                observation = .failed(.overran)
+            } catch let error as EventError {
+                lastError = error
+                observation = .failed(MovePolicy.attemptFailure(for: error))
             } catch {
-                // missingItemBounds is definitive: getCurrentBounds already
-                // refreshed the on-screen items and re-matched by tag before
-                // throwing, so the item's window is genuinely gone (transient
-                // Control Center item vanished, owning app quit). Retrying
-                // just warps the hidden cursor into the menu bar once per
-                // remaining attempt for an item that cannot be moved (#736).
-                if case EventError.missingItemBounds = error {
-                    MenuBarItemManager.diagLog.warning(
-                        "Attempt \(n): \(item.logString) no longer reports bounds, aborting move"
+                lastError = error
+                observation = .failed(.other)
+            }
+
+            switch MovePolicy.decide(
+                after: observation,
+                state: &policyState,
+                configuration: configuration
+            ) {
+            case .succeed:
+                MenuBarItemManager.diagLog.info(
+                    "Move landed: \(item.logString) after \(n) attempt(s)\(attemptStrategy.map { " via \($0)" } ?? "")"
+                )
+                recordLanding(of: item)
+                await validateItemPositionAfterMove(
+                    item: item,
+                    destination: destination,
+                    on: resolvedDisplayID
+                )
+                return
+            case .retry:
+                if case .failed = observation {
+                    MenuBarItemManager.diagLog.debug(
+                        "Attempt \(n) failed: \(lastError.map { "\($0)" } ?? "unknown error")"
                     )
-                    throw error
-                }
-                if case EventError.missingDestinationBounds = error {
-                    MenuBarItemManager.diagLog.warning(
-                        "Attempt \(n): \(destination.targetItem.logString) no longer reports bounds, abandoning the destination"
+                } else {
+                    MenuBarItemManager.diagLog.debug(
+                        "Attempt \(n) events succeeded but item not at destination, retrying"
                     )
-                    throw error
                 }
-                if case EventError.moveTimedOut = error {
-                    throw error
+                let retryBuffer = await moveOperationBufferDuration()
+                if retryBuffer > .zero {
+                    try await budget.sleep(for: retryBuffer)
                 }
-                if case EventError.unsafeMovePath = error {
-                    throw error
-                }
-                // Also definitive for the duration of this call: a hung owner
-                // will not start pumping its event loop within the few hundred
-                // milliseconds between attempts, so the remaining attempts
-                // would only re-pay the semaphore wait. Callers retry the item
-                // on a later cache tick, by which point it may have recovered.
-                if case EventError.ownerUnresponsive = error {
-                    MenuBarItemManager.diagLog.warning(
-                        "Attempt \(n): \(item.logString) owner is unresponsive, aborting move"
-                    )
-                    failureLedger.recordFailure(for: item, kind: .unresponsiveOwner)
-                    throw error
-                }
-                // Raised by the stale-plan check above, which has already
-                // logged. Retrying is precisely what it exists to prevent, and
-                // the item's owner did nothing wrong, so no failure is filed
-                // against it.
-                if case EventError.staleDestination = error {
-                    throw error
-                }
-                if case EventError.moveSuperseded = error {
-                    throw error
-                }
-                if case EventError.inputPauseTimedOut = error {
-                    throw error
-                }
-                // An owner with a standing record of ignoring synthetic events
-                // gets no further attempts once it fails this way again. This
-                // is deliberately narrower than capping maxAttempts up front:
-                // the loop also retries when the owner *did* respond but the
-                // item did not land, which is a different failure and still
-                // deserves its full budget. Capping up front would strip those
-                // retries too, and since the move would then fail, the item
-                // could never earn the success that clears its record.
-                if let error = error as? EventError,
-                   error.indicatesUnresponsiveOwner,
-                   failureLedger.isUnresponsive(item)
-                {
-                    MenuBarItemManager.diagLog.warning(
-                        "Attempt \(n): \(item.logString) failed the way it always does, aborting move"
-                    )
-                    failureLedger.recordFailure(for: item, kind: .unresponsiveOwner)
-                    throw error
-                }
-                MenuBarItemManager.diagLog.debug("Attempt \(n) failed: \(error)")
-                if n < maxAttempts {
-                    try await waitForMoveOperationBuffer()
-                    continue
-                }
-                if let error = error as? EventError {
-                    if error.indicatesUnresponsiveOwner {
-                        failureLedger.recordFailure(for: item, kind: .unresponsiveOwner)
-                    }
-                    throw error
-                }
-                MenuBarItemManager.diagLog.warning("move: final attempt for \(item.logString) failed with non-EventError: \(error)")
-                throw EventError.cannotComplete
+            case let .stop(reason):
+                stopReason = reason
+                logStop(
+                    reason,
+                    attempt: n,
+                    item: item,
+                    destination: destination,
+                    state: policyState,
+                    maxAttempts: configuration.maxAttempts,
+                    error: lastError
+                )
             }
         }
 
-        // All attempts exhausted without confirmed position. Run the stuck-item
-        // validator first (recovers x=-1 blocks), then throw so callers know
-        // the item did not reach the destination.
-        await validateItemPositionAfterMove(item: item, destination: destination, on: resolvedDisplayID)
-        MenuBarItemManager.diagLog.error("move: all \(maxAttempts) attempt(s) exhausted without verifying \(item.logString) reached \(destination.logString)")
-        throw EventError.cannotComplete
+        try await concludeFailedMove(
+            reason: stopReason ?? .other,
+            item: item,
+            destination: destination,
+            on: resolvedDisplayID,
+            attempts: policyState.attempts,
+            budget: budget,
+            lastError: lastError
+        )
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -1059,22 +1059,24 @@ extension MenuBarItemManager {
         budget: MoveTransactionBudget,
         warpCursorAfter: Bool = true
     ) async throws -> MoveEventsOutcome {
-        var acquiredSemaphore = false
+        // Take the permit outside `budget.run`: `run` re-checks the deadline
+        // after its operation succeeds and can throw from that check, which
+        // would leave the permit held while this function reports failure —
+        // leaking it for the life of the process. `timeout(for:)` still
+        // refuses admission before the wait when the deadline has passed, and
+        // later `budget.run`/`budget.sleep` calls keep enforcing the deadline.
+        let semaphoreAllowance = try budget.timeout(for: .milliseconds(3500))
         do {
-            try await budget.run(maximum: .milliseconds(3500)) { timeout in
-                try await eventSemaphore.wait(timeout: timeout)
-            }
-            acquiredSemaphore = true
+            try await eventSemaphore.wait(timeout: semaphoreAllowance)
         } catch is SimpleSemaphore.TimeoutError {
             MenuBarItemManager.diagLog.error(
                 "eventSemaphore timed out while moving \(item.logString); preserving the transaction deadline"
             )
             throw EventError.cannotComplete
         }
+        // The permit is held from here on, so the release is unconditional.
         defer {
-            if acquiredSemaphore {
-                Task.detached { [eventSemaphore] in await eventSemaphore.signal() }
-            }
+            Task.detached { [eventSemaphore] in await eventSemaphore.signal() }
         }
 
         // Event-transport admission can take seconds. Resolve both exact
@@ -1910,6 +1912,10 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.warning(
                 "Attempt \(attempt): \(destination.targetItem.logString) no longer reports bounds"
             )
+        case .staleDestination:
+            MenuBarItemManager.diagLog.warning(
+                "Attempt \(attempt): \(destination.targetItem.logString) no longer matches the move plan"
+            )
         case .superseded:
             MenuBarItemManager.diagLog.debug("move: superseded during attempt \(attempt) for \(item.logString)")
         case .overran:
@@ -2031,6 +2037,17 @@ extension MenuBarItemManager {
                             }
                         } catch let error as EventError {
                             throw error
+                        } catch is TaskTimeoutError {
+                            // The outer task's budget-derived allowance
+                            // elapsed before `waitForUserToPauseInput`'s own
+                            // timeout could fire (it is unset or wider than
+                            // the allowance). That is still an input pause
+                            // timeout, so keep the deferral attribution
+                            // instead of reporting a generic failure.
+                            MenuBarItemManager.diagLog.debug(
+                                "move: input did not pause within \(allowance) for \(item.logString)"
+                            )
+                            throw EventError.inputPauseTimedOut(item)
                         } catch {
                             _ = try budget.remaining()
                             MenuBarItemManager.diagLog.debug(
@@ -2218,11 +2235,11 @@ extension MenuBarItemManager {
         // sees a brief cursor flash. The floor stays at 10 s so ordinary
         // moves keep their safety net against genuinely stuck states.
         if options.hideCursorAcrossAttempts {
-            let cursorWatchdog = min(
+            let cursorWatchdog = try min(
                 options.watchdogTimeout ?? Self.cursorHideWatchdogTimeout(
                     maxAttempts: max(1, options.maxMoveAttempts)
                 ),
-                try budget.remaining()
+                budget.remaining()
             )
             MouseHelpers.hideCursor(watchdogTimeout: cursorWatchdog)
         }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -2235,7 +2235,7 @@ extension MenuBarItemManager {
 
         var policyState = MovePolicy.State(plannedTargetMinX: bufferedEndpoints.target.bounds.minX)
         let configuration = MovePolicy.Configuration(
-            maxAttempts: max(1, maxMoveAttempts),
+            maxAttempts: max(1, options.maxMoveAttempts),
             displayWidth: CGDisplayBounds(resolvedDisplayID).width,
             itemIsControlItem: item.isControlItem,
             ownerHasSilentRecord: failureLedger.isUnresponsive(item)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+Move.swift
@@ -120,6 +120,168 @@ extension MenuBarItemManager {
         }
     }
 
+    /// The event transport selected for one attempt. Parked and cross-notch
+    /// teleports are named separately so an unsafe faithful plan can never
+    /// silently collapse into the legacy press-at-destination path.
+    nonisolated enum MoveStrategy: Equatable, CustomStringConvertible {
+        case teleport
+        case faithfulDrag
+        case parkedTeleport
+        case crossNotchTeleport
+
+        var description: String {
+            switch self {
+            case .teleport: "teleport"
+            case .faithfulDrag: "faithfulDrag"
+            case .parkedTeleport: "parkedTeleport"
+            case .crossNotchTeleport: "crossNotchTeleport"
+            }
+        }
+    }
+
+    /// Whether a horizontal on-bar gesture can stay inside one safe segment.
+    nonisolated enum HorizontalPathDisposition: Equatable {
+        case sameSafeSegment
+        case crossesNotch
+        case invalidEndpoint
+    }
+
+    /// The strict transport decision, including a refusal to post events.
+    nonisolated enum MoveTransportDecision: Equatable {
+        case use(MoveStrategy)
+        case rejectUnsafePath
+    }
+
+    /// Logical placement of a move endpoint relative to the selected menu-bar
+    /// lane. Screen coordinates alone cannot identify parked items because a
+    /// physical display may legitimately sit to the selected display's left.
+    nonisolated enum MoveEndpointDisposition: Equatable {
+        case selectedDisplay
+        case parked
+        case otherDisplay(CGDirectDisplayID)
+        case invalid
+    }
+
+    nonisolated struct MoveDisplayGeometry: Equatable {
+        let id: CGDirectDisplayID
+        let bounds: CGRect
+    }
+
+    static nonisolated func moveEndpointDisposition(
+        bounds: CGRect,
+        isOnScreen: Bool,
+        selectedDisplayID: CGDirectDisplayID,
+        displays: [MoveDisplayGeometry],
+        parkedLaneYRange: ClosedRange<CGFloat>?,
+        controlDividerX: CGFloat?
+    ) -> MoveEndpointDisposition {
+        let center = CGPoint(x: bounds.midX, y: bounds.midY)
+        if isOnScreen {
+            guard let physicalDisplay = displays.first(where: { $0.bounds.contains(center) }) else {
+                return .invalid
+            }
+            return physicalDisplay.id == selectedDisplayID
+                ? .selectedDisplay
+                : .otherDisplay(physicalDisplay.id)
+        }
+
+        guard
+            let parkedLaneYRange,
+            let controlDividerX,
+            parkedLaneYRange.contains(bounds.midY),
+            bounds.maxX <= controlDividerX
+        else {
+            return .invalid
+        }
+        return .parked
+    }
+
+    /// Classifies a horizontal menu-bar path without consulting AppKit.
+    static nonisolated func horizontalPathDisposition(
+        sourceX: CGFloat,
+        destinationX: CGFloat,
+        displayXRange: ClosedRange<CGFloat>,
+        reservedNotchXRange: ClosedRange<CGFloat>?
+    ) -> HorizontalPathDisposition {
+        guard displayXRange.contains(sourceX), displayXRange.contains(destinationX) else {
+            return .invalidEndpoint
+        }
+        guard let notch = reservedNotchXRange else {
+            return .sameSafeSegment
+        }
+        guard !notch.contains(sourceX), !notch.contains(destinationX) else {
+            return .invalidEndpoint
+        }
+        let crosses = (sourceX < notch.lowerBound && destinationX > notch.upperBound)
+            || (destinationX < notch.lowerBound && sourceX > notch.upperBound)
+        return crosses ? .crossesNotch : .sameSafeSegment
+    }
+
+    /// Selects a transport from explicit display membership and path safety.
+    /// A `nil` endpoint display means WindowServer has parked it off-screen;
+    /// a non-selected display means the plan is stale or cross-display and is
+    /// rejected instead of being teleported.
+    static nonisolated func strictTransportDecision(
+        faithfulDragEnabled: Bool,
+        itemIsControlItem: Bool,
+        sourceDisplayID: CGDirectDisplayID?,
+        destinationDisplayID: CGDirectDisplayID?,
+        selectedDisplayID: CGDirectDisplayID,
+        horizontalPath: HorizontalPathDisposition
+    ) -> MoveTransportDecision {
+        if let sourceDisplayID, sourceDisplayID != selectedDisplayID {
+            return .rejectUnsafePath
+        }
+        if let destinationDisplayID, destinationDisplayID != selectedDisplayID {
+            return .rejectUnsafePath
+        }
+        if sourceDisplayID == nil || destinationDisplayID == nil {
+            return .use(.parkedTeleport)
+        }
+        return switch horizontalPath {
+        case .invalidEndpoint:
+            .rejectUnsafePath
+        case .crossesNotch:
+            .use(.crossNotchTeleport)
+        case .sameSafeSegment:
+            .use(faithfulDragEnabled && !itemIsControlItem ? .faithfulDrag : .teleport)
+        }
+    }
+
+    /// What one round of move events observed, beyond the timeout budget the
+    /// next round inherits.
+    nonisolated struct MoveEventsOutcome {
+        var timeout: Duration
+        var revertedToStart: Bool
+        var strategy: MoveStrategy
+    }
+
+    /// Pure construction of a faithful, horizontal command-drag gesture.
+    nonisolated enum MoveGesture {
+        struct Step: Equatable {
+            let subtype: MenuBarItemEventType.MoveSubtype
+            let point: CGPoint
+        }
+
+        static func faithfulDrag(start: CGPoint, end: CGPoint, intermediateSteps: Int) -> [Step] {
+            let steps = max(1, intermediateSteps)
+            var result = [Step(subtype: .mouseDown, point: start)]
+            for index in 1 ... steps {
+                let t = CGFloat(index) / CGFloat(steps + 1)
+                result.append(Step(
+                    subtype: .mouseDragged,
+                    point: CGPoint(
+                        x: start.x + (end.x - start.x) * t,
+                        y: start.y + (end.y - start.y) * t
+                    )
+                ))
+            }
+            result.append(Step(subtype: .mouseDragged, point: end))
+            result.append(Step(subtype: .mouseUp, point: end))
+            return result
+        }
+    }
+
     /// Final coordinates used to create the opening and closing events for a
     /// move. A teleport has no visible intermediate press: its mouse-down is
     /// stamped directly at the destination, including when that destination
@@ -530,6 +692,83 @@ extension MenuBarItemManager {
         }
     }
 
+    /// Validates both endpoint locations and distinguishes a genuinely parked
+    /// status item from a window belonging to a physical display on the left.
+    private func validateMoveEndpointGeometry(
+        item: MenuBarItem,
+        target: MenuBarItem,
+        snapshot: [MenuBarItem],
+        on displayID: CGDirectDisplayID
+    ) throws -> (source: MoveEndpointDisposition, target: MoveEndpointDisposition) {
+        let selectedBounds = CGDisplayBounds(displayID)
+        let displays = NSScreen.screens.map {
+            MoveDisplayGeometry(id: $0.displayID, bounds: CGDisplayBounds($0.displayID))
+        }
+        let dividers = snapshot.filter {
+            ($0.tag == .hiddenControlItem || $0.tag == .alwaysHiddenControlItem)
+                && (selectedBounds.minX ... selectedBounds.maxX).contains($0.bounds.maxX)
+                && (selectedBounds.minY ... selectedBounds.maxY).contains($0.bounds.midY)
+        }
+        let parkedLaneYRange: ClosedRange<CGFloat>? = if
+            let minY = dividers.map(\.bounds.minY).min(),
+            let maxY = dividers.map(\.bounds.maxY).max()
+        {
+            minY ... maxY
+        } else {
+            selectedBounds.minY ... (selectedBounds.minY + 64)
+        }
+        let dividerX = dividers.map(\.bounds.maxX).max() ?? selectedBounds.minX
+
+        func disposition(for endpoint: MenuBarItem) throws -> MoveEndpointDisposition {
+            let value = Self.moveEndpointDisposition(
+                bounds: endpoint.bounds,
+                isOnScreen: endpoint.isOnScreen,
+                selectedDisplayID: displayID,
+                displays: displays,
+                parkedLaneYRange: parkedLaneYRange,
+                controlDividerX: dividerX
+            )
+            switch value {
+            case .selectedDisplay, .parked:
+                return value
+            case .otherDisplay, .invalid:
+                MenuBarItemManager.diagLog.warning(
+                    "Move rejected stale or cross-display endpoint geometry for \(endpoint.logString)"
+                )
+                throw EventError.staleDestination(item)
+            }
+        }
+        return try (disposition(for: item), disposition(for: target))
+    }
+
+    private func transportDecision(
+        item: MenuBarItem,
+        itemBounds: CGRect,
+        targetPoint: CGPoint,
+        geometry: (source: MoveEndpointDisposition, target: MoveEndpointDisposition),
+        on displayID: CGDirectDisplayID
+    ) -> MoveTransportDecision {
+        let displayBounds = CGDisplayBounds(displayID)
+        let screen = NSScreen.screens.first { $0.displayID == displayID }
+        let notchRange = screen?.frameOfNotch.map { notch in
+            (notch.minX - 2) ... (notch.maxX + 2)
+        }
+        let path = Self.horizontalPathDisposition(
+            sourceX: itemBounds.midX,
+            destinationX: targetPoint.x,
+            displayXRange: displayBounds.minX ... displayBounds.maxX,
+            reservedNotchXRange: notchRange
+        )
+        return Self.strictTransportDecision(
+            faithfulDragEnabled: faithfulDragMovesEnabled,
+            itemIsControlItem: item.isControlItem,
+            sourceDisplayID: geometry.source == .selectedDisplay ? displayID : nil,
+            destinationDisplayID: geometry.target == .selectedDisplay ? displayID : nil,
+            selectedDisplayID: displayID,
+            horizontalPath: path
+        )
+    }
+
     /// Returns the target points for creating the events needed to
     /// move a menu bar item to the given destination.
     private nonisolated func getTargetPoints(
@@ -653,7 +892,7 @@ extension MenuBarItemManager {
         destination: MoveDestination,
         on displayID: CGDirectDisplayID,
         warpCursorAfter: Bool = true
-    ) async throws -> Duration {
+    ) async throws -> MoveEventsOutcome {
         var acquiredSemaphore = false
         do {
             try await eventSemaphore.wait(timeout: .milliseconds(3500))
@@ -682,6 +921,12 @@ extension MenuBarItemManager {
             on: displayID
         )
         let initialDestination = initialEndpoints.destination(matching: destination)
+        let initialGeometry = try validateMoveEndpointGeometry(
+            item: initialEndpoints.source,
+            target: initialEndpoints.target,
+            snapshot: initialEndpoints.snapshot,
+            on: displayID
+        )
         let initialTargetPoints = getTargetPoints(
             forMoving: initialEndpoints.source,
             to: initialDestination,
@@ -714,17 +959,28 @@ extension MenuBarItemManager {
             throw EventError.ownerUnresponsive(item)
         }
 
-        // Press and release at the *destination* (targetPoints.start == .end
-        // == the target edge) with the moved item's window ID stamped on the
-        // press, relying on the owner to relocate its item to the press
-        // location. Every move observed in #881 needed a warm-up attempt
-        // before that took: the first press nudged the item a pixel, the
-        // second teleported it. A drag-gesture geometry was trialled behind
-        // a setting to remove that warm-up and did not fix it, so it was
-        // withdrawn; the warm-up attempt remains an open problem.
+        let initialStrategy: MoveStrategy
+        switch transportDecision(
+            item: initialEndpoints.source,
+            itemBounds: initialEndpoints.source.bounds,
+            targetPoint: initialTargetPoints.end,
+            geometry: initialGeometry,
+            on: displayID
+        ) {
+        case let .use(selected):
+            initialStrategy = selected
+        case .rejectUnsafePath:
+            throw EventError.unsafeMovePath(initialEndpoints.source)
+        }
+        let initialDragPlan = initialStrategy == .faithfulDrag
+            ? faithfulDragSteps(
+                itemBounds: initialEndpoints.source.bounds,
+                targetPoints: initialTargetPoints
+            )
+            : nil
         let initialEventLocations = Self.moveEventLocations(
             targetPoints: initialTargetPoints,
-            faithfulDragStart: nil
+            faithfulDragStart: initialDragPlan?.first?.point
         )
 
         // Capture mouse location only when this call owns the cursor warp.
@@ -740,9 +996,7 @@ extension MenuBarItemManager {
         // when slow apps have to register the tracking events before the
         // mouseDown; irrelevant offscreen.
         let warpPoint = initialEventLocations.press
-        let warpIsOnScreen = NSScreen.screens.contains {
-            CGDisplayBounds($0.displayID).contains(warpPoint)
-        }
+        let warpIsOnScreen = initialGeometry.target == .selectedDisplay
         if warpIsOnScreen {
             // Load-bearing for event delivery — keep unconditionally, even
             // during a bulk apply: the receiving app's tracking needs the
@@ -793,6 +1047,12 @@ extension MenuBarItemManager {
         )
         let liveItem = endpoints.source
         let liveDestination = endpoints.destination(matching: destination)
+        let geometry = try validateMoveEndpointGeometry(
+            item: liveItem,
+            target: endpoints.target,
+            snapshot: endpoints.snapshot,
+            on: displayID
+        )
         let itemBounds = liveItem.bounds
         var itemOrigin = itemBounds.origin
         let targetPoints = getTargetPoints(
@@ -802,15 +1062,35 @@ extension MenuBarItemManager {
             targetBounds: endpoints.target.bounds,
             on: displayID
         )
+        let strategy: MoveStrategy
+        switch transportDecision(
+            item: liveItem,
+            itemBounds: itemBounds,
+            targetPoint: targetPoints.end,
+            geometry: geometry,
+            on: displayID
+        ) {
+        case let .use(selected):
+            strategy = selected
+        case .rejectUnsafePath:
+            MenuBarItemManager.diagLog.warning(
+                "Move transport rejected unsafe or cross-display geometry for \(liveItem.logString)"
+            )
+            throw EventError.unsafeMovePath(liveItem)
+        }
+        let dragPlan = strategy == .faithfulDrag
+            ? faithfulDragSteps(itemBounds: itemBounds, targetPoints: targetPoints)
+            : nil
         let eventLocations = Self.moveEventLocations(
             targetPoints: targetPoints,
-            faithfulDragStart: nil
+            faithfulDragStart: dragPlan?.first?.point
         )
         if warpIsOnScreen, eventLocations.press != warpPoint {
             MouseHelpers.warpCursor(to: eventLocations.press)
         }
         let source = try getEventSource()
         try permitLocalEvents()
+        let releaseItem = strategy == .faithfulDrag ? liveItem : endpoints.target
         guard
             let mouseDown = CGEvent.menuBarItemEvent(
                 item: liveItem,
@@ -819,7 +1099,7 @@ extension MenuBarItemManager {
                 location: eventLocations.press
             ),
             let mouseUp = CGEvent.menuBarItemEvent(
-                item: endpoints.target,
+                item: releaseItem,
                 source: source,
                 type: .move(.mouseUp),
                 location: eventLocations.release
@@ -830,6 +1110,9 @@ extension MenuBarItemManager {
 
         var timeout = getMoveOperationTimeout(for: liveItem)
         MenuBarItemManager.diagLog.debug("Move operation timeout: \(timeout)")
+        MenuBarItemManager.diagLog.info(
+            "Move strategy: \(strategy) for \(liveItem.logString); press at (\(eventLocations.press.x),\(eventLocations.press.y)), release at (\(eventLocations.release.x),\(eventLocations.release.y))"
+        )
         let releaseGuard = makePressReleaseGuard(
             for: liveItem,
             mouseUp: mouseUp,
@@ -840,52 +1123,72 @@ extension MenuBarItemManager {
         // release even if the async attempt stops making progress.
         releaseGuard.arm()
         do {
-            try await scrombleEvent(
-                mouseDown,
-                item: liveItem,
-                timeout: timeout
-            )
-            itemOrigin = try await waitForMoveEventResponse(
-                from: liveItem,
-                initialOrigin: itemOrigin,
-                timeout: timeout
-            )
+            if let dragPlan {
+                itemOrigin = try await postFaithfulDragSteps(
+                    dragPlan,
+                    item: liveItem,
+                    source: source,
+                    startOrigin: itemOrigin,
+                    timeout: timeout,
+                    openingEvent: mouseDown,
+                    releaseGuard: releaseGuard,
+                    destination: destination,
+                    on: displayID
+                )
+            } else {
+                try await scrombleEvent(
+                    mouseDown,
+                    item: liveItem,
+                    timeout: timeout
+                )
+                itemOrigin = try await waitForMoveEventResponse(
+                    from: liveItem,
+                    initialOrigin: itemOrigin,
+                    timeout: timeout
+                )
 
-            // Reflow after the opening press can move the target edge. Release
-            // against a newly resolved exact endpoint rather than stale bounds.
-            let releaseEndpoints = try await resolveCurrentMoveEndpoints(
-                source: item,
-                destination: destination.targetItem,
-                on: displayID
-            )
-            let releaseDestination = releaseEndpoints.destination(matching: destination)
-            let releasePoints = getTargetPoints(
-                forMoving: releaseEndpoints.source,
-                to: releaseDestination,
-                itemBounds: releaseEndpoints.source.bounds,
-                targetBounds: releaseEndpoints.target.bounds,
-                on: displayID
-            )
-            guard let liveMouseUp = CGEvent.menuBarItemEvent(
-                item: releaseEndpoints.target,
-                source: source,
-                type: .move(.mouseUp),
-                location: releasePoints.end
-            ) else {
-                throw EventError.eventCreationFailure(releaseEndpoints.source)
+                // Reflow after the opening press can move the target edge.
+                // Release against a freshly validated endpoint snapshot.
+                let releaseEndpoints = try await resolveCurrentMoveEndpoints(
+                    source: item,
+                    destination: destination.targetItem,
+                    on: displayID
+                )
+                _ = try validateMoveEndpointGeometry(
+                    item: releaseEndpoints.source,
+                    target: releaseEndpoints.target,
+                    snapshot: releaseEndpoints.snapshot,
+                    on: displayID
+                )
+                let releaseDestination = releaseEndpoints.destination(matching: destination)
+                let releasePoints = getTargetPoints(
+                    forMoving: releaseEndpoints.source,
+                    to: releaseDestination,
+                    itemBounds: releaseEndpoints.source.bounds,
+                    targetBounds: releaseEndpoints.target.bounds,
+                    on: displayID
+                )
+                guard let liveMouseUp = CGEvent.menuBarItemEvent(
+                    item: releaseEndpoints.target,
+                    source: source,
+                    type: .move(.mouseUp),
+                    location: releasePoints.end
+                ) else {
+                    throw EventError.eventCreationFailure(releaseEndpoints.source)
+                }
+                try await scrombleEvent(
+                    liveMouseUp,
+                    item: releaseEndpoints.source,
+                    timeout: timeout,
+                    repeating: 2 // Double mouse up prevents invalid item state.
+                )
+                releaseGuard.recordReleaseAttempt(delivered: true)
+                itemOrigin = try await waitForMoveEventResponse(
+                    from: releaseEndpoints.source,
+                    initialOrigin: itemOrigin,
+                    timeout: timeout
+                )
             }
-            try await scrombleEvent(
-                liveMouseUp,
-                item: releaseEndpoints.source,
-                timeout: timeout,
-                repeating: 2 // Double mouse up prevents invalid item state.
-            )
-            releaseGuard.recordReleaseAttempt(delivered: true)
-            itemOrigin = try await waitForMoveEventResponse(
-                from: releaseEndpoints.source,
-                initialOrigin: itemOrigin,
-                timeout: timeout
-            )
         } catch {
             let attemptError = error
             do {
@@ -912,7 +1215,154 @@ extension MenuBarItemManager {
         guard !releaseGuard.didFire else {
             throw EventError.moveTimedOut(item)
         }
-        return timeout
+        let revertedToStart = itemOrigin == itemBounds.origin
+        if revertedToStart {
+            MenuBarItemManager.diagLog.debug(
+                "Move events (\(strategy)) left \(liveItem.logString) at its starting origin (\(itemOrigin.x),\(itemOrigin.y))"
+            )
+        }
+        return MoveEventsOutcome(
+            timeout: timeout,
+            revertedToStart: revertedToStart,
+            strategy: strategy
+        )
+    }
+
+    /// Builds a faithful drag on the item's own menu-bar row. The strict
+    /// transport classifier has already proved both endpoints are on the
+    /// selected display and in one notch-safe segment.
+    private func faithfulDragSteps(
+        itemBounds: CGRect,
+        targetPoints: (start: CGPoint, end: CGPoint)
+    ) -> [MoveGesture.Step] {
+        let barY = itemBounds.minY
+        return MoveGesture.faithfulDrag(
+            start: CGPoint(x: itemBounds.midX, y: barY),
+            end: CGPoint(x: targetPoints.end.x, y: barY),
+            intermediateSteps: 3
+        )
+    }
+
+    /// Posts one coherent faithful drag, and always ends it with a release on
+    /// the bar before propagating a failure.
+    private func postFaithfulDragSteps(
+        _ steps: [MoveGesture.Step],
+        item: MenuBarItem,
+        source: CGEventSource,
+        startOrigin: CGPoint,
+        timeout: Duration,
+        openingEvent: CGEvent,
+        releaseGuard: PressReleaseGuard,
+        destination: MoveDestination,
+        on displayID: CGDirectDisplayID
+    ) async throws -> CGPoint {
+        guard steps.last?.subtype == .mouseUp else {
+            throw EventError.eventCreationFailure(item)
+        }
+        let dragSteps = steps.dropLast()
+
+        var itemOrigin = startOrigin
+        var responseItem = item
+        for (index, step) in dragSteps.enumerated() {
+            let liveItem: MenuBarItem
+            let event: CGEvent
+            if index == 0 {
+                guard step.subtype == .mouseDown else {
+                    throw EventError.eventCreationFailure(item)
+                }
+                liveItem = item
+                event = openingEvent
+            } else {
+                let endpoints = try await resolveCurrentMoveEndpoints(
+                    source: item,
+                    destination: destination.targetItem,
+                    on: displayID
+                )
+                _ = try validateMoveEndpointGeometry(
+                    item: endpoints.source,
+                    target: endpoints.target,
+                    snapshot: endpoints.snapshot,
+                    on: displayID
+                )
+                liveItem = endpoints.source
+                guard let liveEvent = CGEvent.menuBarItemEvent(
+                    item: liveItem,
+                    source: source,
+                    type: .move(step.subtype),
+                    location: step.point
+                ) else {
+                    throw EventError.eventCreationFailure(liveItem)
+                }
+                event = liveEvent
+            }
+            try await scrombleEvent(event, item: liveItem, timeout: timeout)
+            responseItem = liveItem
+            if step.subtype == .mouseDragged {
+                await eventSleep(for: .milliseconds(8))
+            }
+        }
+        itemOrigin = try await waitForMoveEventResponse(
+            from: responseItem,
+            initialOrigin: startOrigin,
+            timeout: timeout
+        )
+
+        // Reflow can move the anchor while the button is held. Re-resolve and
+        // validate the exact release edge instead of using the planned one.
+        let releaseEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        _ = try validateMoveEndpointGeometry(
+            item: releaseEndpoints.source,
+            target: releaseEndpoints.target,
+            snapshot: releaseEndpoints.snapshot,
+            on: displayID
+        )
+        let releaseDestination = releaseEndpoints.destination(matching: destination)
+        let releasePoints = getTargetPoints(
+            forMoving: releaseEndpoints.source,
+            to: releaseDestination,
+            itemBounds: releaseEndpoints.source.bounds,
+            targetBounds: releaseEndpoints.target.bounds,
+            on: displayID
+        )
+        let releasePoint = CGPoint(
+            x: releasePoints.end.x,
+            y: releaseEndpoints.source.bounds.minY
+        )
+        guard let releaseEvent = CGEvent.menuBarItemEvent(
+            item: releaseEndpoints.source,
+            source: source,
+            type: .move(.mouseUp),
+            location: releasePoint
+        ) else {
+            throw EventError.eventCreationFailure(releaseEndpoints.source)
+        }
+        try await scrombleEvent(
+            releaseEvent,
+            item: releaseEndpoints.source,
+            timeout: timeout,
+            repeating: 2
+        )
+        releaseGuard.recordReleaseAttempt(delivered: true)
+
+        // A revert returns to the start and therefore cannot be awaited as an
+        // origin change after release. Give the drop one short settling beat
+        // and re-resolve the exact source before reading its resting origin.
+        await eventSleep(for: .milliseconds(30))
+        let restingEndpoints = try await resolveCurrentMoveEndpoints(
+            source: item,
+            destination: destination.targetItem,
+            on: displayID
+        )
+        itemOrigin = restingEndpoints.source.bounds.origin
+        return itemOrigin
+    }
+
+    private var faithfulDragMovesEnabled: Bool {
+        (Defaults.object(forKey: .faithfulDragMoves) as? Bool) ?? Defaults.DefaultValue.faithfulDragMoves
     }
 
     /// Checks if a menu bar item is in a "blocked" state (positioned at x=-1 off-screen).
@@ -1478,7 +1928,7 @@ extension MenuBarItemManager {
                     attemptMouseLocation = try getMouseLocation()
                     MouseHelpers.hideCursor(watchdogTimeout: options.watchdogTimeout ?? .seconds(2))
                 }
-                let attemptTimeout = try await postMoveEvents(
+                let outcome = try await postMoveEvents(
                     item: item,
                     destination: destination,
                     on: resolvedDisplayID,
@@ -1501,7 +1951,7 @@ extension MenuBarItemManager {
                 // successful moves (#889).
                 updateMoveOperationTimeout(
                     Self.nextMoveOperationTimeout(
-                        after: attemptTimeout,
+                        after: outcome.timeout,
                         outcome: landedOnDestination ? .landed : .displacedWithoutLanding
                     ),
                     for: item
@@ -1592,6 +2042,9 @@ extension MenuBarItemManager {
                     throw error
                 }
                 if case EventError.moveTimedOut = error {
+                    throw error
+                }
+                if case EventError.unsafeMovePath = error {
                     throw error
                 }
                 // Also definitive for the duration of this call: a hung owner

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -382,11 +382,8 @@ extension MenuBarItemManager {
                     item: item,
                     to: .leftOfItem(controlItems.hidden),
                     options: .init(
-
                         shouldBegin: shouldBeginBatchMove,
-
                         didFinishWhileHoldingGate: didFinishBatchMove
-
                     )
                 )
                 notchOverflowEjectedUIDs.insert(uid)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -381,8 +381,13 @@ extension MenuBarItemManager {
                 try await move(
                     item: item,
                     to: .leftOfItem(controlItems.hidden),
-                    shouldBegin: shouldBeginBatchMove,
-                    didFinishWhileHoldingGate: didFinishBatchMove
+                    options: .init(
+
+                        shouldBegin: shouldBeginBatchMove,
+
+                        didFinishWhileHoldingGate: didFinishBatchMove
+
+                    )
                 )
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -351,7 +351,7 @@ extension MenuBarItemManager {
                 failureLedger.recordSuccess(for: item)
             } catch {
                 if !Self.moveAlreadyFiledFailure(for: error) {
-                    failureLedger.recordFailure(for: item, kind: Self.failureKind(of: error))
+                    failureLedger.recordFailure(for: item, kind: ledgerFailureKind(for: error, item: item))
                 }
                 MenuBarItemManager.diagLog.error(
                     "Notch overflow rebalance: failed to eject \(item.logString): \(error)"

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemManager+NotchOverflow.swift
@@ -135,14 +135,18 @@ extension MenuBarItemManager {
     /// handoff waits until the planner has actually found overflow — a pass
     /// with nothing to do must return without arming anything, or it drives
     /// the apply on every cache tick forever (#881).
-    func rebalanceNotchOverflowIfNeeded(items: [MenuBarItem], controlItems: ControlItemPair) async {
-        guard let appState else { return }
-        guard appState.settings.advanced.enableMenuBarItemOverflow else { return }
+    func rebalanceNotchOverflowIfNeeded(
+        items: [MenuBarItem],
+        controlItems: ControlItemPair,
+        shouldBeginMove: (@MainActor () -> Bool)? = nil
+    ) async -> CacheDrivenMoveOutcome {
+        guard let appState else { return .noAttempt }
+        guard appState.settings.advanced.enableMenuBarItemOverflow else { return .noAttempt }
         guard controlItems.canRepositionControlItems else {
             MenuBarItemManager.diagLog.debug(
                 "Notch overflow rebalance: skipping for provisional AX-frame correlation"
             )
-            return
+            return .noAttempt
         }
 
         // Never fight another mover. Each of these owns the layout while it
@@ -152,12 +156,12 @@ extension MenuBarItemManager {
               !isRestoringItemOrder,
               !isInStartupSettling,
               !isBulkApplyInProgress
-        else { return }
+        else { return .noAttempt }
 
         // A temporarily-shown item is deliberately parked in visible for as
         // long as the user is interacting with it. Ejecting it would cancel
         // the reveal the user just asked for.
-        guard temporarilyShownItemContexts.isEmpty else { return }
+        guard temporarilyShownItemContexts.isEmpty else { return .noAttempt }
 
         // If the bar just refused synthetic drags in a profile apply, the
         // rebalance's own drags will fare no better — and each eject is a
@@ -168,7 +172,7 @@ extension MenuBarItemManager {
         // backoff cannot help because the rebalance's items are typically
         // different from the ones that failed in the batch.
         guard isAutomaticBulkApplyPermitted(caller: "Notch overflow rebalance", quietly: true) else {
-            return
+            return .noAttempt
         }
 
         let activeMenuBarScreen = NSScreen.screenWithActiveMenuBar
@@ -180,7 +184,7 @@ extension MenuBarItemManager {
         ),
             let screen = activeMenuBarScreen,
             let notch = screen.frameOfNotch
-        else { return }
+        else { return .noAttempt }
 
         // Mid-relocation between displays the item bounds straddle two screens
         // and the budget cannot be trusted. Same guard the persist path uses,
@@ -208,12 +212,12 @@ extension MenuBarItemManager {
         guard !LayoutSolver.itemsSpanMultipleDisplays(
             itemCenters: unparkedItems.map { CGPoint(x: $0.bounds.midX, y: $0.bounds.midY) },
             screenFrames: NSScreen.screens.map { CGDisplayBounds($0.displayID) }
-        ) else { return }
+        ) else { return .noAttempt }
 
         if let last = lastNotchRebalanceTimestamp,
            Date.now.timeIntervalSince(last) < Self.notchRebalanceCooldown
         {
-            return
+            return .noAttempt
         }
 
         let hiddenCtrlUID = controlItems.hidden.uniqueIdentifier
@@ -286,7 +290,7 @@ extension MenuBarItemManager {
             uidWidths: uidWidths,
             availableWidth: availableWidth
         )
-        guard !result.overflowUIDs.isEmpty else { return }
+        guard !result.overflowUIDs.isEmpty else { return .noAttempt }
 
         // A profile apply is the better tool: it re-runs this same planner and
         // restores the saved order at the same time.
@@ -307,7 +311,7 @@ extension MenuBarItemManager {
                 "Notch overflow rebalance: deferring \(result.overflowUIDs.count) item(s) to the profile apply"
             )
             scheduleProfileResort()
-            return
+            return .noAttempt
         }
 
         // Bounce-back guard. Every UID the planner wants to eject is one this
@@ -319,7 +323,7 @@ extension MenuBarItemManager {
             MenuBarItemManager.diagLog.debug(
                 "Notch overflow rebalance: standing down; all \(result.overflowUIDs.count) candidate(s) were already ejected once"
             )
-            return
+            return .noAttempt
         }
 
         lastNotchRebalanceTimestamp = .now
@@ -329,6 +333,33 @@ extension MenuBarItemManager {
             \(budget.logString)
             """
         )
+
+        // The cache snapshot owns the first move. Each accepted attempt then
+        // adopts its timestamp before releasing moveGate, so later moves in
+        // this batch accept its own work but reject an intervening user move.
+        var batchMovePreflight = BatchMovePreflightState()
+        var didAcceptMoveAttempt = false
+        var didAcceptCurrentMove = false
+        var didCompleteMove = false
+        var didFailAcceptedMove = false
+        func shouldBeginBatchMove() -> Bool {
+            let shouldBegin = batchMovePreflight.shouldBeginMove(
+                currentTimestamp: lastMoveOperationTimestamp,
+                initialPreflight: {
+                    shouldBeginMove?() ?? true
+                }
+            )
+            if shouldBegin {
+                didAcceptMoveAttempt = true
+                didAcceptCurrentMove = true
+            }
+            return shouldBegin
+        }
+        func didFinishBatchMove() {
+            batchMovePreflight.recordMoveGateExit(
+                timestamp: lastMoveOperationTimestamp
+            )
+        }
 
         // Leftmost-first, so each ejected item lands deeper in hidden than the
         // one before it and the surviving visible order is preserved.
@@ -345,11 +376,28 @@ extension MenuBarItemManager {
                 )
                 continue
             }
+            didAcceptCurrentMove = false
             do {
-                try await move(item: item, to: .leftOfItem(controlItems.hidden))
+                try await move(
+                    item: item,
+                    to: .leftOfItem(controlItems.hidden),
+                    shouldBegin: shouldBeginBatchMove,
+                    didFinishWhileHoldingGate: didFinishBatchMove
+                )
                 notchOverflowEjectedUIDs.insert(uid)
                 failureLedger.recordSuccess(for: item)
+                didCompleteMove = true
+            } catch EventError.moveSuperseded {
+                didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
+                MenuBarItemManager.diagLog.debug(
+                    "Stopping stale notch-overflow rebalance before moving \(item.logString)"
+                )
+                if didFailAcceptedMove {
+                    return .failedAttempt
+                }
+                return didCompleteMove ? .completed : .noAttempt
             } catch {
+                didFailAcceptedMove = didFailAcceptedMove || didAcceptCurrentMove
                 if !Self.moveAlreadyFiledFailure(for: error) {
                     failureLedger.recordFailure(for: item, kind: ledgerFailureKind(for: error, item: item))
                 }
@@ -358,5 +406,12 @@ extension MenuBarItemManager {
                 )
             }
         }
+        if didFailAcceptedMove {
+            return .failedAttempt
+        }
+        if didCompleteMove {
+            return .completed
+        }
+        return didAcceptMoveAttempt ? .failedAttempt : .noAttempt
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
@@ -53,6 +53,8 @@ extension MenuBarItemManager {
             case superseded
             /// The press outlived its deadline and was released by the guard.
             case overran
+            /// The selected endpoints do not form a safe path on one display.
+            case unsafePath
             /// Anything else.
             case other
         }
@@ -86,6 +88,8 @@ extension MenuBarItemManager {
             /// A press was released by the deadline guard, or the move as a
             /// whole ran past its deadline.
             case overran
+            /// No transport can safely connect the selected endpoints.
+            case unsafePath
             /// Every attempt displaced the item without landing it.
             case budgetExhausted
             /// The final attempt failed for an unclassified reason.
@@ -103,7 +107,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .targetMoved, .targetRetreating, .ownerAlwaysSilent, .ownerSilent, .overran, .budgetExhausted, .other:
                     true
-                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded:
+                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded, .unsafePath:
                     false
                 }
             }
@@ -115,7 +119,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent:
                     true
-                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other:
+                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .unsafePath, .budgetExhausted, .other:
                     false
                 }
             }
@@ -132,6 +136,7 @@ extension MenuBarItemManager {
                 case .destinationGone: "destination gone"
                 case .superseded: "superseded"
                 case .overran: "overran deadline"
+                case .unsafePath: "unsafe path"
                 case .budgetExhausted: "budget exhausted"
                 case .other: "other"
                 }
@@ -248,6 +253,8 @@ extension MenuBarItemManager {
                     return .stop(.superseded)
                 case .overran:
                     return .stop(.overran)
+                case .unsafePath:
+                    return .stop(.unsafePath)
                 case .ownerSilent:
                     // An owner with a standing record of ignoring synthetic
                     // events gets no further attempts once it fails this way
@@ -308,6 +315,8 @@ extension MenuBarItemManager {
                 .superseded
             case .moveTimedOut:
                 .overran
+            case .unsafeMovePath:
+                .unsafePath
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
                  .itemNotMovable, .menuTrackingActive, .eventWindowMismatch, .staleDestination,
                  .inputPauseTimedOut, .dropReverted, .moveEngineBusy:
@@ -344,7 +353,7 @@ extension MenuBarItemManager {
         case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
              .itemNotMovable, .missingItemBounds, .missingDestinationBounds, .menuTrackingActive, .eventWindowMismatch,
              .staleDestination, .inputPauseTimedOut, .moveSuperseded, .dropReverted,
-             .moveEngineBusy, .moveTimedOut:
+             .moveEngineBusy, .moveTimedOut, .unsafeMovePath:
             return .other
         }
     }
@@ -411,6 +420,8 @@ extension MenuBarItemManager {
             EventError.moveSuperseded(item)
         case .overran:
             EventError.moveTimedOut(item)
+        case .unsafePath:
+            EventError.unsafeMovePath(item)
         case .ownerAlwaysSilent, .ownerSilent, .other:
             (lastError as? EventError) ?? EventError.cannotComplete
         case .budgetExhausted:

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemManager/MenuBarItemMovePolicy.swift
@@ -49,6 +49,11 @@ extension MenuBarItemManager {
             case itemGone
             /// The destination anchor no longer reports bounds.
             case destinationGone
+            /// The destination's identity no longer matches the plan: the
+            /// target window was recycled or the endpoint geometry is no
+            /// longer usable. Retrying would drag the item against geometry
+            /// the bar no longer has.
+            case staleDestination
             /// The caller's condition changed; the move is obsolete.
             case superseded
             /// The press outlived its deadline and was released by the guard.
@@ -84,6 +89,9 @@ extension MenuBarItemManager {
             case ownerSilent
             case itemGone
             case destinationGone
+            /// The destination anchor no longer matches the plan (recycled
+            /// target window or unusable endpoint geometry).
+            case staleDestination
             case superseded
             /// A press was released by the deadline guard, or the move as a
             /// whole ran past its deadline.
@@ -107,7 +115,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .targetMoved, .targetRetreating, .ownerAlwaysSilent, .ownerSilent, .overran, .budgetExhausted, .other:
                     true
-                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded, .unsafePath:
+                case .refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .staleDestination, .superseded, .unsafePath:
                     false
                 }
             }
@@ -119,7 +127,7 @@ extension MenuBarItemManager {
                 switch self {
                 case .ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent:
                     true
-                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .unsafePath, .budgetExhausted, .other:
+                case .refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .staleDestination, .superseded, .overran, .unsafePath, .budgetExhausted, .other:
                     false
                 }
             }
@@ -134,6 +142,7 @@ extension MenuBarItemManager {
                 case .ownerSilent: "owner silent"
                 case .itemGone: "item gone"
                 case .destinationGone: "destination gone"
+                case .staleDestination: "stale destination"
                 case .superseded: "superseded"
                 case .overran: "overran deadline"
                 case .unsafePath: "unsafe path"
@@ -247,6 +256,8 @@ extension MenuBarItemManager {
                     return .stop(.itemGone)
                 case .destinationGone:
                     return .stop(.destinationGone)
+                case .staleDestination:
+                    return .stop(.staleDestination)
                 case .ownerUnresponsive:
                     return .stop(.ownerUnresponsive)
                 case .superseded:
@@ -317,8 +328,10 @@ extension MenuBarItemManager {
                 .overran
             case .unsafeMovePath:
                 .unsafePath
+            case .staleDestination:
+                .staleDestination
             case .cannotComplete, .invalidEventSource, .missingMouseLocation, .eventCreationFailure,
-                 .itemNotMovable, .menuTrackingActive, .eventWindowMismatch, .staleDestination,
+                 .itemNotMovable, .menuTrackingActive, .eventWindowMismatch,
                  .inputPauseTimedOut, .dropReverted, .moveEngineBusy:
                 .other
             }
@@ -416,6 +429,8 @@ extension MenuBarItemManager {
             EventError.missingItemBounds(item)
         case .destinationGone:
             EventError.missingDestinationBounds(destinationItem ?? item)
+        case .staleDestination:
+            EventError.staleDestination(item)
         case .superseded:
             EventError.moveSuperseded(item)
         case .overran:

--- a/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
+++ b/Thaw/Settings/SettingsPanes/Layout/LayoutBarsSection.swift
@@ -154,7 +154,7 @@ struct LayoutBarsSection: View {
                     .font(.headline)
                     .padding(.leading, 8)
 
-                LayoutBar(imageCache: appState.imageCache, section: name)
+                LayoutBar(section: name)
             }
         }
     }

--- a/Thaw/Utilities/Defaults.swift
+++ b/Thaw/Utilities/Defaults.swift
@@ -245,6 +245,7 @@ nonisolated extension Defaults {
         static let postMoveEventsToWindowOwner = true
         static let discardStrayMoveEvents = true
         static let failFastOnEventWindowMismatch = false
+        static let faithfulDragMoves = false
         static let axMessagingTimeout = SharedConstants.axMessagingTimeout
     }
 }
@@ -545,6 +546,31 @@ nonisolated extension Defaults {
         ///
         /// Hidden diagnostic flag; not exposed in Settings. Default: false.
         case failFastOnEventWindowMismatch = "failFastOnEventWindowMismatch"
+
+        /// Whether an eligible move presses on the item where it sits and
+        /// drags it to the destination (a faithful gesture) instead of the
+        /// press-at-destination "teleport".
+        ///
+        /// On macOS 26 Control Center hosts every status item as a remote
+        /// FrontBoard scene owned by the source app. The teleport presses at
+        /// the destination with the item's window stamped and relies on
+        /// Control Center to relocate a passive item; when the source app's
+        /// status-item scene is cold, the drop can complete on Control
+        /// Center's side while the app never commits the new position, so
+        /// Control Center restores the item's autosaved slot (the "revert").
+        /// Pressing on the item makes the source app start the drag itself
+        /// (`NSStatusItemStartDragAction`) with a warm scene. The transport
+        /// classifier uses this only for an on-screen path inside one safe
+        /// notch segment. Parked and cross-notch endpoints have explicitly
+        /// named teleport transports; invalid or cross-display geometry is
+        /// rejected rather than silently falling back. Inferred from field
+        /// logs, not yet confirmed on a live bar, so it is opt-in.
+        ///
+        /// Enable with:
+        ///   defaults write com.stonerl.Thaw faithfulDragMoves -bool YES
+        ///
+        /// Hidden diagnostic flag; not exposed in Settings. Default: false.
+        case faithfulDragMoves = "faithfulDragMoves"
 
         /// Seconds an accessibility message may block before it fails.
         ///

--- a/Thaw/Utilities/DiagnosticRedactor.swift
+++ b/Thaw/Utilities/DiagnosticRedactor.swift
@@ -109,8 +109,10 @@ nonisolated struct DiagnosticRedactor {
         // Values written after privacy-sensitive labels. This catches
         // trigger-like values that can appear in a log without requiring the
         // report code to depend on a particular automation implementation.
+        // The optional quote after the label covers JSON-style field names
+        // such as {"wifiSSID":"Home Network"}.
         result = result.replacingOccurrences(
-            of: #"(?i)\b(?:ssid|wifi(?:ssid|network)?|networkname|devicename|bluetoothdevice|audiodevice|focusmode|trigger(?:name|value)?|condition(?:name|value)?|script(?:path|output)|location(?:name|label)?)\s*[=:]\s*(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^,;\r\n]+)"#,
+            of: #"(?i)\b(?:ssid|wifi(?:ssid|network)?|networkname|devicename|bluetoothdevice|audiodevice|focusmode|trigger(?:name|value)?|condition(?:name|value)?|script(?:path|output)|location(?:name|label)?)"?\s*[=:]\s*(?:\"[^\"\r\n]*\"|'[^'\r\n]*'|[^,;\r\n]+)"#,
             with: "<sensitive-value>",
             options: .regularExpression
         )

--- a/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
+++ b/ThawTests/MenuBar/ControlItem/ControlItemRecoveryTests.swift
@@ -616,6 +616,18 @@ struct ControlCenterRelaunchGraceTests {
         #expect(MenuBarItemManager.shouldCountControlItemLookupFailure(hostUptime: nil))
     }
 
+    @Test("Layout-editor refreshes never advance missing-control recovery")
+    func layoutEditorRefreshDoesNotCount() {
+        #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: nil,
+            suppressAutomaticMoves: true
+        ))
+        #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(
+            hostUptime: .seconds(3600),
+            suppressAutomaticMoves: true
+        ))
+    }
+
     @Test("A custom grace period is respected")
     func customGraceIsRespected() {
         #expect(!MenuBarItemManager.shouldCountControlItemLookupFailure(

--- a/ThawTests/MenuBar/Items/BulkMoveCoordinationTests.swift
+++ b/ThawTests/MenuBar/Items/BulkMoveCoordinationTests.swift
@@ -1,0 +1,107 @@
+//
+//  BulkMoveCoordinationTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+@Suite("Bulk move coordination")
+struct BulkMoveCoordinationTests {
+    typealias Outcome = MenuBarItemManager.CacheDrivenMoveOutcome
+    typealias State = MenuBarItemManager.BatchMovePreflightState
+
+    private let initialTimestamp = ContinuousClock.now
+
+    @Test("Only failed cache-driven moves suppress recovery side effects", arguments: [
+        (Outcome.noAttempt, false, false, false),
+        (Outcome.completed, true, false, false),
+        (Outcome.failedAttempt, true, true, true),
+    ])
+    @MainActor
+    func cacheDrivenMoveRecoveryPolicy(
+        outcome: Outcome,
+        needsRecache: Bool,
+        suppressesMoves: Bool,
+        suppressesPersistence: Bool
+    ) {
+        #expect(outcome.needsAuthoritativeRecache == needsRecache)
+        #expect(outcome.shouldSuppressAutomaticMovesDuringRecache == suppressesMoves)
+        #expect(outcome.shouldSuppressSavedOrderPersistenceDuringRecache == suppressesPersistence)
+    }
+
+    @Test("The cache snapshot owns the first move's preflight")
+    func firstMoveUsesInitialPreflight() {
+        let state = State()
+        var initialPreflightCalls = 0
+
+        let shouldBegin = state.shouldBeginMove(
+            currentTimestamp: initialTimestamp,
+            initialPreflight: {
+                initialPreflightCalls += 1
+                return false
+            }
+        )
+
+        #expect(!shouldBegin)
+        #expect(initialPreflightCalls == 1)
+    }
+
+    @Test("A batch adopts its own move timestamp for the next item")
+    func ownedTimestampAllowsNextItem() {
+        var state = State()
+        let ownedTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        state.recordMoveGateExit(timestamp: ownedTimestamp)
+        var initialPreflightCalls = 0
+
+        let shouldBegin = state.shouldBeginMove(
+            currentTimestamp: ownedTimestamp,
+            initialPreflight: {
+                initialPreflightCalls += 1
+                return false
+            }
+        )
+
+        #expect(shouldBegin)
+        #expect(initialPreflightCalls == 0)
+    }
+
+    @Test("A user timestamp between batch items supersedes the remainder")
+    func interveningUserTimestampStopsBatch() {
+        var state = State()
+        let ownedTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        let userTimestamp = initialTimestamp.advanced(by: .milliseconds(2))
+        state.recordMoveGateExit(timestamp: ownedTimestamp)
+
+        #expect(!state.shouldBeginMove(
+            currentTimestamp: userTimestamp,
+            initialPreflight: { true }
+        ))
+    }
+
+    @Test("Each owned item advances the batch timestamp")
+    func successiveOwnedMovesAdvanceTimestamp() {
+        var state = State()
+        let firstMoveTimestamp = initialTimestamp.advanced(by: .milliseconds(1))
+        let secondMoveTimestamp = initialTimestamp.advanced(by: .milliseconds(2))
+
+        state.recordMoveGateExit(timestamp: firstMoveTimestamp)
+        #expect(state.shouldBeginMove(
+            currentTimestamp: firstMoveTimestamp,
+            initialPreflight: { false }
+        ))
+
+        state.recordMoveGateExit(timestamp: secondMoveTimestamp)
+        #expect(state.shouldBeginMove(
+            currentTimestamp: secondMoveTimestamp,
+            initialPreflight: { false }
+        ))
+        #expect(!state.shouldBeginMove(
+            currentTimestamp: firstMoveTimestamp,
+            initialPreflight: { true }
+        ))
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
+++ b/ThawTests/MenuBar/Items/MoveEndpointIdentityTests.swift
@@ -127,4 +127,38 @@ struct MoveEndpointIdentityTests {
             destinationWindowID: destination.windowID
         ) == nil)
     }
+
+    @Test("Parked lane geometry is not mistaken for a left display")
+    func parkedLaneIsExplicit() {
+        let selected: CGDirectDisplayID = 1
+        let left: CGDirectDisplayID = 2
+        let displays = [
+            MenuBarItemManager.MoveDisplayGeometry(
+                id: selected,
+                bounds: CGRect(x: 0, y: 0, width: 1728, height: 1117)
+            ),
+            MenuBarItemManager.MoveDisplayGeometry(
+                id: left,
+                bounds: CGRect(x: -2560, y: 0, width: 2560, height: 1440)
+            ),
+        ]
+        let parked = CGRect(x: -2450, y: 0, width: 24, height: 24)
+
+        #expect(MenuBarItemManager.moveEndpointDisposition(
+            bounds: parked,
+            isOnScreen: false,
+            selectedDisplayID: selected,
+            displays: displays,
+            parkedLaneYRange: 0 ... 24,
+            controlDividerX: 1400
+        ) == .parked)
+        #expect(MenuBarItemManager.moveEndpointDisposition(
+            bounds: parked,
+            isOnScreen: true,
+            selectedDisplayID: selected,
+            displays: displays,
+            parkedLaneYRange: 0 ... 24,
+            controlDividerX: 1400
+        ) == .otherDisplay(left))
+    }
 }

--- a/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
+++ b/ThawTests/MenuBar/Items/MoveFailureAttributionTests.swift
@@ -83,6 +83,7 @@ struct MoveFailureAttributionTests {
         .staleDestination(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .moveTimedOut(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .moveEngineBusy(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
+        .unsafeMovePath(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .missingItemBounds(.fixture(tag: .appItem(bundleID: "a", title: "b"), windowID: 1)),
         .cannotComplete,
     ])

--- a/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
@@ -166,6 +166,23 @@ struct MoveGatePreflightTests {
 
         #expect(events == ["first-wait", "second-body", "first-body"])
     }
+
+    @Test("The transaction budget caps waits and reports exhaustion")
+    func transactionBudgetCapsWaits() async throws {
+        let elapsed = OSAllocatedUnfairLock(initialState: Duration.zero)
+        let budget = MenuBarItemManager.MoveTransactionBudget(
+            limit: .milliseconds(100),
+            elapsed: { elapsed.withLock { $0 } },
+            sleeper: { duration in elapsed.withLock { $0 += duration } }
+        )
+
+        try await budget.sleep(for: .milliseconds(60))
+        #expect(try budget.remaining() == .milliseconds(40))
+        await #expect(throws: MenuBarItemManager.MoveDeadlineExceeded.self) {
+            try await budget.sleep(for: .milliseconds(50))
+        }
+        #expect(elapsed.withLock { $0 } == .milliseconds(100))
+    }
 }
 
 private actor MoveTestLatch {

--- a/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGatePreflightTests.swift
@@ -38,6 +38,7 @@ struct MoveGatePreflightTests {
             try await manager.move(
                 item: movedItem,
                 to: .leftOfItem(targetItem),
+                skipInputPause: true,
                 options: .init(
                     shouldBegin: {
                         events.append("preflight")

--- a/ThawTests/MenuBar/Items/MoveGestureTests.swift
+++ b/ThawTests/MenuBar/Items/MoveGestureTests.swift
@@ -1,0 +1,231 @@
+//
+//  MoveGestureTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import CoreGraphics
+import Foundation
+import Testing
+@testable import Thaw
+
+/// Tests for the pure faithful-drag gesture builder used by the on-item drop
+/// strategy. The geometry is exercised without a live menu bar.
+@Suite("Move gesture")
+struct MoveGestureTests {
+    private typealias Gesture = MenuBarItemManager.MoveGesture
+    private typealias Path = MenuBarItemManager.HorizontalPathDisposition
+    private typealias Transport = MenuBarItemManager.MoveTransportDecision
+
+    /// A gesture is a well-formed drag: it opens with a mouse-down on the
+    /// press point and closes with a mouse-up on the destination, with a
+    /// settling drag onto the destination just before the release.
+    @Test("A faithful drag opens with a down on the item and closes with an up on the destination")
+    func gestureIsWellFormed() {
+        let start = CGPoint(x: 1452, y: 16.5)
+        let end = CGPoint(x: -3725, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 3)
+
+        #expect(steps.first == Gesture.Step(subtype: .mouseDown, point: start))
+        #expect(steps.last == Gesture.Step(subtype: .mouseUp, point: end))
+        #expect(steps.dropLast().last == Gesture.Step(subtype: .mouseDragged, point: end))
+        // down + 3 interpolated drags + settle drag + up.
+        #expect(steps.count == 6)
+        // Exactly one down and one up; everything else is a drag.
+        #expect(steps.count(where: { $0.subtype == .mouseDown }) == 1)
+        #expect(steps.count(where: { $0.subtype == .mouseUp }) == 1)
+        #expect(steps.count(where: { $0.subtype == .mouseDragged }) == 4)
+    }
+
+    /// The gesture always contains at least one interpolated drag, even when
+    /// the caller asks for none, so the item is never teleported by a bare
+    /// down/up pair on this path.
+    @Test("The intermediate step count is clamped to at least one")
+    func intermediateStepsAreClamped() {
+        let start = CGPoint(x: 1000, y: 16.5)
+        let end = CGPoint(x: 200, y: 16.5)
+
+        let zero = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 0)
+        let negative = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: -5)
+
+        // down + 1 interpolated drag + settle drag + up.
+        #expect(zero.count == 4)
+        #expect(negative.count == 4)
+    }
+
+    /// Every event of an on-bar gesture shares the caller-pinned vertical
+    /// coordinate. This is the invariant that keeps Control Center reading a
+    /// reorder: a path that dips below the bar is read as a removal, which is
+    /// what orphaned a hosted item's scene in the field.
+    @Test("A gesture pinned to one bar line keeps every event on that line")
+    func gestureStaysOnTheBarLine() {
+        let barY: CGFloat = 16.5
+        let start = CGPoint(x: 1452, y: barY)
+        let end = CGPoint(x: -3725, y: barY)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 4)
+
+        #expect(steps.allSatisfy { $0.point.y == barY })
+    }
+
+    /// The interpolated drag points march monotonically from the press toward
+    /// the destination and never overshoot either endpoint, so the drag reads
+    /// as one continuous sweep.
+    @Test("Interpolated points advance monotonically and stay between the endpoints")
+    func interpolatedPointsAreMonotonic() {
+        let start = CGPoint(x: 1452, y: 16.5)
+        let end = CGPoint(x: -3725, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 5)
+        // The release intentionally repeats the destination occupied by the
+        // settling drag, so monotonicity applies through the final drag rather
+        // than across the stationary mouse-up event.
+        let xs = steps.dropLast().map(\.point.x)
+
+        // Strictly decreasing overall (start.x > end.x here).
+        #expect(zip(xs, xs.dropFirst()).allSatisfy { $0 > $1 })
+        let lowerBound = min(start.x, end.x)
+        let upperBound = max(start.x, end.x)
+        #expect(steps.allSatisfy { $0.point.x >= lowerBound && $0.point.x <= upperBound })
+    }
+
+    /// A rightward move (destination to the right of the item) advances the
+    /// other way, confirming the builder is direction-agnostic.
+    @Test("A rightward move advances left to right")
+    func rightwardMoveAdvances() {
+        let start = CGPoint(x: 200, y: 16.5)
+        let end = CGPoint(x: 1000, y: 16.5)
+
+        let steps = Gesture.faithfulDrag(start: start, end: end, intermediateSteps: 3)
+        let xs = steps.dropLast().map(\.point.x)
+
+        #expect(zip(xs, xs.dropFirst()).allSatisfy { $0 < $1 })
+    }
+
+    // MARK: Transport safety
+
+    @Test("Horizontal paths distinguish safe segments, notch crossings, and invalid endpoints")
+    func horizontalPathClassification() {
+        let display: ClosedRange<CGFloat> = 0 ... 1470
+        let notch: ClosedRange<CGFloat> = 645 ... 825
+
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 100,
+            destinationX: 600,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .sameSafeSegment)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 900,
+            destinationX: 1400,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .sameSafeSegment)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 600,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .crossesNotch)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: 700,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .invalidEndpoint)
+        #expect(MenuBarItemManager.horizontalPathDisposition(
+            sourceX: -1,
+            destinationX: 900,
+            displayXRange: display,
+            reservedNotchXRange: notch
+        ) == .invalidEndpoint)
+    }
+
+    @Test("Faithful dragging is selected only for one safe on-screen segment")
+    func faithfulTransportSelection() {
+        let selected: CGDirectDisplayID = 1
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.faithfulDrag))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: false,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.teleport))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: true,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .use(.teleport))
+    }
+
+    @Test("Parked and cross-notch teleports are explicit decisions")
+    func explicitTeleportSelection() {
+        let selected: CGDirectDisplayID = 1
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: nil,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .invalidEndpoint
+        ) == .use(.parkedTeleport))
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .crossesNotch
+        ) == .use(.crossNotchTeleport))
+    }
+
+    @Test("Cross-display and invalid on-screen paths are rejected")
+    func unsafeTransportIsRejected() {
+        let selected: CGDirectDisplayID = 1
+        let other: CGDirectDisplayID = 2
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: other,
+            selectedDisplayID: selected,
+            horizontalPath: .sameSafeSegment
+        ) == .rejectUnsafePath)
+        #expect(MenuBarItemManager.strictTransportDecision(
+            faithfulDragEnabled: true,
+            itemIsControlItem: false,
+            sourceDisplayID: selected,
+            destinationDisplayID: selected,
+            selectedDisplayID: selected,
+            horizontalPath: .invalidEndpoint
+        ) == .rejectUnsafePath)
+    }
+
+    @Test("A cross-notch teleport posts no intermediate center coordinate")
+    func crossNotchTeleportUsesExactDestination() {
+        let destination = CGPoint(x: 1200, y: 0)
+        let locations = MenuBarItemManager.moveEventLocations(
+            targetPoints: (start: destination, end: destination),
+            faithfulDragStart: nil
+        )
+
+        #expect(locations.press == destination)
+        #expect(locations.release == destination)
+        #expect(locations.press.x != 735)
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveLayoutSettlingTests.swift
+++ b/ThawTests/MenuBar/Items/MoveLayoutSettlingTests.swift
@@ -1,0 +1,69 @@
+//
+//  MoveLayoutSettlingTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import Testing
+@testable import Thaw
+
+/// The polling loop behind `waitForLayoutToSettle`: a landing is judged
+/// only once two consecutive readings of the bar agree, and never later
+/// than the poll budget.
+@Suite("Move layout settling")
+struct MoveLayoutSettlingTests {
+    @Test("Two matching consecutive readings settle the value")
+    func settlesOnTheFirstRepeat() async {
+        let values = [1465, 1445, 1427, 1427, 1400]
+        var index = 0
+        var waits = 0
+
+        let outcome = await MenuBarItemManager.settledReading(
+            maxPolls: 10,
+            read: {
+                defer { index += 1 }
+                return values[index]
+            },
+            wait: { waits += 1 }
+        )
+
+        #expect(outcome.settled)
+        #expect(outcome.value == 1427)
+        #expect(index == 4)
+        #expect(waits == 3)
+    }
+
+    @Test("A bar that keeps moving gives up after the poll budget")
+    func givesUpAfterTheBudget() async {
+        var next = 0
+
+        let outcome = await MenuBarItemManager.settledReading(
+            maxPolls: 4,
+            read: {
+                next += 1
+                return next
+            },
+            wait: {}
+        )
+
+        #expect(!outcome.settled)
+        #expect(outcome.value == 4)
+    }
+
+    @Test("A single-poll budget returns the first reading unconfirmed")
+    func singlePollIsUnconfirmed() async {
+        var waits = 0
+
+        let outcome = await MenuBarItemManager.settledReading(
+            maxPolls: 1,
+            read: { "only" },
+            wait: { waits += 1 }
+        )
+
+        #expect(!outcome.settled)
+        #expect(outcome.value == "only")
+        #expect(waits == 0)
+    }
+}

--- a/ThawTests/MenuBar/Items/MoveLayoutSettlingTests.swift
+++ b/ThawTests/MenuBar/Items/MoveLayoutSettlingTests.swift
@@ -6,6 +6,7 @@
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 
+import CoreGraphics
 import Testing
 @testable import Thaw
 
@@ -14,6 +15,122 @@ import Testing
 /// than the poll budget.
 @Suite("Move layout settling")
 struct MoveLayoutSettlingTests {
+    @Test("Only a requested final refresh evaluates an unchanged cache for persistence")
+    func validatedMoveCanPersistUnchangedCache() {
+        #expect(!MenuBarItemManager.shouldEvaluateSavedOrderPersistence(
+            cacheChanged: false,
+            forcePersistSavedOrder: false
+        ))
+        #expect(MenuBarItemManager.shouldEvaluateSavedOrderPersistence(
+            cacheChanged: false,
+            forcePersistSavedOrder: true
+        ))
+        #expect(MenuBarItemManager.shouldEvaluateSavedOrderPersistence(
+            cacheChanged: true,
+            forcePersistSavedOrder: false
+        ))
+    }
+
+    @Test("A dropped cache attempt cannot report a completed cycle")
+    @MainActor
+    func droppedCacheAttemptIsIncomplete() {
+        let attempt = MenuBarItemManager.CacheAttempt()
+
+        attempt.recordCompletion(cyclesAtEntry: 12, cyclesAtExit: 12)
+
+        #expect(!attempt.didCompleteCycle)
+    }
+
+    @Test("An accepted cache attempt reports its own completed cycle")
+    @MainActor
+    func acceptedCacheAttemptCompletes() {
+        let attempt = MenuBarItemManager.CacheAttempt()
+
+        attempt.recordCompletion(cyclesAtEntry: 12, cyclesAtExit: 13)
+
+        #expect(attempt.didCompleteCycle)
+    }
+
+    @Test("A cache attempt invalidated by a later move remains incomplete")
+    @MainActor
+    func movedAfterCacheAttemptIsIncomplete() {
+        let attempt = MenuBarItemManager.CacheAttempt()
+
+        attempt.recordCompletion(
+            cyclesAtEntry: 12,
+            cyclesAtExit: 13,
+            snapshotRemainedCurrent: false
+        )
+
+        #expect(!attempt.didCompleteCycle)
+    }
+
+    @Test("A fast layout refresh keeps the cached identity and fresh geometry")
+    func fastRefreshReusesCachedIdentity() {
+        let windowID: CGWindowID = 711
+        let cached = MenuBarItem.fixture(
+            tag: .appItem(
+                bundleID: "com.example.status-item",
+                title: "Item-0",
+                windowID: windowID
+            ),
+            windowID: windowID,
+            bounds: CGRect(x: 1400, y: 0, width: 24, height: 33),
+            sourcePID: 4321,
+            ownerPID: 99,
+            title: "Item-0"
+        )
+        let freshGeometry = MenuBarItem.fixture(
+            tag: .appItem(
+                bundleID: "com.apple.controlcenter",
+                title: "Item-0",
+                windowID: windowID
+            ),
+            windowID: windowID,
+            bounds: CGRect(x: -3700, y: 0, width: 24, height: 33),
+            sourcePID: nil,
+            ownerPID: 99,
+            title: "Item-0",
+            isOnScreen: false
+        )
+
+        let refreshed = MenuBarItemManager.reusingCachedIdentities(
+            in: [freshGeometry],
+            from: [cached]
+        )
+
+        #expect(refreshed.count == 1)
+        #expect(refreshed[0].tag == cached.tag)
+        #expect(refreshed[0].sourcePID == cached.sourcePID)
+        #expect(refreshed[0].bounds == freshGeometry.bounds)
+        #expect(!refreshed[0].isOnScreen)
+    }
+
+    @Test("A recycled window from another owner does not inherit cached identity")
+    func recycledWindowDoesNotReuseCachedIdentity() {
+        let cached = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.old", title: "Item-0", windowID: 711),
+            windowID: 711,
+            sourcePID: 4321,
+            ownerPID: 99,
+            title: "Item-0"
+        )
+        let replacement = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.apple.controlcenter", title: "Item-0", windowID: 711),
+            windowID: 711,
+            sourcePID: nil,
+            ownerPID: 100,
+            title: "Item-0"
+        )
+
+        let refreshed = MenuBarItemManager.reusingCachedIdentities(
+            in: [replacement],
+            from: [cached]
+        )
+
+        #expect(refreshed == [replacement])
+    }
+
     @Test("Two matching consecutive readings settle the value")
     func settlesOnTheFirstRepeat() async {
         let values = [1465, 1445, 1427, 1427, 1400]

--- a/ThawTests/MenuBar/Items/MovePolicyTests.swift
+++ b/ThawTests/MenuBar/Items/MovePolicyTests.swift
@@ -245,6 +245,7 @@ struct MovePolicyTests {
         #expect(Policy.attemptFailure(for: .ownerUnresponsive(item)) == .ownerUnresponsive)
         #expect(Policy.attemptFailure(for: .missingItemBounds(item)) == .itemGone)
         #expect(Policy.attemptFailure(for: .missingDestinationBounds(item)) == .destinationGone)
+        #expect(Policy.attemptFailure(for: .staleDestination(item)) == .staleDestination)
         #expect(Policy.attemptFailure(for: .moveSuperseded(item)) == .superseded)
         #expect(Policy.attemptFailure(for: .moveTimedOut(item)) == .overran)
         #expect(Policy.attemptFailure(for: .unsafeMovePath(item)) == .unsafePath)
@@ -258,6 +259,7 @@ struct MovePolicyTests {
         (.ownerUnresponsive, "ownerUnresponsive"),
         (.itemGone, "missingItemBounds"),
         (.destinationGone, "missingDestinationBounds"),
+        (.staleDestination, "staleDestination"),
         (.superseded, "moveSuperseded"),
         (.overran, "moveTimedOut"),
         (.unsafePath, "unsafeMovePath"),

--- a/ThawTests/MenuBar/Items/MovePolicyTests.swift
+++ b/ThawTests/MenuBar/Items/MovePolicyTests.swift
@@ -144,6 +144,7 @@ struct MovePolicyTests {
         (.ownerUnresponsive, .ownerUnresponsive),
         (.superseded, .superseded),
         (.overran, .overran),
+        (.unsafePath, .unsafePath),
     ])
     func definitiveFailuresStop(failure: Policy.AttemptFailure, reason: Policy.StopReason) {
         #expect(decisions([.failed(failure)]) == [.stop(reason)])
@@ -214,7 +215,7 @@ struct MovePolicyTests {
     }
 
     @Test("Reasons that prove the item did not land skip the final check", arguments: [
-        Policy.StopReason.refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded,
+        Policy.StopReason.refusedByMacOS, .ownerUnresponsive, .itemGone, .destinationGone, .superseded, .unsafePath,
     ])
     func noFinalCheckReasons(reason: Policy.StopReason) {
         #expect(!reason.deservesFinalLandingCheck)
@@ -223,7 +224,7 @@ struct MovePolicyTests {
     @Test("Only silence is filed against the owner")
     func onlySilenceIsFiled() {
         let filed: [Policy.StopReason] = [.ownerUnresponsive, .ownerAlwaysSilent, .ownerSilent]
-        let notFiled: [Policy.StopReason] = [.refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .budgetExhausted, .other]
+        let notFiled: [Policy.StopReason] = [.refusedByMacOS, .targetMoved, .targetRetreating, .itemGone, .destinationGone, .superseded, .overran, .unsafePath, .budgetExhausted, .other]
         let everyFiledReasonIsFiled = filed.allSatisfy(\.isFiledAgainstOwner)
         let noOtherReasonIsFiled = notFiled.allSatisfy { !$0.isFiledAgainstOwner }
         #expect(everyFiledReasonIsFiled)
@@ -246,6 +247,7 @@ struct MovePolicyTests {
         #expect(Policy.attemptFailure(for: .missingDestinationBounds(item)) == .destinationGone)
         #expect(Policy.attemptFailure(for: .moveSuperseded(item)) == .superseded)
         #expect(Policy.attemptFailure(for: .moveTimedOut(item)) == .overran)
+        #expect(Policy.attemptFailure(for: .unsafeMovePath(item)) == .unsafePath)
         #expect(Policy.attemptFailure(for: .cannotComplete) == .other)
     }
 
@@ -258,6 +260,7 @@ struct MovePolicyTests {
         (.destinationGone, "missingDestinationBounds"),
         (.superseded, "moveSuperseded"),
         (.overran, "moveTimedOut"),
+        (.unsafePath, "unsafeMovePath"),
         (.budgetExhausted, "cannotComplete"),
         (.ownerSilent, "cannotComplete"),
         (.other, "cannotComplete"),

--- a/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
+++ b/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
@@ -157,3 +157,245 @@ struct LayoutBarGroupResolutionOrderTests {
         #expect(unit == [first.tag, dragged.tag, stranded.tag])
     }
 }
+
+@Suite("Layout item drag presentation")
+struct LayoutBarItemDragPresentationTests {
+    @Test("A dragged item keeps a visible dimmed placeholder")
+    func draggedItemKeepsVisiblePlaceholder() {
+        let fraction = LayoutBarItemView.iconFraction(
+            isDraggingPlaceholder: true,
+            isEnabled: true
+        )
+
+        #expect(fraction > 0)
+        #expect(fraction < 1)
+    }
+
+    @Test("A frozen container keeps its last stable thumbnail")
+    func frozenContainerRejectsTransientThumbnail() {
+        #expect(!LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: true,
+            containerAllowsUpdates: false
+        ))
+        #expect(LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: true,
+            containerAllowsUpdates: true
+        ))
+        #expect(LayoutBarItemView.shouldUpdateCachedImage(
+            hasContainer: false,
+            containerAllowsUpdates: false
+        ))
+    }
+
+    @Test("Geometry-only cache changes keep the existing item view")
+    func geometryChangeReusesItemView() {
+        let tag = MenuBarItemTag.appItem(
+            bundleID: "com.example.status-item",
+            title: "Item-0",
+            windowID: 711
+        )
+        let beforeMove = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: 1400, y: 0, width: 24, height: 33),
+            isOnScreen: true
+        )
+        let afterMove = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: -3700, y: 0, width: 24, height: 33),
+            isOnScreen: false
+        )
+
+        #expect(LayoutBarContainer.canReuseItemView(
+            representing: beforeMove,
+            for: afterMove
+        ))
+    }
+
+    @Test("A recreated status-item window gets a new item view")
+    func recreatedWindowDoesNotReuseItemView() {
+        let oldItem = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.status-item", title: "Item-0", windowID: 711),
+            windowID: 711
+        )
+        let recreatedItem = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.status-item", title: "Item-0", windowID: 812),
+            windowID: 812
+        )
+
+        #expect(!LayoutBarContainer.canReuseItemView(
+            representing: oldItem,
+            for: recreatedItem
+        ))
+    }
+
+    @Test("A changed status-item size gets a new item view")
+    func resizedItemDoesNotReuseItemView() {
+        let tag = MenuBarItemTag.appItem(
+            bundleID: "com.example.status-item",
+            title: "Item-0",
+            windowID: 711
+        )
+        let oldItem = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: 1400, y: 0, width: 24, height: 33)
+        )
+        let resizedItem = MenuBarItem.fixture(
+            tag: tag,
+            windowID: 711,
+            bounds: CGRect(x: -3700, y: 0, width: 36, height: 33),
+            isOnScreen: false
+        )
+
+        #expect(!LayoutBarContainer.canReuseItemView(
+            representing: oldItem,
+            for: resizedItem
+        ))
+    }
+
+    @Test("The New Items badge remains visible while dragged")
+    func draggedBadgeKeepsVisiblePlaceholder() {
+        let opacity = LayoutBarNewItemsBadgeView.contentOpacity(isDraggingPlaceholder: true)
+
+        #expect(opacity > 0)
+        #expect(opacity < 1)
+    }
+
+    @Test("A cancelled cross-row drag restores the original view exactly once")
+    @MainActor
+    func cancelledCrossRowDragRestoresOriginalView() {
+        let appState = AppState()
+        let source = LayoutBarContainer(appState: appState, section: .visible)
+        let destination = LayoutBarContainer(appState: appState, section: .hidden)
+        let draggedView = LayoutBarNewItemsBadgeView()
+
+        source.arrangedViews = [draggedView]
+        source.arrangedViews.removeAll()
+        destination.arrangedViews = [draggedView]
+
+        source.restoreArrangedViewAfterCancelledDrag(
+            draggedView,
+            from: destination,
+            at: 0
+        )
+
+        #expect(source.arrangedViews.count { $0 === draggedView } == 1)
+        #expect(!destination.arrangedViews.contains { $0 === draggedView })
+        #expect(draggedView.superview === source)
+    }
+
+    @Test("A row frozen by another drag rejects a new drag")
+    func frozenRowRejectsUnrelatedDrag() {
+        #expect(!LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: false,
+            alreadyAccepted: false
+        ))
+        #expect(LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: true,
+            alreadyAccepted: false
+        ))
+        #expect(LayoutBarPaddingView.canAcceptDrag(
+            containerAllowsUpdates: false,
+            beganInContainer: false,
+            alreadyAccepted: true
+        ))
+    }
+}
+
+@Suite("Layout bar drag identity")
+struct LayoutBarDragIdentityTests {
+    private let provisional = MenuBarItem.fixture(
+        tag: MenuBarItemTag(
+            namespace: .controlCenter,
+            title: "Item-0",
+            windowID: 5467,
+            instanceIndex: 0
+        ),
+        windowID: 5467,
+        sourcePID: nil,
+        ownerPID: 645
+    )
+
+    private let resolved = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "IconSwitcher", title: "Item-0", windowID: 5467),
+        windowID: 5467,
+        sourcePID: 12460,
+        ownerPID: 645
+    )
+
+    private let otherItem = MenuBarItem.fixture(
+        tag: .appItem(bundleID: "com.example.other", title: "Item-0", windowID: 2556),
+        windowID: 2556
+    )
+
+    @Test("The same window is the same item after its identity resolves")
+    func sameWindowIsSameItem() {
+        #expect(LayoutBarPaddingView.isSameItem(resolved, provisional))
+        #expect(!LayoutBarPaddingView.isSameItem(otherItem, provisional))
+    }
+
+    @Test("A recreated window still matches by tag")
+    func recreatedWindowMatchesByTag() {
+        let recreated = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "IconSwitcher", title: "Item-0", windowID: 5744),
+            windowID: 5744,
+            sourcePID: 12460,
+            ownerPID: 645
+        )
+
+        #expect(LayoutBarPaddingView.isSameItem(recreated, resolved))
+    }
+
+    @Test("The dragged item is found beside its target under its resolved name")
+    func reachedPositionUnderResolvedName() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(otherItem),
+            sectionItems: [resolved, otherItem]
+        )
+
+        #expect(reached)
+    }
+
+    @Test("The wrong side of the target is not the intended position")
+    func wrongSideIsNotReached() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .rightOfItem(otherItem),
+            sectionItems: [resolved, otherItem]
+        )
+
+        #expect(!reached)
+    }
+
+    @Test("Containment is enough when the target is a section divider")
+    func dividerTargetNeedsOnlyContainment() {
+        let divider = MenuBarItem.fixture(
+            tag: .hiddenControlItem,
+            windowID: 5134,
+            sourcePID: nil
+        )
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(divider),
+            sectionItems: [otherItem, resolved]
+        )
+
+        #expect(reached)
+    }
+
+    @Test("An item missing from the section has not reached its position")
+    func missingItemIsNotReached() {
+        let reached = LayoutBarPaddingView.itemReachedIntendedPosition(
+            item: provisional,
+            destination: .leftOfItem(otherItem),
+            sectionItems: [otherItem]
+        )
+
+        #expect(!reached)
+    }
+}

--- a/ThawTests/Utilities/DiagnosticRedactorTests.swift
+++ b/ThawTests/Utilities/DiagnosticRedactorTests.swift
@@ -59,6 +59,18 @@ struct DiagnosticRedactorTests {
         #expect(!redacted.contains("private"))
     }
 
+    @Test("JSON-style quoted field names are removed")
+    func jsonQuotedFieldNames() {
+        let redactor = DiagnosticRedactor(terms: [])
+
+        // The quoted key and its value are consumed together; the secret
+        // never survives, which is what matters.
+        #expect(redactor.redact("{\"wifiSSID\":\"Home Network\"}") == "{\"<sensitive-value>}")
+        #expect(!redactor.redact("{\"triggerName\":\"Focus 1\"}").contains("Focus 1"))
+        // Unquoted forms keep working.
+        #expect(redactor.redact("ssid: net") == "<sensitive-value>")
+    }
+
     @Test("Menu bar geometry and identifiers survive redaction")
     func geometry() {
         let redactor = DiagnosticRedactor(


### PR DESCRIPTION
Lands the remaining layout-stability stack (former #999–#1003) as one PR, retargeted onto development after the squash-merges of #993–#998.

## What's included

- **Safe move transport (was #999):** keeps move gestures on the menu bar; the press-release guard now lives inside `postMoveEvents`, so a stalled drag is always released.
- **Bounded, verified attempts (was #1000):** every move runs under a `MoveTransactionBudget` with a hard deadline; a `MovePolicy` state machine decides retry vs stop per attempt, and `concludeFailedMove` renders the verdict.
- **Transactional cache refreshes (was #1001):** layout editor moves refresh through `CacheGate` with `refreshCacheAfterLayoutEditorMove`, so a dropped refresh no longer strands a frozen editor.
- **Coordinated batches (was #1002):** automatic multi-move batches carry a `BatchMovePreflightState`; each move re-validates its timestamp while holding the move gate, so user moves invalidate stale batch moves.
- **Stable editor transitions (was #1003):** generation-based drag stabilization, stale-thumbnail rejection while a container is frozen, and window-based drag identity that survives Control Center identity resolution.

## Integration notes

- Rebased onto the `MoveOptions`-based trunk API: the per-move gates (`shouldBegin`, `didFinishWhileHoldingGate`) ride in `MoveOptions`, and trunk's `shouldProceed`/`hideCursorAcrossAttempts` semantics and `inputPauseTimedOut` attribution are preserved throughout.
- `LayoutBar` drops its `imageCache:` parameter (thumbnails arrive via cache observation); the settings pane caller is updated.
- Full suite green on this branch: 3,222 tests / 380 suites.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791108926&installation_model_id=431242&pr_number=1041&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1041&signature=9b95b827157ccd01cf85292f1e886eeba542292d63d81dd9bfefb6fdccad6d31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu bar item dragging across rows, displays, notches, and layout sections.
  - Cancelled or interrupted drags now restore items more reliably.
  - Prevented unsafe moves, stale destinations, and competing operations from causing incorrect layouts.
  - Reduced visual flicker during layout updates and preserved item icons and badges while dragging.
  - Improved recovery from timed-out or blocked moves, including Control Center restarts.
  - Improved diagnostic redaction for sensitive values in quoted JSON fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Closes: N/A (supersedes the stacked #999–#1003)
