### PR TITLE
fix(icebar): omit clipped top border on square Thaw Bar corners

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -515,10 +515,18 @@ private struct IceBarContentView: View {
             .clipShape(clipShape)
 
             if appearance.hasBorder {
-                clipShape
-                    .inset(by: appearance.borderWidth / 2)
-                    .stroke(lineWidth: appearance.borderWidth)
-                    .foregroundStyle(Color(cgColor: appearance.borderColor))
+                // Square corners sit under the display's rounded screen edge
+                // (#325): omit the top stroke so it is not clipped mid-line.
+                ThawBarBorderShape(
+                    cornerRadius: appearance.hasRoundedShape
+                        ? contentHeight / 2
+                        : contentHeight / 4,
+                    cornerStyle: appearance.hasRoundedShape ? .circular : .continuous,
+                    omitTopEdge: !appearance.hasRoundedShape,
+                    inset: appearance.borderWidth / 2
+                )
+                .stroke(lineWidth: appearance.borderWidth)
+                .foregroundStyle(Color(cgColor: appearance.borderColor))
             }
         }
         .padding(5)

--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -483,11 +483,10 @@ private struct IceBarContentView: View {
     }
 
     private var clipShape: some InsettableShape {
-        if appearance.hasRoundedShape {
-            RoundedRectangle(cornerRadius: contentHeight / 2, style: .circular)
-        } else {
-            RoundedRectangle(cornerRadius: contentHeight / 4, style: .continuous)
-        }
+        ThawBarBorderShape.thawBarClip(
+            height: contentHeight,
+            hasRoundedShape: appearance.hasRoundedShape
+        )
     }
 
     var body: some View {
@@ -515,15 +514,10 @@ private struct IceBarContentView: View {
             .clipShape(clipShape)
 
             if appearance.hasBorder {
-                // Square corners sit under the display's rounded screen edge
-                // (#325): omit the top stroke so it is not clipped mid-line.
-                ThawBarBorderShape(
-                    cornerRadius: appearance.hasRoundedShape
-                        ? contentHeight / 2
-                        : contentHeight / 4,
-                    cornerStyle: appearance.hasRoundedShape ? .circular : .continuous,
-                    omitTopEdge: !appearance.hasRoundedShape,
-                    inset: appearance.borderWidth / 2
+                ThawBarBorderShape.thawBarBorder(
+                    height: contentHeight,
+                    hasRoundedShape: appearance.hasRoundedShape,
+                    borderWidth: appearance.borderWidth
                 )
                 .stroke(lineWidth: appearance.borderWidth)
                 .foregroundStyle(Color(cgColor: appearance.borderColor))

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -13,7 +13,7 @@ import SwiftUI
 /// Used by the Thaw Bar when square corners meet the display's rounded
 /// screen corners (#325): drawing the top edge would be clipped and look
 /// broken, so only the leading, trailing, and bottom edges are stroked.
-struct ThawBarBorderShape: Shape {
+nonisolated struct ThawBarBorderShape: Shape {
     /// Corner radius of the un-inset clip path.
     var cornerRadius: CGFloat
     /// Matches the Thaw Bar clip: circular for fully rounded ends,

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -97,59 +97,97 @@ nonisolated struct ThawBarBorderShape: InsettableShape {
         return Self.openPathOmittingTopEdge(closed, in: drawRect)
     }
 
-    /// Drops the top edge of a closed rounded-rect path and reverses the
+    /// Drops the top edge of a closed rounded-rect path and reopens the
     /// remaining outline so the stroke runs top-leading → bottom → top-trailing.
+    ///
+    /// The source is a closed loop, but SwiftUI is free to begin that loop
+    /// anywhere on it — `UnevenRoundedRectangle` in fact begins partway down
+    /// the trailing edge — so the removed edge usually sits in the *middle* of
+    /// the emitted order. Walking that order directly would join the two loose
+    /// ends and draw the top edge straight back in, while losing the stretch of
+    /// trailing edge above the start point. The outline is therefore rebuilt as
+    /// a full loop, including the segment `closeSubpath` implies, and rotated
+    /// to begin just after the top edge before being reversed.
     private static func openPathOmittingTopEdge(_ closed: Path, in rect: CGRect) -> Path {
-        var current = CGPoint.zero
-        var skippedTopEdge = false
-        var chain: [(from: CGPoint, to: CGPoint, element: ElementKind)] = []
-
-        closed.forEach { element in
-            switch element {
-            case .move(to: let point):
-                current = point
-            case .line(to: let point):
-                if !skippedTopEdge,
-                   abs(current.y - rect.minY) < 0.5,
-                   abs(point.y - rect.minY) < 0.5 {
-                    skippedTopEdge = true
-                    current = point
-                    return
-                }
-                chain.append((current, point, .line))
-                current = point
-            case .quadCurve(to: let point, control: let control):
-                chain.append((current, point, .quad(control: control)))
-                current = point
-            case .curve(to: let point, control1: let c1, control2: let c2):
-                chain.append((current, point, .cubic(control1: c1, control2: c2)))
-                current = point
-            case .closeSubpath:
-                break
-            }
+        let loop = segments(of: closed)
+        guard let topEdge = loop.firstIndex(where: { isTopEdge($0, in: rect) }) else {
+            // Nothing recognizable to remove; a closed outline beats a mangled
+            // one, so draw the shape as it came.
+            return closed
         }
+
+        let chain = Array(loop[(topEdge + 1)...] + loop[..<topEdge])
 
         var path = Path()
         guard let last = chain.last else {
             return path
         }
 
-        // Reverse so drawing starts at the original end (top-leading).
+        // Reverse so drawing starts at the top-leading corner.
         path.move(to: last.to)
         for segment in chain.reversed() {
-            switch segment.element {
+            switch segment.kind {
             case .line:
                 path.addLine(to: segment.from)
-            case .quad(let control):
+            case let .quad(control):
                 path.addQuadCurve(to: segment.from, control: control)
-            case .cubic(let control1, let control2):
+            case let .cubic(control1, control2):
                 path.addCurve(to: segment.from, control1: control2, control2: control1)
             }
         }
         return path
     }
 
-    private enum ElementKind {
+    /// Flattens a path into its segments, materializing the closing segment
+    /// that `closeSubpath` only implies.
+    private static func segments(of path: Path) -> [Segment] {
+        var segments: [Segment] = []
+        var current = CGPoint.zero
+        var subpathStart = CGPoint.zero
+
+        path.forEach { element in
+            switch element {
+            case let .move(to: point):
+                current = point
+                subpathStart = point
+            case let .line(to: point):
+                segments.append(Segment(from: current, to: point, kind: .line))
+                current = point
+            case let .quadCurve(to: point, control: control):
+                segments.append(Segment(from: current, to: point, kind: .quad(control: control)))
+                current = point
+            case let .curve(to: point, control1: control1, control2: control2):
+                let kind = SegmentKind.cubic(control1: control1, control2: control2)
+                segments.append(Segment(from: current, to: point, kind: kind))
+                current = point
+            case .closeSubpath:
+                if current != subpathStart {
+                    segments.append(Segment(from: current, to: subpathStart, kind: .line))
+                }
+                current = subpathStart
+            }
+        }
+        return segments
+    }
+
+    /// Whether a segment is the run along the top of `rect`.
+    ///
+    /// The width test matters: a zero-radius corner still emits curve elements,
+    /// they are just zero-length, and both of the top ones sit exactly on
+    /// `minY`. Without it the first of those would be mistaken for the edge.
+    private static func isTopEdge(_ segment: Segment, in rect: CGRect) -> Bool {
+        abs(segment.from.y - rect.minY) < 0.5
+            && abs(segment.to.y - rect.minY) < 0.5
+            && abs(segment.to.x - segment.from.x) > 0.5
+    }
+
+    private struct Segment {
+        var from: CGPoint
+        var to: CGPoint
+        var kind: SegmentKind
+    }
+
+    private enum SegmentKind {
         case line
         case quad(control: CGPoint)
         case cubic(control1: CGPoint, control2: CGPoint)

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -2,6 +2,7 @@
 //  ThawBarBorderShape.swift
 //  Project: Thaw
 //
+//  Copyright (Ice) © 2023–2025 Jordan Baird
 //  Copyright (Thaw) © 2026 Toni Förster
 //  Licensed under the GNU GPLv3
 

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -8,28 +8,64 @@
 
 import SwiftUI
 
-/// A rounded rectangle whose stroke can omit the top edge.
+/// The Thaw Bar's rounded-rectangle geometry, serving as both its clip and
+/// its border stroke.
 ///
-/// Used by the Thaw Bar when square corners meet the display's rounded
-/// screen corners (#325): drawing the top edge would be clipped and look
-/// broken, so only the leading, trailing, and bottom edges are stroked.
-nonisolated struct ThawBarBorderShape: Shape {
-    /// Corner radius of the un-inset clip path.
+/// The clip and the stroke have to agree on corner radius and style or the
+/// border drifts off the clipped edge, so both are built by the factories
+/// below instead of by separately maintained expressions at each call site.
+///
+/// When square corners meet the display's rounded screen corners (#325),
+/// the top edge of the stroke would be clipped and look broken, so the
+/// border omits it and draws only the leading, trailing, and bottom edges.
+nonisolated struct ThawBarBorderShape: InsettableShape {
+    /// Corner radius of the un-inset path.
     var cornerRadius: CGFloat
-    /// Matches the Thaw Bar clip: circular for fully rounded ends,
-    /// continuous for square corners.
+    /// Circular for fully rounded ends, continuous for square corners.
     var cornerStyle: RoundedCornerStyle = .continuous
     /// When `true`, the path starts at the top-leading corner, runs down the
     /// leading side, across the bottom, and up the trailing side — leaving the
     /// top edge open.
     var omitTopEdge: Bool
-    /// Inset applied before constructing the path (half the stroke width so
-    /// the stroke sits on the clip edge, matching `InsettableShape.inset`).
-    var inset: CGFloat = 0
+    /// Inset applied before constructing the path. Accumulated through
+    /// ``inset(by:)`` rather than set directly.
+    var insetAmount: CGFloat = 0
+
+    /// The Thaw Bar's clip for a given content height: fully rounded ends get
+    /// a circular half-height radius, square corners a continuous
+    /// quarter-height one.
+    static func thawBarClip(height: CGFloat, hasRoundedShape: Bool) -> ThawBarBorderShape {
+        ThawBarBorderShape(
+            cornerRadius: hasRoundedShape ? height / 2 : height / 4,
+            cornerStyle: hasRoundedShape ? .circular : .continuous,
+            omitTopEdge: false
+        )
+    }
+
+    /// The border that traces ``thawBarClip(height:hasRoundedShape:)``.
+    ///
+    /// Derived from the clip so the two cannot drift apart, inset by half the
+    /// stroke width so the stroke sits centred on the clip edge, and opened at
+    /// the top on square corners (#325).
+    static func thawBarBorder(
+        height: CGFloat,
+        hasRoundedShape: Bool,
+        borderWidth: CGFloat
+    ) -> ThawBarBorderShape {
+        var shape = thawBarClip(height: height, hasRoundedShape: hasRoundedShape)
+        shape.omitTopEdge = !hasRoundedShape
+        return shape.inset(by: borderWidth / 2)
+    }
+
+    func inset(by amount: CGFloat) -> ThawBarBorderShape {
+        var shape = self
+        shape.insetAmount += amount
+        return shape
+    }
 
     func path(in rect: CGRect) -> Path {
-        let drawRect = rect.insetBy(dx: inset, dy: inset)
-        let radius = min(max(cornerRadius - inset, 0), min(drawRect.width, drawRect.height) / 2)
+        let drawRect = rect.insetBy(dx: insetAmount, dy: insetAmount)
+        let radius = min(max(cornerRadius - insetAmount, 0), min(drawRect.width, drawRect.height) / 2)
 
         if !omitTopEdge {
             return RoundedRectangle(cornerRadius: radius, style: cornerStyle)

--- a/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
+++ b/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
@@ -1,0 +1,120 @@
+//
+//  ThawBarBorderShape.swift
+//  Project: Thaw
+//
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+
+/// A rounded rectangle whose stroke can omit the top edge.
+///
+/// Used by the Thaw Bar when square corners meet the display's rounded
+/// screen corners (#325): drawing the top edge would be clipped and look
+/// broken, so only the leading, trailing, and bottom edges are stroked.
+struct ThawBarBorderShape: Shape {
+    /// Corner radius of the un-inset clip path.
+    var cornerRadius: CGFloat
+    /// Matches the Thaw Bar clip: circular for fully rounded ends,
+    /// continuous for square corners.
+    var cornerStyle: RoundedCornerStyle = .continuous
+    /// When `true`, the path starts at the top-leading corner, runs down the
+    /// leading side, across the bottom, and up the trailing side — leaving the
+    /// top edge open.
+    var omitTopEdge: Bool
+    /// Inset applied before constructing the path (half the stroke width so
+    /// the stroke sits on the clip edge, matching `InsettableShape.inset`).
+    var inset: CGFloat = 0
+
+    func path(in rect: CGRect) -> Path {
+        let drawRect = rect.insetBy(dx: inset, dy: inset)
+        let radius = min(max(cornerRadius - inset, 0), min(drawRect.width, drawRect.height) / 2)
+
+        if !omitTopEdge {
+            return RoundedRectangle(cornerRadius: radius, style: cornerStyle)
+                .path(in: drawRect)
+        }
+
+        guard radius > 0 else {
+            var path = Path()
+            path.move(to: CGPoint(x: drawRect.minX, y: drawRect.minY))
+            path.addLine(to: CGPoint(x: drawRect.minX, y: drawRect.maxY))
+            path.addLine(to: CGPoint(x: drawRect.maxX, y: drawRect.maxY))
+            path.addLine(to: CGPoint(x: drawRect.maxX, y: drawRect.minY))
+            return path
+        }
+
+        // Top corners stay square (open edge); bottom corners follow
+        // `cornerStyle` so the stroke matches the clip path for both
+        // `.circular` and `.continuous`.
+        let closed = UnevenRoundedRectangle(
+            cornerRadii: RectangleCornerRadii(
+                topLeading: 0,
+                bottomLeading: radius,
+                bottomTrailing: radius,
+                topTrailing: 0
+            ),
+            style: cornerStyle
+        ).path(in: drawRect)
+
+        return Self.openPathOmittingTopEdge(closed, in: drawRect)
+    }
+
+    /// Drops the top edge of a closed rounded-rect path and reverses the
+    /// remaining outline so the stroke runs top-leading → bottom → top-trailing.
+    private static func openPathOmittingTopEdge(_ closed: Path, in rect: CGRect) -> Path {
+        var current = CGPoint.zero
+        var skippedTopEdge = false
+        var chain: [(from: CGPoint, to: CGPoint, element: ElementKind)] = []
+
+        closed.forEach { element in
+            switch element {
+            case .move(to: let point):
+                current = point
+            case .line(to: let point):
+                if !skippedTopEdge,
+                   abs(current.y - rect.minY) < 0.5,
+                   abs(point.y - rect.minY) < 0.5 {
+                    skippedTopEdge = true
+                    current = point
+                    return
+                }
+                chain.append((current, point, .line))
+                current = point
+            case .quadCurve(to: let point, control: let control):
+                chain.append((current, point, .quad(control: control)))
+                current = point
+            case .curve(to: let point, control1: let c1, control2: let c2):
+                chain.append((current, point, .cubic(control1: c1, control2: c2)))
+                current = point
+            case .closeSubpath:
+                break
+            }
+        }
+
+        var path = Path()
+        guard let last = chain.last else {
+            return path
+        }
+
+        // Reverse so drawing starts at the original end (top-leading).
+        path.move(to: last.to)
+        for segment in chain.reversed() {
+            switch segment.element {
+            case .line:
+                path.addLine(to: segment.from)
+            case .quad(let control):
+                path.addQuadCurve(to: segment.from, control: control)
+            case .cubic(let control1, let control2):
+                path.addCurve(to: segment.from, control1: control2, control2: control1)
+            }
+        }
+        return path
+    }
+
+    private enum ElementKind {
+        case line
+        case quad(control: CGPoint)
+        case cubic(control1: CGPoint, control2: CGPoint)
+    }
+}

--- a/ThawTests/MenuBar/IceBar/ThawBarBorderShapeTests.swift
+++ b/ThawTests/MenuBar/IceBar/ThawBarBorderShapeTests.swift
@@ -1,0 +1,282 @@
+//
+//  ThawBarBorderShapeTests.swift
+//  Project: Thaw
+//
+//  Copyright (Ice) © 2023–2025 Jordan Baird
+//  Copyright (Thaw) © 2026 Toni Förster
+//  Licensed under the GNU GPLv3
+
+import SwiftUI
+import Testing
+@testable import Thaw
+
+/// Covers the geometry the Thaw Bar's clip and border share, and the path
+/// surgery that opens the top edge on square corners (#325).
+///
+/// `path(in:)` drops the top edge by introspecting a closed
+/// `UnevenRoundedRectangle` path, which makes it sensitive to how SwiftUI
+/// happens to emit that path: which element the outline starts on, and
+/// whether the top corners land exactly on `minY`. These tests pin the
+/// observable result — an open outline with no top edge and both ends on the
+/// top corners — so a change in that emission order is caught here rather
+/// than as a stray line across the bar.
+@Suite("Thaw Bar border shape")
+struct ThawBarBorderShapeTests {
+    private let rect = CGRect(x: 0, y: 0, width: 200, height: 30)
+
+    // MARK: - Closed outline
+
+    /// Rounded ends stroke all four edges, so the path stays a plain closed
+    /// rounded rectangle.
+    @Test("Keeping the top edge leaves a closed outline")
+    func keepingTopEdgeStaysClosed() {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 15, cornerStyle: .circular, omitTopEdge: false)
+                .path(in: rect)
+        )
+        #expect(outline.isClosed)
+        #expect(outline.boundingRect.isNear(rect))
+        #expect(outline.hasTopEdge(of: rect))
+    }
+
+    // MARK: - Open outline
+
+    /// The point of the shape: no segment runs along the top of the rect.
+    ///
+    /// The reconstruction walks the remaining segments as one continuous
+    /// chain, so if the dropped edge were not at the start or end of the
+    /// traversal the join would draw the top edge straight back in.
+    @Test("Omitting the top edge leaves no segment along the top", arguments: [
+        RoundedCornerStyle.continuous, .circular,
+    ])
+    func omittingTopEdgeRemovesIt(style: RoundedCornerStyle) {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 7.5, cornerStyle: style, omitTopEdge: true)
+                .path(in: rect)
+        )
+        #expect(!outline.isClosed)
+        #expect(!outline.hasTopEdge(of: rect))
+    }
+
+    /// The open ends sit on the two top corners, so the stroke runs down the
+    /// leading side, across the bottom, and back up the trailing side.
+    @Test("The open ends are the two top corners")
+    func openEndsAreTopCorners() {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 7.5, cornerStyle: .continuous, omitTopEdge: true)
+                .path(in: rect)
+        )
+        let ends = [outline.start, outline.end].sorted { $0.x < $1.x }
+        #expect(ends.count == 2)
+        #expect(ends[0].isNear(CGPoint(x: rect.minX, y: rect.minY)))
+        #expect(ends[1].isNear(CGPoint(x: rect.maxX, y: rect.minY)))
+        #expect(outline.boundingRect.isNear(rect))
+    }
+
+    // MARK: - Degenerate radii
+
+    /// A zero radius takes the hand-built three-edge fallback rather than the
+    /// path-surgery branch.
+    @Test("A zero radius draws three straight edges")
+    func zeroRadiusDrawsThreeEdges() {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 0, omitTopEdge: true).path(in: rect)
+        )
+        #expect(outline.segments.count == 3)
+        #expect(outline.curveCount == 0)
+        #expect(!outline.isClosed)
+        #expect(outline.start.isNear(CGPoint(x: rect.minX, y: rect.minY)))
+        #expect(outline.end.isNear(CGPoint(x: rect.maxX, y: rect.minY)))
+    }
+
+    /// An inset deeper than the radius must clamp to zero rather than produce
+    /// a negative radius.
+    @Test("An inset past the radius degenerates to straight edges")
+    func insetPastRadiusDegenerates() {
+        let shape = ThawBarBorderShape(cornerRadius: 4, omitTopEdge: true).inset(by: 6)
+        let outline = Outline(shape.path(in: rect))
+        #expect(outline.curveCount == 0)
+        #expect(outline.boundingRect.isNear(rect.insetBy(dx: 6, dy: 6)))
+    }
+
+    /// A radius larger than the rect can hold is clamped, so the path never
+    /// escapes its bounds.
+    @Test("An oversized radius is clamped to the rect")
+    func oversizedRadiusIsClamped() {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 500, cornerStyle: .circular, omitTopEdge: true)
+                .path(in: rect)
+        )
+        #expect(outline.boundingRect.isNear(rect))
+        #expect(!outline.hasTopEdge(of: rect))
+    }
+
+    /// Zero-height bars occur transiently while the menu bar height is still
+    /// being estimated; they must not trap on a negative dimension.
+    @Test("A degenerate rect collapses to a point")
+    func degenerateRectCollapses() {
+        let outline = Outline(
+            ThawBarBorderShape(cornerRadius: 8, omitTopEdge: true).path(in: .zero)
+        )
+        #expect(outline.boundingRect.isNear(.zero))
+    }
+
+    // MARK: - Inset accumulation
+
+    /// `InsettableShape` insets compose, so `.strokeBorder` and an explicit
+    /// inset do not overwrite one another.
+    @Test("Insets accumulate")
+    func insetsAccumulate() {
+        let shape = ThawBarBorderShape(cornerRadius: 15, omitTopEdge: false)
+            .inset(by: 2)
+            .inset(by: 3)
+        #expect(shape.insetAmount == 5)
+        #expect(Outline(shape.path(in: rect)).boundingRect.isNear(rect.insetBy(dx: 5, dy: 5)))
+    }
+
+    // MARK: - Clip and border agreement
+
+    /// Rounded ends: a circular half-height radius, top edge kept.
+    @Test("A rounded clip is a circular half-height radius")
+    func roundedClipGeometry() {
+        let clip = ThawBarBorderShape.thawBarClip(height: 30, hasRoundedShape: true)
+        #expect(clip.cornerRadius == 15)
+        #expect(clip.cornerStyle == .circular)
+        #expect(!clip.omitTopEdge)
+        #expect(clip.insetAmount == 0)
+    }
+
+    /// Square ends: a continuous quarter-height radius, top edge kept — the
+    /// clip has to stay closed even where the border opens up.
+    @Test("A square clip is a continuous quarter-height radius and stays closed")
+    func squareClipGeometry() {
+        let clip = ThawBarBorderShape.thawBarClip(height: 30, hasRoundedShape: false)
+        #expect(clip.cornerRadius == 7.5)
+        #expect(clip.cornerStyle == .continuous)
+        #expect(!clip.omitTopEdge)
+    }
+
+    /// The border must inherit radius and style from the clip; drifting apart
+    /// is what leaves the stroke floating off the clipped edge.
+    @Test("The border inherits the clip's radius and style", arguments: [true, false])
+    func borderInheritsClipGeometry(hasRoundedShape: Bool) {
+        let clip = ThawBarBorderShape.thawBarClip(height: 30, hasRoundedShape: hasRoundedShape)
+        let border = ThawBarBorderShape.thawBarBorder(
+            height: 30,
+            hasRoundedShape: hasRoundedShape,
+            borderWidth: 2
+        )
+        #expect(border.cornerRadius == clip.cornerRadius)
+        #expect(border.cornerStyle == clip.cornerStyle)
+        #expect(border.insetAmount == 1)
+    }
+
+    /// Only square corners open the top edge (#325); rounded ends have no
+    /// screen corner to collide with.
+    @Test("Only a square border opens the top edge")
+    func onlySquareBorderOpensTopEdge() {
+        #expect(
+            ThawBarBorderShape
+                .thawBarBorder(height: 30, hasRoundedShape: false, borderWidth: 1)
+                .omitTopEdge
+        )
+        #expect(
+            !ThawBarBorderShape
+                .thawBarBorder(height: 30, hasRoundedShape: true, borderWidth: 1)
+                .omitTopEdge
+        )
+    }
+
+    /// Half the stroke width of inset is what keeps the stroke centred on the
+    /// clip edge instead of straddling it.
+    @Test("The border sits half a stroke width inside the clip")
+    func borderSitsInsideClip() {
+        let clipBounds = Outline(
+            ThawBarBorderShape.thawBarClip(height: 30, hasRoundedShape: true).path(in: rect)
+        ).boundingRect
+        let borderBounds = Outline(
+            ThawBarBorderShape
+                .thawBarBorder(height: 30, hasRoundedShape: true, borderWidth: 4)
+                .path(in: rect)
+        ).boundingRect
+        #expect(borderBounds.isNear(clipBounds.insetBy(dx: 2, dy: 2)))
+    }
+}
+
+// MARK: - Path introspection
+
+/// A flattened view of a `Path`: its segment endpoints, in draw order.
+private struct Outline {
+    struct Segment {
+        var from: CGPoint
+        var to: CGPoint
+        var isCurve: Bool
+    }
+
+    var segments: [Segment] = []
+    var isClosed = false
+
+    var start: CGPoint { segments.first?.from ?? .zero }
+    var end: CGPoint { segments.last?.to ?? .zero }
+    var curveCount: Int { segments.count { $0.isCurve } }
+
+    var boundingRect: CGRect {
+        let points = segments.flatMap { [$0.from, $0.to] }
+        guard let first = points.first else { return .null }
+        return points.dropFirst().reduce(CGRect(origin: first, size: .zero)) { rect, point in
+            rect.union(CGRect(origin: point, size: .zero))
+        }
+    }
+
+    init(_ path: Path) {
+        var current = CGPoint.zero
+        var subpathStart = CGPoint.zero
+        path.forEach { element in
+            switch element {
+            case let .move(to: point):
+                current = point
+                subpathStart = point
+            case let .line(to: point):
+                segments.append(Segment(from: current, to: point, isCurve: false))
+                current = point
+            case let .quadCurve(to: point, control: _):
+                segments.append(Segment(from: current, to: point, isCurve: true))
+                current = point
+            case let .curve(to: point, control1: _, control2: _):
+                segments.append(Segment(from: current, to: point, isCurve: true))
+                current = point
+            case .closeSubpath:
+                isClosed = true
+                segments.append(Segment(from: current, to: subpathStart, isCurve: false))
+                current = subpathStart
+            }
+        }
+    }
+
+    /// Whether any segment runs horizontally along the top of `rect`.
+    ///
+    /// Uses a wider tolerance than the shape's own 0.5 so a top edge that
+    /// merely drifted, rather than vanished, still counts as present.
+    func hasTopEdge(of rect: CGRect) -> Bool {
+        segments.contains { segment in
+            abs(segment.from.y - rect.minY) < 1
+                && abs(segment.to.y - rect.minY) < 1
+                && abs(segment.to.x - segment.from.x) > 1
+        }
+    }
+}
+
+private extension CGPoint {
+    func isNear(_ other: CGPoint, tolerance: CGFloat = 0.5) -> Bool {
+        abs(x - other.x) <= tolerance && abs(y - other.y) <= tolerance
+    }
+}
+
+private extension CGRect {
+    func isNear(_ other: CGRect, tolerance: CGFloat = 0.5) -> Bool {
+        abs(minX - other.minX) <= tolerance
+            && abs(minY - other.minY) <= tolerance
+            && abs(maxX - other.maxX) <= tolerance
+            && abs(maxY - other.maxY) <= tolerance
+    }
+}

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -60,6 +60,7 @@ $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGroupPolicy.swift
 $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGroupResolution.swift
 $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGrouping.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBar.swift
+$(SRCROOT)/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarColorManager.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLayout.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLocation.swift

--- a/scripts/swiftlint-inputs.xcfilelist
+++ b/scripts/swiftlint-inputs.xcfilelist
@@ -60,11 +60,11 @@ $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGroupPolicy.swift
 $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGroupResolution.swift
 $(SRCROOT)/Thaw/MenuBar/Groups/MenuBarItemGrouping.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBar.swift
-$(SRCROOT)/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarColorManager.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLayout.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/IceBarLocation.swift
 $(SRCROOT)/Thaw/MenuBar/IceBar/MenuBarItemIconFallback.swift
+$(SRCROOT)/Thaw/MenuBar/IceBar/ThawBarBorderShape.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBar.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarArrangedView.swift
 $(SRCROOT)/Thaw/MenuBar/LayoutBar/LayoutBarContainer.swift


### PR DESCRIPTION
## Summary
- Fixes #325: when Thaw Bar uses square corners with a border, omit the top stroke so the display's rounded screen edge does not clip it mid-line.
- Adds `ThawBarBorderShape` with an open-top path whose bottom corners follow the clip's `.circular` / `.continuous` style (no circular-arc mismatch on continuous corners).

## Test plan
- [ ] Enable Appearance → Shape with a border and square (non-rounded) corners
- [ ] Open Thaw Bar on a notched / rounded-corner display and confirm the top border is absent and side/bottom strokes align with the panel
- [ ] Switch to fully rounded corners and confirm the border is a closed stroke that matches the capsule clip

Closes: #325

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved IceBar border rendering across different corner styles.
  - Square-corner bars now correctly omit the top border edge.
  - Rounded bars retain consistent outlines and inset spacing.
  - Border outlines now better match the bar’s appearance, with smoother bottom corners and more accurate spacing.
  - Corrected border geometry for more consistent visual results across supported appearances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->