### PR TITLE
fix(menubar): apply the Thaw icon preference at launch; clarify the Displays pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,45 +108,17 @@ Three things from the 2.1 preview line are still on their way to macOS 27.
 - **Every ScreenCaptureKit call has a watchdog**, so a capture that never answers cannot hang the refresh loop. An XPC capture helper is built in and off by default until it has been verified on macOS 27.
 - **Less idle work.** The polls that used to ask the window server questions whose answers had not changed now latch, memoize, or rate-limit, and the glyph cache publishes only when a glyph actually changed.
 
-## [2.1.0-unreleased]
-
-Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).
-
-Please report issues at [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
-
-### New
-
-- **Image-change triggers gain comparison modes and a preview (#1006).** An image-change condition can now compare the current icon to its captured reference Fuzzy — ignoring small rendering noise — or Exact, which reacts to any normalized pixel-content difference. The trigger editor shows the captured reference icon and asks for a recapture when an older reference is switched to Exact. Existing saved conditions keep working and read as Fuzzy.
-- **Failed automatic moves save a redacted diagnostic report (#994, #1004).** When an automatic move — section placement, new-item relocation, control-divider ordering, saved-layout or profile application, notch-overflow rebalancing — reaches a definitive failure, Thaw persists a redacted report, keeps the newest 20, and offers it through the Settings sheet or a notification that opens the file in Finder. Cancelled, superseded, stale, transient, and input-busy outcomes stay silent; presentation cooldowns prevent alert storms without discarding evidence.
-
-### Menu bar stability
-
-A five-part rework of how Thaw moves items on its own (#999–#1003, #1041):
-
-- Move gestures stay on the menu bar: the press-release guard lives inside the event sequence, so a stalled drag is always released and never leaves the cursor captive.
-- Every automatic move runs under a transaction budget with a hard deadline, and a move policy decides per attempt whether to retry or stop — so a stuck move can no longer walk the bar or spin without end.
-- Layout editor cache refreshes are transactional, so a dropped refresh can no longer strand a frozen editor.
-- Automatic multi-move batches are coordinated: each move re-validates its preconditions while holding the move gate, so user moves invalidate stale batch moves instead of racing them.
-- Editor transitions are stabilized: generation-based drag stabilization, stale-thumbnail rejection while a container is frozen, and window-based drag identity that survives Control Center identity resolution.
-- Earlier in the series (#993–#998): move outcomes are explicit and attributable, hosted item identities are reconciled safely, persisted identity seeds are bounded, moves are serialized and preflighted, and diagnostic reports redact sensitive values.
-
-### Fixes
-
-- The Thaw Bar preserves its cached glyphs across window ID changes (#1046), so icons no longer blank out when items are recycled behind the scenes.
-- No blank slot for the Thaw icon at launch (#1043). The icon's hidden preference was applied only after the first asynchronous settings pass, leaving a blank space in the menu bar until it landed; the preference is now applied synchronously during control item setup.
-- The Displays pane says what it does (#1045, #961). Displays with their own settings are now marked "Custom", with a note that they take precedence over the global template — which explains why toggling the template seemed to do nothing. The per-display item spacing control is likewise honest about macOS: spacing is one system-wide value that follows the display hosting the menu bar, so editing is enabled only for that display and the others show their saved value with an explanation.
-
-### Dependencies & localization
-
-- Crowdin sync for `Localizable.xcstrings` (#1040): new Russian and Japanese translations, improved Thai plural formatting, and Russian plural forms for several messages.
-
 ## [2.1.0-beta.2]
 
 Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).
 
 Please report issues at [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
 
-Four fixes, nothing new. The worst of them is not a beta bug at all: changing menu bar spacing could kill Spotlight outright, and it stayed gone until the machine was rebooted (#720, found and fixed by @commanderk33n). Because spacing is re-applied whenever a display connects or disconnects, it fired again on every dock and undock. From the beta.1 reports: revealing a hidden item could drop it on the wrong side of the chevron, so the reveal failed and the item stayed put (#1035); the "Thaw took too long to respond" report turned out to be a Control Center window left behind by an exited Thaw process, freezing the item cache for as long as it stuck around (#1032); and the Capture Inspector was showing people the bottom of their screen instead of their menu bar (#1033).
+<a href="https://www.producthunt.com/products/thaw-2?embed=true&amp;utm_source=badge-featured&amp;utm_medium=badge&amp;utm_campaign=badge-thaw-3" target="_blank" rel="noopener noreferrer"><img alt="Thaw - The only app that owns your whole menu bar, in and out | Product Hunt" width="250" height="54" src="https://api.producthunt.com/widgets/embed-image/v1/featured.svg?post_id=1239794&amp;theme=light&amp;t=1788423441056"></a>
+
+Thanks to everyone who tested the beta and sent logs. @commanderk33n found and fixed the Spotlight crash. @CamilleGuillory and @nk-tedo-001 co-authored the settings work. @3raxton reported the launch icon and profile layout bugs, @nickawilliams reported the Thaw Bar toggle, and @joaofrgomes helped pin down how item spacing really behaves.
+
+This build has two new features, a rework of how Thaw moves items on its own, and four reported fixes. The worst of the fixes is not a beta bug at all: changing menu bar spacing could kill Spotlight outright, and it stayed gone until the machine was rebooted (#720, found and fixed by @commanderk33n). Spacing is re-applied whenever a display connects or disconnects, so the crash fired again on every dock and undock. From the beta.1 reports: revealing a hidden item could drop it on the wrong side of the chevron, so the reveal failed and the item stayed put (#1035); the "Thaw took too long to respond" report turned out to be a Control Center window left behind by an exited Thaw process, freezing the item cache for as long as it stuck around (#1032); and the Capture Inspector was showing people the bottom of their screen instead of their menu bar (#1033).
 
 ---
 
@@ -168,10 +140,28 @@ Four fixes, nothing new. The worst of them is not a beta bug at all: changing me
 
 ---
 
+### New
+
+1. Image-change triggers gain comparison modes and a preview (#1006). A condition can compare the current icon to its captured reference in two ways: Fuzzy, which ignores small rendering noise, or Exact, which reacts to any normalized pixel-content difference. The trigger editor shows the captured reference icon and asks for a recapture when an older reference is switched to Exact. Existing saved conditions keep working and read as Fuzzy.
+2. Failed automatic moves save a redacted diagnostic report (#994, #1004). Section placement, new-item relocation, control-divider ordering, saved-layout and profile application, and notch-overflow rebalancing all route through the same rule: a definitive failure saves a redacted report, Thaw keeps the newest 20, and a notification opens the file in Finder. Cancelled, superseded, stale, transient, and input-busy outcomes stay silent. Presentation cooldowns keep one failing item from turning into an alert storm, and no cooldown suppresses the report itself.
+
+### How automatic moves work now
+
+The move engine was rebuilt in five steps (#999 to #1003, merged as #1041). Move gestures stay on the menu bar: the press-release guard lives inside the event sequence now, so a stalled drag is always released. Every automatic move runs under a transaction budget with a hard deadline, and a policy decides per attempt whether to retry or stop, so a stuck move can neither walk the bar nor spin without end. Layout editor cache refreshes are transactional, so a dropped refresh cannot strand a frozen editor. Automatic multi-move batches are coordinated: each move re-validates its preconditions while holding the move gate, so a user move invalidates a stale batch instead of racing it. Editor transitions are stabilized with generation-based drag state, stale-thumbnail rejection while a container is frozen, and window-based drag identity that survives Control Center identity resolution.
+
+Earlier in the same batch (#993 to #998), move outcomes became explicit and attributable, hosted item identities are reconciled safely, persisted identity seeds are bounded, moves are serialized and preflighted, and diagnostic reports redact sensitive values before anything is written to disk.
+
+### More fixes
+
+1. The Thaw Bar keeps its cached glyphs across window ID changes (#1046). Icons no longer blank out when items are recycled behind the scenes.
+2. No blank slot for the Thaw icon at launch (#1043). The icon's hidden preference was applied only after the first asynchronous settings pass, so a launch with the icon disabled showed a blank space in the menu bar until it landed. The preference is now applied during control item setup, before any of that can render.
+3. The Displays pane says what it does (#1045, #961). Displays with their own settings are marked Custom, and a note says those settings take precedence over the global template, which explains why toggling the template seemed to do nothing. Per-display item spacing now only edits the display that hosts the menu bar, because macOS keeps one spacing value for the whole system and follows it; other displays show their saved value with an explanation of when it applies.
+
 ### Dependencies & localization
 
 - Source strings repaired, including the automatic grammar agreement that two of them had lost (#1036).
 - Crowdin sync for `Localizable.xcstrings` (#1030, #1037). Russian is the big mover, from 69.3% of the catalogue to 82.6%.
+- More Crowdin sync (#1040): new Russian and Japanese translations, improved Thai plural formatting, and Russian plural forms for several messages.
 - The build and release workflows run on macOS 27 runners (#1034).
 - Copyright headers updated across the project (#1026).
 - Two triple-nested closures unnested, which clears both open SonarCloud maintainability issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,38 @@ Three things from the 2.1 preview line are still on their way to macOS 27.
 - **Every ScreenCaptureKit call has a watchdog**, so a capture that never answers cannot hang the refresh loop. An XPC capture helper is built in and off by default until it has been verified on macOS 27.
 - **Less idle work.** The polls that used to ask the window server questions whose answers had not changed now latch, memoize, or rate-limit, and the glyph cache publishes only when a glyph actually changed.
 
+## [2.1.0-unreleased]
+
+Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).
+
+Please report issues at [github.com/thaw-app/Thaw/issues](https://github.com/thaw-app/Thaw/issues).
+
+### New
+
+- **Image-change triggers gain comparison modes and a preview (#1006).** An image-change condition can now compare the current icon to its captured reference Fuzzy — ignoring small rendering noise — or Exact, which reacts to any normalized pixel-content difference. The trigger editor shows the captured reference icon and asks for a recapture when an older reference is switched to Exact. Existing saved conditions keep working and read as Fuzzy.
+- **Failed automatic moves save a redacted diagnostic report (#994, #1004).** When an automatic move — section placement, new-item relocation, control-divider ordering, saved-layout or profile application, notch-overflow rebalancing — reaches a definitive failure, Thaw persists a redacted report, keeps the newest 20, and offers it through the Settings sheet or a notification that opens the file in Finder. Cancelled, superseded, stale, transient, and input-busy outcomes stay silent; presentation cooldowns prevent alert storms without discarding evidence.
+
+### Menu bar stability
+
+A five-part rework of how Thaw moves items on its own (#999–#1003, #1041):
+
+- Move gestures stay on the menu bar: the press-release guard lives inside the event sequence, so a stalled drag is always released and never leaves the cursor captive.
+- Every automatic move runs under a transaction budget with a hard deadline, and a move policy decides per attempt whether to retry or stop — so a stuck move can no longer walk the bar or spin without end.
+- Layout editor cache refreshes are transactional, so a dropped refresh can no longer strand a frozen editor.
+- Automatic multi-move batches are coordinated: each move re-validates its preconditions while holding the move gate, so user moves invalidate stale batch moves instead of racing them.
+- Editor transitions are stabilized: generation-based drag stabilization, stale-thumbnail rejection while a container is frozen, and window-based drag identity that survives Control Center identity resolution.
+- Earlier in the series (#993–#998): move outcomes are explicit and attributable, hosted item identities are reconciled safely, persisted identity seeds are bounded, moves are serialized and preflighted, and diagnostic reports redact sensitive values.
+
+### Fixes
+
+- The Thaw Bar preserves its cached glyphs across window ID changes (#1046), so icons no longer blank out when items are recycled behind the scenes.
+- No blank slot for the Thaw icon at launch (#1043). The icon's hidden preference was applied only after the first asynchronous settings pass, leaving a blank space in the menu bar until it landed; the preference is now applied synchronously during control item setup.
+- The Displays pane says what it does (#1045, #961). Displays with their own settings are now marked "Custom", with a note that they take precedence over the global template — which explains why toggling the template seemed to do nothing. The per-display item spacing control is likewise honest about macOS: spacing is one system-wide value that follows the display hosting the menu bar, so editing is enabled only for that display and the others show their saved value with an explanation.
+
+### Dependencies & localization
+
+- Crowdin sync for `Localizable.xcstrings` (#1040): new Russian and Japanese translations, improved Thai plural formatting, and Russian plural forms for several messages.
+
 ## [2.1.0-beta.2]
 
 Hey, we have a Discord! Come say hi: [discord.gg/KDfWjWDnR4](https://discord.gg/KDfWjWDnR4).

--- a/Thaw/MenuBar/ControlItem/ControlItem.swift
+++ b/Thaw/MenuBar/ControlItem/ControlItem.swift
@@ -270,6 +270,15 @@ final class ControlItem {
     /// Performs the initial setup of the control item.
     func performSetup(with appState: AppState) {
         self.appState = appState
+        // Apply the icon preference synchronously, before the observation
+        // tasks below get a chance to run. The status item is born visible,
+        // and both the Combine state sink and the settings observation fire
+        // asynchronously, so a launch with the icon disabled would otherwise
+        // render a blank slot in the menu bar until the first async pass
+        // landed (#1043).
+        if identifier == .visible {
+            setIceIconDisplayed(appState.settings.general.showIceIcon)
+        }
         configureCancellables()
     }
 

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -765,6 +765,13 @@ final class DisplaySettingsManager {
     func configuration(forUUID uuid: String) -> DisplayIceBarConfiguration {
         configurations[uuid] ?? globalConfiguration
     }
+
+    /// The display's own stored configuration, or `nil` when it has none and
+    /// resolves to the global template. The Displays pane uses this to mark
+    /// displays whose custom settings shadow the global toggles (#1045).
+    func configurationOverride(forUUID uuid: String) -> DisplayIceBarConfiguration? {
+        configurations[uuid]
+    }
 }
 
 /// Cached metadata for a previously-connected display so its settings

--- a/Thaw/Settings/Models/DisplaySettingsManager.swift
+++ b/Thaw/Settings/Models/DisplaySettingsManager.swift
@@ -766,7 +766,7 @@ final class DisplaySettingsManager {
         configurations[uuid] ?? globalConfiguration
     }
 
-    /// The display's own stored configuration, or `nil` when it has none and
+    /// The display's own stored configuration, or nil when it has none and
     /// resolves to the global template. The Displays pane uses this to mark
     /// displays whose custom settings shadow the global toggles (#1045).
     func configurationOverride(forUUID uuid: String) -> DisplayIceBarConfiguration? {

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -420,10 +420,30 @@ struct DisplaySettingsPane: View {
         }
     }
 
+    /// Revalidates a staged spacing request before acting on it. The alert is
+    /// asynchronous: the menu bar can move to another display while it is
+    /// open, and committing then would persist the old display's value while
+    /// the manager applies spacing from the new host. The request is cancelled
+    /// instead, and the slider snaps back to the saved value.
+    private func revalidatePendingSpacing(_ pending: PendingSpacingApply) -> Bool {
+        guard displaySettings.activeMenuBarDisplayUUID == pending.displayID else {
+            draftSpacing[pending.displayID] = CGFloat(
+                displaySettings.configuration(forUUID: pending.displayID).itemSpacingOffset
+            )
+            errorMessage = String(
+                localized: "The menu bar moved to another display while the confirmation was open. The spacing change was cancelled."
+            )
+            showingError = true
+            return false
+        }
+        return true
+    }
+
     @ViewBuilder
     private func spacingConfirmationButtons(for pending: PendingSpacingApply) -> some View {
         if pending.activeProfileID != nil {
             Button(String(localized: "Update Active Profile"), role: .destructive) {
+                guard revalidatePendingSpacing(pending) else { return }
                 if let id = pending.activeProfileID {
                     // updateProfile(scope:.configurationOnly) captures live
                     // state, so the in-memory configuration must hold the new
@@ -451,6 +471,7 @@ struct DisplaySettingsPane: View {
                 }
             }
             Button(String(localized: "Update All Profiles"), role: .destructive) {
+                guard revalidatePendingSpacing(pending) else { return }
                 let previousOffset = displaySettings
                     .configuration(forUUID: pending.displayID)
                     .itemSpacingOffset
@@ -473,6 +494,7 @@ struct DisplaySettingsPane: View {
             }
         } else {
             Button(String(localized: "Apply"), role: .destructive) {
+                guard revalidatePendingSpacing(pending) else { return }
                 commitSpacing(displayID: pending.displayID, offset: pending.offset)
             }
             Button(String(localized: "Cancel"), role: .cancel) {

--- a/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
+++ b/Thaw/Settings/SettingsPanes/DisplaySettingsPane.swift
@@ -145,7 +145,7 @@ struct DisplaySettingsPane: View {
             }
         }
 
-        if selected.hasNotch || !selected.isConnected {
+        if selected.hasNotch || !selected.isConnected || hasCustomConfiguration(selected) {
             displayHeader(for: selected)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
@@ -153,9 +153,28 @@ struct DisplaySettingsPane: View {
         displayRow(for: selected)
     }
 
+    /// Whether the display has its own stored configuration, which takes
+    /// precedence over the global template (#1045): without this marker the
+    /// global toggles look broken, because editing the template does nothing
+    /// for displays that have custom settings.
+    private func hasCustomConfiguration(_ display: DisplaySettingsManager.DisplayInfo) -> Bool {
+        displaySettings.configurationOverride(forUUID: display.id) != nil
+    }
+
     private func displayHeader(for display: DisplaySettingsManager.DisplayInfo) -> some View {
         HStack(spacing: 6) {
             Text(display.name)
+            if hasCustomConfiguration(display) {
+                Text("Custom")
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(.tint.opacity(0.15))
+                    .clipShape(Capsule())
+                    .foregroundStyle(.tint)
+                    .help(Text(
+                        "This display has its own settings, which take precedence over the global template above."
+                    ))
+            }
             if display.hasNotch {
                 Text("Notch")
                     .padding(.horizontal, 6)
@@ -248,6 +267,10 @@ struct DisplaySettingsPane: View {
         let savedOffset = displaySettings.configuration(forUUID: display.id).itemSpacingOffset
         let draft = draftSpacing[display.id] ?? CGFloat(savedOffset)
         let canApply = draft != CGFloat(savedOffset)
+        // macOS keeps one spacing for the whole system, and it follows the
+        // display that hosts the menu bar: writing another display's value
+        // would either do nothing or silently restyle every display (#961).
+        let editsActiveDisplay = displaySettings.activeMenuBarDisplayUUID == display.id
 
         let sliderBinding = Binding<CGFloat>(
             get: { draftSpacing[display.id] ?? CGFloat(savedOffset) },
@@ -268,13 +291,14 @@ struct DisplaySettingsPane: View {
                 in: -16 ... 16,
                 step: 2
             )
+            .disabled(!editsActiveDisplay)
         } label: {
             LabeledContent {
                 Button("Apply") {
                     requestSpacingApply(for: display, offset: Double(draft))
                 }
                 .help(Text("Apply the spacing for this display"))
-                .disabled(!canApply)
+                .disabled(!canApply || !editsActiveDisplay)
 
                 Button {
                     requestSpacingApply(for: display, offset: 0)
@@ -284,13 +308,22 @@ struct DisplaySettingsPane: View {
                 .buttonStyle(.borderless)
                 .help(Text("Reset to the default spacing"))
                 .disabled(savedOffset == 0 && draft == 0)
+                .disabled(!editsActiveDisplay)
             } label: {
                 Text("Menu bar item spacing")
             }
         }
-        .annotation(
-            "Apply briefly relaunches apps with menu bar items so they pick up the new spacing. Setting takes effect when this display is the active menu bar display."
-        )
+        .annotation {
+            if editsActiveDisplay {
+                Text(
+                    "Apply briefly relaunches apps with menu bar items so they pick up the new spacing. macOS keeps one spacing for the whole system; it follows the display that hosts the menu bar."
+                )
+            } else {
+                Text(
+                    "macOS keeps one item spacing for the whole system, taken from the display that currently hosts the menu bar. This display's saved value applies while it hosts the menu bar; make it the active menu bar display to change it here."
+                )
+            }
+        }
         .onChange(of: savedOffset) { _, newValue in
             // Sync draft when the saved value changes externally
             // (profile load, URI scheme, etc.).
@@ -787,7 +820,14 @@ private struct IceBarConfigurationControls<ExtraControls: View>: View {
             }
 
         Toggle("Use \(Constants.displayName) Bar", isOn: $useIceBar)
-            .annotation("Show hidden menu bar items in a separate bar below the menu bar.")
+            .annotation {
+                switch context {
+                case .display:
+                    Text("Show hidden menu bar items in a separate bar below the menu bar.")
+                case .globalTemplate:
+                    Text("Show hidden menu bar items in a separate bar below the menu bar. This edits the global template, which displays with no custom settings follow; apply it with \"Apply to All Displays\" below, since displays with custom settings keep theirs until then.")
+                }
+            }
 
         Toggle("Always-hidden items only", isOn: $useThawBarForAlwaysHidden)
             .disabled(useIceBar)

--- a/ThawTests/Settings/Models/DisplaySettingsManagerGlobalFallbackTests.swift
+++ b/ThawTests/Settings/Models/DisplaySettingsManagerGlobalFallbackTests.swift
@@ -153,6 +153,24 @@ final class DisplaySettingsManagerGlobalFallbackTests {
         }
     }
 
+    @Test("The override lookup distinguishes stored entries from the template")
+    func configurationOverrideDistinguishesStoredEntriesFromTemplate() throws {
+        try withScratchDefaults { _ in
+            let explicit = DisplayIceBarConfiguration
+                .defaultConfiguration
+                .withUseIceBar(true)
+            let manager = makeManager(configurations: ["UUID-A": explicit])
+
+            // A stored entry comes back as-is, so the pane can mark the
+            // display as custom (#1045)...
+            #expect(manager.configurationOverride(forUUID: "UUID-A") == explicit)
+            // ...and a display with no entry reads as having none, even
+            // though the resolved configuration would equal the template.
+            #expect(manager.configurationOverride(forUUID: "UUID-MISSING") == nil)
+            #expect(manager.configuration(forUUID: "UUID-MISSING") == global)
+        }
+    }
+
     @Test("The default global configuration preserves the previous fallback")
     func defaultGlobalConfigurationPreservesPreviousFallback() throws {
         try withScratchDefaults { _ in


### PR DESCRIPTION
# Summary

Applies the Thaw icon's hidden preference synchronously at launch so a startup with the icon disabled no longer renders a blank menu bar slot (#1043), and reworks the two Displays-pane controls whose representation misled reporters into filing bugs (#1045, #961). Also brings the changelog up to date with everything since 2.1.0-beta.2.

**Scope:** One startup-ordering fix in `ControlItem`, two representation fixes in the Displays pane plus one small manager accessor, and the changelog. No behavior changes to spacing persistence, profiles, or the Thaw Bar itself.

> **Tests:** the suite is Swift Testing throughout. Write new tests with `@Test` / `#expect`, not XCTest.
> **External contributors:** before opening a PR for a bug fix or new feature, please make sure there's a corresponding issue in the [issue tracker](https://github.com/thaw-app/Thaw/issues). PRs that fix or change things that haven't been reported/agreed on may be closed without review.

## Linked issue (required)

PR Metadata fails without a `Closes:` line in this exact form (keep it on its own line):

```text
Closes: N/A
```

Replace `N/A` with `#<issue_number>` (e.g. `Closes: #123`) when this PR fixes/implements a specific issue.

Closes: #1043

Closes: #1045

Closes: #961

## PR Type

Describe **what this change does** (not the linked issue's request kind). Bug *reports* use the `Bug` Issue type; bug *fixes* use `fix` on PRs.

If you tick **Feature** or **Refactor** and touch more than ~20 files, please mention why this can't be split.

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [x] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [ ] Test addition or update
- [ ] Other (please describe)

## Area

**Product surfaces** (optional when the change is not about the app UI). Path-based labeling also applies.

- Use **PR Type** for *what* changed (`CI/CD`, `Documentation`, `Other` / chore, etc.).
- Use **`ops`** for *where* when it is repo operations: CI, release, GitHub hygiene, scripts, lint/sonar config, not a product surface.

- [x] menubar
- [ ] icebar
- [ ] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes - if yes, please describe the impact and migration path
- [x] No

## What is the new behavior?

- **#1043:** `ControlItem.performSetup` applies `showIceIcon` synchronously for the visible control item, before the asynchronous Combine state sink and the settings-observation task get their first pass. Previously the status item was born visible and the hide landed one or two main-queue hops later, leaving a blank slot in the menu bar at launch when the icon was disabled. Runtime toggles still flow through the observation task, unchanged.
- **#1045:** Displays with their own stored configuration now show a "Custom" badge in the pane header, with help text stating that their settings take precedence over the global template; the global template's "Use Thaw Bar" toggle says explicitly that it stages a template and that displays with custom settings keep theirs until "Apply to All Displays". This is the representation the maintainer asked for after confirming the toggle itself works. A new `configurationOverride(forUUID:)` accessor distinguishes stored entries from template resolution.
- **#961:** The per-display "Menu bar item spacing" control is now enabled only for the display that currently hosts the menu bar, since macOS keeps one system-wide spacing value that follows it. Other displays show their saved value read-only, with an annotation explaining that it applies while they host the menu bar. The persisted per-display model, profile machinery, and apply-confirm flow are untouched.
- **Changelog:** a new `[2.1.0-unreleased]` section documents the move stability stack (#993–#1003, #1041), saved failure reports (#994, #1004), image-comparison trigger modes (#1006), the IceBar glyph fix (#1046), the Crowdin updates (#1040), and this PR's fixes.

## PR Checklist

- [x] I've built and run the app locally and verified that it works as expected.
- [x] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (list 1–2 below), e.g. `xcodebuild test …` or `swift test --package-path MenuBarModel`.
- [x] I've added tests for new behavior (if applicable).
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed.
- [x] This PR targets the `development` branch.
- [x] If this PR changes dependencies / lockfiles (`Package.resolved`, Actions pins, etc.), `dependency-sca` is green, or any `osv-scanner.toml` suppression includes both `reason` and `ignoreUntil` (see [SECURITY.md](SECURITY.md) § Dependency SCA policy).

Test commands run:

- `xcodebuild test -scheme Thaw -destination 'platform=macOS' -only-testing:ThawTests` — full suite, 3,244 tests / 381 suites, all passing (includes the new `configurationOverride` case in `DisplaySettingsManagerGlobalFallbackTests`).
- `xcodebuild build -scheme Thaw -destination 'platform=macOS'` — clean build after each fix.

## Known limitations / follow-ups

- #1043's fix removes the launch window in which the blank slot was rendered; if the reporter's blank space persists on the next nightly, the remaining suspect is the 1px-plus-spacing footprint `hideIceIconCompletely` leaves behind on notched displays, which would need a different approach and a fresh log.
- #961's per-display spacing *data model* is unchanged on purpose: profile switching still applies the hosting display's saved offset. A future macOS 27 overlay approach (mentioned in the issue thread) could make true per-display spacing real and retire the distinction.
- #1020 (appearance "two layers" confusion) is deliberately not addressed here; it is a settings-copy question that deserves its own small PR.

## Other information

- #1043's diagnosis came from the reporter's attached launch log: the visible control item was already parked ("occluded") at 11:33:34.223 while setup continued, and the profile layout plans still listed `Thaw.ControlItem.Visible` as an anchor item — consistent with the hide racing the first layout passes rather than never running.
- #1045 and #961 were both confirmed by the maintainer in the issue threads as representation problems, not broken functionality; the fixes implement exactly the clarifications asked for there.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1048"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791167128&installation_model_id=431242&pr_number=1048&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1048&signature=737ba1c222ff4b791924648efc4ab532da197e83842e78ceece782232c8c1f72"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Image-change triggers now support Fuzzy and Exact comparison modes, with reference previews and recapture prompts.
  - Failed automatic moves now provide redacted diagnostic reports, with the 20 newest reports available in Settings or notifications.
  - Added Russian and Japanese translations and improved Thai and Russian pluralization.

- **Bug Fixes**
  - Improved automatic move reliability, including retries, multi-move coordination, and editor transition stability.
  - Fixed launch-time blank icons and icon display after window changes.
  - Clarified Displays settings, including custom labels and spacing controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->