### PR TITLE
fix(icebar): preserve cached glyphs across window ID changes

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -441,11 +441,12 @@ private struct IceBarContentView: View {
             rows.compactMap { row in
                 guard col < row.count else { return nil }
                 let item = row[col]
+                let cachedImage = imageCache.image(for: item.tag)
                 guard !MenuBarItemIconFallback.shouldUseAppIcon(
                     for: item,
-                    hasCapture: imageCache.images[item.tag] != nil,
+                    hasCapture: cachedImage != nil,
                     prefersAppIcon: prefersAppIcon
-                ), let cachedImage = imageCache.images[item.tag] else {
+                ), let cachedImage else {
                     // No capture: the item renders as a square app icon, so
                     // reserve that width rather than dropping the column and
                     // letting the grid collapse around a visible item.
@@ -816,29 +817,7 @@ private struct IceBarItemView: View {
     /// square app icon at full height reads as oversized next to them.
     static let iconFallbackHeightRatio: CGFloat = 0.82
 
-    /// The captured glyph, or the owning app's icon when no capture is
-    /// available — most often because Screen Recording was declined.
-    private var image: NSImage? {
-        if isIconFallback {
-            return MenuBarItemIconFallback.image(for: item)
-        }
-        return imageCache.images[item.tag]?.nsImage
-    }
-
-    /// Whether ``image`` is an app icon rather than a captured glyph.
-    ///
-    /// An icon is square and arbitrarily large, so it is sized to the bar's
-    /// height instead of being scaled from its own intrinsic size the way a
-    /// capture is.
-    private var isIconFallback: Bool {
-        MenuBarItemIconFallback.shouldUseAppIcon(
-            for: item,
-            hasCapture: imageCache.images[item.tag] != nil,
-            prefersAppIcon: prefersAppIcon
-        )
-    }
-
-    private func targetSize(for image: NSImage) -> CGSize {
+    private func targetSize(for image: NSImage, usesAppIcon: Bool) -> CGSize {
         let intrinsic = image.size
         guard intrinsic.height > 0 else {
             return intrinsic
@@ -848,7 +827,7 @@ private struct IceBarItemView: View {
             return intrinsic
         }
 
-        if isIconFallback {
+        if usesAppIcon {
             // App icons are square and come at whatever size AppKit felt
             // like; a capture's intrinsic size is meaningful, an icon's is
             // not. Inset slightly so icons do not crowd the bar the way
@@ -867,8 +846,17 @@ private struct IceBarItemView: View {
     }
 
     var body: some View {
+        let capturedImage = imageCache.image(for: item.tag)
+        let usesAppIcon = MenuBarItemIconFallback.shouldUseAppIcon(
+            for: item,
+            hasCapture: capturedImage != nil,
+            prefersAppIcon: prefersAppIcon
+        )
+        let image = usesAppIcon
+            ? MenuBarItemIconFallback.image(for: item)
+            : capturedImage?.nsImage
         if let image {
-            let size = targetSize(for: image)
+            let size = targetSize(for: image, usesAppIcon: usesAppIcon)
             Image(nsImage: image)
                 .interpolation(.high)
                 .antialiased(true)

--- a/ThawTests/MenuBar/Items/MenuBarItemImageCacheObservationTests.swift
+++ b/ThawTests/MenuBar/Items/MenuBarItemImageCacheObservationTests.swift
@@ -60,6 +60,22 @@ struct MenuBarItemImageCacheObservationTests {
 
     @Test
     @MainActor
+    func imageLookupSurvivesWindowIDChange() throws {
+        let cachedTag = makeTag(title: "Stable", windowID: 1)
+        let currentTag = makeTag(title: "Stable", windowID: 2)
+        let image = try #require(makeOpaqueImage())
+        let cache = MenuBarItemImageCache(images: [
+            cachedTag: .init(cgImage: image, scale: 1),
+        ])
+
+        let result = cache.image(for: currentTag)
+
+        #expect(result?.cgImage === image)
+        #expect(result?.scale == 1)
+    }
+
+    @Test
+    @MainActor
     func capturePermitSerializesOperations() async {
         let cache = MenuBarItemImageCache()
         let concurrency = OSAllocatedUnfairLock(initialState: (active: 0, maximum: 0))


### PR DESCRIPTION
## Summary

Fixes the brief application icon flash when opening the Thaw Bar after a status item window ID changes.

The Thaw Bar now uses the image cache's existing semantic lookup, which matches non system items by namespace, title, and instance instead of requiring the volatile window ID to be identical. The last known menu bar glyph remains visible while a fresh capture arrives.

## Linked issue (required)

Closes: N/A

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [ ] menubar
- [x] icebar
- [ ] layout
- [ ] appearance
- [ ] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

When the Thaw Bar opens, a cached glyph continues to render even if macOS has recreated the item's window with a new window ID. The owning application's icon remains the fallback only when no captured glyph exists or the user has enabled app icon mode.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [ ] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [ ] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green — or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -destination 'platform=macOS' -only-testing:ThawTests/MenuBarItemImageCacheObservationTests -only-testing:ThawTests/MenuBarIconFallbackTests -only-testing:ThawTests/MenuBarItemImageCacheDisplayResolutionTests -only-testing:ThawTests/MenuBarItemImageCacheGatingTests` (8 tests passed)

## Known limitations / follow-ups

- Visual verification across Space changes, sleep and wake, display transitions, and source app restarts should be confirmed on a daily-use machine.
- Unrelated `.sf/` workspace metadata was left uncommitted.

## Other information

No new fallback, delay, animation, setting, or background capture was added. This fixes the cache identity lookup at the point where the Thaw Bar renders the item.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791144859&installation_model_id=431242&pr_number=1046&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1046&signature=c3cac5c06b2f6da38ef982940b85b73087e7576905e9a85e6d67881afd6c873c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved menu bar item image handling so icons continue displaying correctly when an item’s window identifier changes.
  - Preserved image scaling and fallback behavior across menu bar updates.

- **Tests**
  - Added coverage to verify that cached images remain available and consistent when window identifiers change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->