### PR TITLE
fix(layout): omit transient Control Center items

### DIFF
--- a/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
+++ b/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift
@@ -317,14 +317,21 @@ final class LayoutBarContainer: NSView {
             arrangedViews.removeAll()
             return
         }
+        // Live Activities and other transient Control Center slots are not
+        // stable menu bar items: macOS may expose them with a temporary
+        // Control Center identity, and it refuses attempts to arrange them.
+        // Do not present those slots as draggable controls in the editor.
+        // A regular hosted app item appears here once source-PID resolution
+        // gives it a stable, non-Control-Center identity.
+        let eligibleItems = items.filter(Self.shouldRepresentInLayout)
         // Thumbnail refreshes below can trigger an immediate size-only layout,
         // which normally resets this flag. Preserve the caller's animation
         // choice for the actual ordered reconciliation that follows.
         let shouldAnimateReconciledLayout = shouldAnimateNextLayoutPass
         var newViews = [LayoutBarArrangedView]()
-        let itemIdentifiers = items.map(\.uniqueIdentifier)
+        let itemIdentifiers = eligibleItems.map(\.uniqueIdentifier)
         let badgeIndex = appState.itemManager.newItemsBadgeIndex(in: section, itemIdentifiers: itemIdentifiers)
-        for item in items {
+        for item in eligibleItems {
             if let existingView = arrangedViews.lazy
                 .compactMap({ $0 as? LayoutBarItemView })
                 .first(where: { Self.canReuseItemView(representing: $0.item, for: item) })
@@ -356,6 +363,12 @@ final class LayoutBarContainer: NSView {
         }
         shouldAnimateNextLayoutPass = shouldAnimateReconciledLayout
         arrangedViews = newViews
+    }
+
+    /// Whether an observed item represents a durable item the layout editor
+    /// can offer for arrangement.
+    static nonisolated func shouldRepresentInLayout(_ item: MenuBarItem) -> Bool {
+        !item.isTransientControlCenterItem && !item.hasProvisionalIdentity
     }
 
     /// Whether an existing view still represents the same live status-item

--- a/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
+++ b/ThawTests/MenuBar/Layout/LayoutBarContainerTests.swift
@@ -63,6 +63,45 @@ struct LayoutBarContainerTests {
     }
 }
 
+@Suite("Layout editor item eligibility")
+struct LayoutBarItemEligibilityTests {
+    @Test("A mirrored Live Activity is omitted after source resolution")
+    func resolvedLiveActivityIsOmitted() {
+        let item = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .controlCenter, title: "Item-16"),
+            windowID: 35_774,
+            sourcePID: 9_001
+        )
+
+        #expect(item.isTransientControlCenterItem)
+        #expect(!LayoutBarContainer.shouldRepresentInLayout(item))
+    }
+
+    @Test("An unresolved Control Center slot is omitted while its identity is provisional")
+    func unresolvedControlCenterSlotIsOmitted() {
+        let item = MenuBarItem.fixture(
+            tag: MenuBarItemTag(namespace: .controlCenter, title: "Item-16"),
+            windowID: 35_774,
+            sourcePID: nil,
+            ownerPID: 943
+        )
+
+        #expect(item.hasProvisionalIdentity)
+        #expect(!LayoutBarContainer.shouldRepresentInLayout(item))
+    }
+
+    @Test("A durable app item remains available for arrangement")
+    func durableAppItemRemainsVisible() {
+        let item = MenuBarItem.fixture(
+            tag: .appItem(bundleID: "com.example.weather", title: "Item-0"),
+            windowID: 4_200,
+            sourcePID: 9_002
+        )
+
+        #expect(LayoutBarContainer.shouldRepresentInLayout(item))
+    }
+}
+
 @Suite("Layout item activation")
 struct LayoutBarItemActivationTests {
     @Test("A left click released inside the icon activates its menu bar item")


### PR DESCRIPTION
# Summary

Omit transient Control Center slots from the Layout editor instead of presenting them as draggable menu bar items.

This covers both resolved transient slots and unresolved `com.apple.controlcenter:Item-N` placeholders such as the mirrored Yandex Weather Live Activity observed on macOS 26.5.2. Durable app-owned menu bar items remain available once they have a stable identity.

**Scope:** Layout editor presentation only; the underlying item cache and menu bar remain unchanged.

## Linked issue (required)

Closes: N/A

Related to #722 and #556.

## PR Type

- [x] Bug fix
- [ ] CI/CD
- [ ] Documentation
- [ ] Feature
- [ ] Enhancement
- [ ] Performance improvement
- [ ] Refactor
- [x] Test addition or update
- [ ] Other (please describe)

## Area

- [x] menubar
- [ ] icebar
- [x] layout
- [ ] appearance
- [x] settings
- [ ] onboarding
- [ ] permissions
- [ ] profiles
- [ ] hotkeys
- [ ] updates
- [ ] ops

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What is the new behavior?

Live Activities and other ephemeral Control Center slots no longer appear in the Layout editor. This avoids offering a drag interaction for windows whose identity and position macOS does not keep stable and whose move requests time out or revert.

The New Items badge index is calculated against the same filtered list shown to the user.

## PR Checklist

- [ ] I've built and run the app locally and verified that it works as expected.
- [ ] I've run `swiftformat .` to keep the code style consistent.
- [x] I've run the smallest relevant test commands (listed below).
- [x] I've added tests for new behavior.
- [x] I've documented new public APIs / non-obvious helpers.
- [x] I've updated documentation as needed (no user-facing documentation change required).
- [x] This PR targets the `development` branch.
- [x] This PR does not change dependencies or lockfiles.

Test commands run:

- `xcodebuild test -project Thaw.xcodeproj -scheme Thaw -derivedDataPath Build/ -destination 'platform=macOS' -only-testing:ThawTests/LayoutBarItemEligibilityTests -only-testing:ThawTests/LayoutBarContainerTests CODE_SIGN_IDENTITY='' CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO`

Result: 6 tests in 2 suites passed.

## Known limitations / follow-ups

- macOS treats a mirrored Live Activity as a wall in the physical menu bar. Omitting that window from the editor prevents direct manipulation but cannot make unrelated items move across that wall; users may still need to close the Live Activity before cross-section rearrangement.

## Other information

The field diagnostic identified the mirrored activity as `com.apple.controlcenter:Item-16` with an unresolved source PID, matching the item class described in #722.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/thaw-app/codesmith/Thaw/pr/1050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791204582&installation_model_id=431242&pr_number=1050&repository=thaw-app%2FThaw&return_to=https%3A%2F%2Fgithub.com%2Fthaw-app%2FThaw%2Fpull%2F1050&signature=fab57c57ac349afcccd0964e228c4ae2ec0e68805aaf7b711b2c70d35c872f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented transient Control Center items and items with provisional identities from appearing in the menu bar layout.
  - Ensured only durable, fully identified items are included in arrangement and badge displays.

- **Tests**
  - Added coverage for filtering mirrored Live Activity items, unresolved Control Center slots, and eligible app items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->