### PR TITLE
fix(icebar): restore correct icon tint when opening on another display

### DIFF
--- a/Thaw/MenuBar/IceBar/IceBar.swift
+++ b/Thaw/MenuBar/IceBar/IceBar.swift
@@ -34,6 +34,10 @@ final class IceBarPanel: NSPanel {
     /// change posts that notification, racing with the show).
     private var lastShowTimestamp: Date?
 
+    /// Display the Thaw Bar was last shown on. Cross-screen opens must drop
+    /// the previous screen's icon captures (light/dark tint is baked in).
+    private var lastShownDisplayID: CGDirectDisplayID?
+
     /// Storage for internal observers.
     private var cancellables = Set<AnyCancellable>()
 
@@ -228,9 +232,26 @@ final class IceBarPanel: NSPanel {
         currentSection = section
         lastShowTimestamp = Date()
 
-        // Show the panel immediately with whatever cached data we have.
-        // The SwiftUI view observes itemManager and imageCache, so it
-        // will re-render automatically as the background updates land.
+        // Menu bar icon light/dark tint is baked into the captured bitmaps.
+        // Restore this display's warm snapshot when we have one; otherwise clear
+        // wrong-display icons so the panel can still appear instantly (Loading)
+        // while a background SkyLight recapture fills the correct tint.
+        let switchedDisplay = lastShownDisplayID.map { $0 != screen.displayID } ?? false
+        let needsBackgroundRecapture = appState.imageCache.prepareImagesForThawBar(
+            displayID: screen.displayID,
+            section: section
+        )
+        if switchedDisplay {
+            colorManager.invalidateColorInfo()
+            diagLog.notice(
+                "show: display \(self.lastShownDisplayID.map(String.init) ?? "nil") → \(screen.displayID); warmCache=\(!needsBackgroundRecapture)"
+            )
+        }
+        lastShownDisplayID = screen.displayID
+
+        // Show the panel immediately. Never defer orderFront: setting
+        // currentSection without a visible panel makes isHidden flip to false,
+        // so a second click would call hide() instead of show().
         contentView = IceBarHostingView(
             appState: appState,
             colorManager: colorManager,
@@ -242,23 +263,23 @@ final class IceBarPanel: NSPanel {
 
         // Color manager must be updated after updating the panel's origin,
         // but before it is shown.
-        //
-        // Color manager handles frame changes automatically, but does so on
-        // the main queue, so we need to update manually once before showing
-        // the panel to prevent the color from flashing.
         colorManager.updateAllProperties(with: frame, screen: screen)
 
         orderFrontRegardless()
 
-        // Rehide temporarily shown items and refresh caches in the
-        // background. Ordering is preserved: rehide moves items back
-        // to their correct sections before the cache is rebuilt.
-        // The task is cancelled in close() to avoid holding appState.
+        // Refresh color + icons in the background. Keep the settle delay so
+        // control-item positioning does not leave the hidden section empty.
+        let panelFrame = frame
+        let targetDisplayID = screen.displayID
         cacheTask?.cancel()
-        cacheTask = Task { [weak appState] in
+        cacheTask = Task { [weak appState, weak colorManager] in
             guard let appState else { return }
+
+            await colorManager?.refresh(with: panelFrame, screen: screen)
+
             await appState.itemManager.rehideTemporarilyShownItems(force: true)
             guard !Task.isCancelled else { return }
+
             // Settle delay: when the IceBar just opened on a screen that
             // was previously inactive, the menu bar has moved screens and
             // NSStatusItem windows (control item chevrons) are still
@@ -270,7 +291,10 @@ final class IceBarPanel: NSPanel {
             guard !Task.isCancelled else { return }
             await appState.itemManager.cacheItemsIfNeeded()
             guard !Task.isCancelled else { return }
-            await appState.imageCache.updateCache()
+            await appState.imageCache.recaptureSection(
+                section,
+                preferredDisplayID: targetDisplayID
+            )
         }
     }
 

--- a/Thaw/MenuBar/IceBar/IceBarColorManager.swift
+++ b/Thaw/MenuBar/IceBar/IceBarColorManager.swift
@@ -10,6 +10,10 @@ import Combine
 import Observation
 import SwiftUI
 
+/// Samples the menu bar / wallpaper strip under the Thaw Bar for icon contrast.
+///
+/// Sampling runs on whatever screen the panel is on — not only the main
+/// display — so a secondary-screen open does not keep the previous brightness.
 @MainActor
 @Observable
 final class IceBarColorManager {
@@ -47,17 +51,17 @@ final class IceBarColorManager {
         if let iceBarPanel {
             iceBarPanel.publisher(for: \.screen)
                 .receive(on: DispatchQueue.main)
-                .sink { [weak self] screen in
-                    guard
-                        let self,
-                        let screen,
-                        screen == .main
-                    else {
+                .sink { [weak self, weak iceBarPanel] screen in
+                    guard let self, let screen, let iceBarPanel, iceBarPanel.isVisible else {
                         return
                     }
+                    // Drop the previous display's sample before the new capture
+                    // lands so icon contrast cannot briefly reuse the old screen.
+                    self.invalidateColorInfo()
+                    let frame = iceBarPanel.frame
                     Task { [weak self] in
                         guard let self else { return }
-                        await self.updateWindowImage(for: screen)
+                        await self.refresh(with: frame, screen: screen)
                     }
                 }
                 .store(in: &c)
@@ -69,8 +73,7 @@ final class IceBarColorManager {
                         let self,
                         let iceBarPanel,
                         let screen = iceBarPanel.screen,
-                        iceBarPanel.isVisible,
-                        screen == .main
+                        iceBarPanel.isVisible
                     else {
                         return
                     }
@@ -103,15 +106,14 @@ final class IceBarColorManager {
                 guard
                     let iceBarPanel,
                     iceBarPanel.isVisible,
-                    let screen = iceBarPanel.screen,
-                    screen == .main
+                    let screen = iceBarPanel.screen
                 else {
                     return
                 }
                 let frame = iceBarPanel.frame
                 Task { [weak self] in
                     guard let self else { return }
-                    await self.updateWindowImage(for: screen)
+                    guard await self.updateWindowImage(for: screen) else { return }
                     withAnimation {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
@@ -120,22 +122,17 @@ final class IceBarColorManager {
             .store(in: &c)
 
             // Manage visibility: update colors immediately + start/stop periodic timer.
-            // Single subscription replaces the previous two \.isVisible observers.
             iceBarPanel.publisher(for: \.isVisible)
                 .removeDuplicates()
                 .receive(on: DispatchQueue.main)
                 .sink { [weak self, weak iceBarPanel] isVisible in
                     guard let self else { return }
                     if isVisible {
-                        // Refresh windowImage immediately so the first color
-                        // update isn't stale. Awaiting inside a Task so
-                        // updateColorInfo reads the fresh capture, not the
-                        // previous cycle's leftover.
-                        if let iceBarPanel, let screen = iceBarPanel.screen, screen == .main {
+                        if let iceBarPanel, let screen = iceBarPanel.screen {
                             let frame = iceBarPanel.frame
                             Task { [weak self] in
                                 guard let self else { return }
-                                await self.updateWindowImage(for: screen)
+                                guard await self.updateWindowImage(for: screen) else { return }
                                 self.updateColorInfo(with: frame, screen: screen)
                             }
                         }
@@ -160,15 +157,14 @@ final class IceBarColorManager {
                     let self,
                     let iceBarPanel,
                     iceBarPanel.isVisible,
-                    let screen = iceBarPanel.screen,
-                    screen == .main
+                    let screen = iceBarPanel.screen
                 else {
                     return
                 }
                 let frame = iceBarPanel.frame
                 Task { [weak self] in
                     guard let self else { return }
-                    await self.updateWindowImage(for: screen)
+                    guard await self.updateWindowImage(for: screen) else { return }
                     withAnimation {
                         self.updateColorInfo(with: frame, screen: screen)
                     }
@@ -192,7 +188,14 @@ final class IceBarColorManager {
         windowImage = nil
     }
 
-    private func updateWindowImage(for screen: NSScreen) async {
+    /// Captures the menu bar / wallpaper strip for `screen`.
+    ///
+    /// - Returns: `true` when this call stored the current generation's image.
+    ///   Callers must not update ``colorInfo`` after a `false` result — a stale
+    ///   capture would otherwise sample a newer `windowImage` with an older
+    ///   frame / screen.
+    @discardableResult
+    private func updateWindowImage(for screen: NSScreen) async -> Bool {
         let windows = WindowInfo.createWindows(option: .onScreen)
         let displayID = screen.displayID
 
@@ -200,11 +203,13 @@ final class IceBarColorManager {
             let menuBarWindow = WindowInfo.menuBarWindow(from: windows, for: displayID),
             let wallpaperWindow = WindowInfo.wallpaperWindow(from: windows, for: displayID)
         else {
-            return
+            return false
         }
 
         let windowIDs = [menuBarWindow.windowID, wallpaperWindow.windowID]
-        let bounds = withMutableCopy(of: wallpaperWindow.bounds) { $0.size.height = 1 }
+        // Quartz window bounds use a top-left origin. Capture the menu bar
+        // window's own frame so the average matches the visible bar body.
+        let bounds = menuBarWindow.bounds
 
         // Stamp our generation before suspending. If the counter advances while
         // we await (a clearWindowImage, a stopPeriodicRefresh, or a newer
@@ -218,8 +223,9 @@ final class IceBarColorManager {
             screenBounds: bounds,
             option: .nominalResolution
         )
-        guard generation == windowImageGeneration, let image else { return }
+        guard generation == windowImageGeneration, let image else { return false }
         windowImage = image
+        return true
     }
 
     /// The horizontal position (`0...1`) of the bar's center within the screen,
@@ -250,20 +256,27 @@ final class IceBarColorManager {
 
         let percentage = Self.colorSamplePercentage(frame: frame, screenFrame: screen.frame)
 
-        let cropRect = CGRect(x: imageBounds.width * percentage, y: 0, width: 0, height: 1)
-            .insetBy(dx: -150, dy: 0)
-            .intersection(imageBounds)
+        // Sample a horizontal band across the full captured menu-bar height so
+        // the average tracks the visible bar body, not only the top pixel row.
+        let cropRect = CGRect(
+            x: imageBounds.width * percentage,
+            y: 0,
+            width: 0,
+            height: imageBounds.height
+        )
+        .insetBy(dx: -150, dy: 0)
+        .intersection(imageBounds)
 
         guard
             let croppedImage = image.cropping(to: cropRect),
-            let averageColor = croppedImage.averageColor()
+            let averageColor = croppedImage.averageColor(option: .ignoreAlpha)
         else {
             return
         }
 
-        // Just use `menuBarWindow` as the source for now, regardless
-        // of whether its image contributed to the average.
-        colorInfo = MenuBarAverageColorInfo(color: averageColor, source: .menuBarWindow)
+        let next = MenuBarAverageColorInfo(color: averageColor, source: .menuBarWindow)
+        guard colorInfo != next else { return }
+        colorInfo = next
     }
 
     func updateAllProperties(with frame: CGRect, screen: NSScreen) {
@@ -273,8 +286,20 @@ final class IceBarColorManager {
         // cycle's leftover.
         Task { [weak self] in
             guard let self else { return }
-            await self.updateWindowImage(for: screen)
-            self.updateColorInfo(with: frame, screen: screen)
+            await self.refresh(with: frame, screen: screen)
         }
+    }
+
+    /// Drops the standing sample so a cross-display Thaw Bar open cannot
+    /// briefly reuse the previous screen's brightness for icon contrast.
+    func invalidateColorInfo() {
+        colorInfo = nil
+        clearWindowImage()
+    }
+
+    /// Captures the menu bar strip for `screen` and rewrites ``colorInfo``.
+    func refresh(with frame: CGRect, screen: NSScreen) async {
+        guard await updateWindowImage(for: screen) else { return }
+        updateColorInfo(with: frame, screen: screen)
     }
 }

--- a/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
+++ b/Thaw/MenuBar/MenuBarItems/MenuBarItemImageCache.swift
@@ -154,6 +154,18 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     /// The cached item images, keyed by their corresponding tags.
     private(set) var images = [MenuBarItemTag: CapturedImage]()
 
+    /// Display ID of the screen the current ``images`` were last captured for.
+    ///
+    /// Used by the Thaw Bar to drop stale bitmaps when opening on a different
+    /// screen: menu bar icon light/dark tint is baked into the capture, so
+    /// reusing another display's cache briefly shows the wrong icon colors.
+    private(set) var lastCaptureDisplayID: CGDirectDisplayID?
+
+    /// Per-display icon snapshots so switching screens can restore the correct
+    /// light/dark tint immediately instead of flashing the previous screen.
+    @ObservationIgnored
+    private var imagesByDisplay = [CGDirectDisplayID: [MenuBarItemTag: CapturedImage]]()
+
     /// Tracks which items are blinking for attention.
     ///
     /// Deliberately not observable: it is fed on every capture, and the
@@ -824,7 +836,7 @@ final class MenuBarItemImageCache: @unchecked Sendable {
 
             let nav = appState.navigationState
 
-            let preferredDisplayID = appState.itemManager.itemCache.displayID
+            let preferredDisplayID = preferredCaptureDisplayID(appState: appState)
             guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
                 MenuBarItemImageCache.diagLog.warning("liveRefresh: no connected screens available, skipping")
                 try? await Task.sleep(for: .seconds(max(interval, Self.minIconRefreshInterval)))
@@ -982,6 +994,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 }
             case .visible, nil:
                 break
+            }
+
+            await MainActor.run {
+                storeImages(for: screen.displayID)
             }
 
             if let hiddenInterval, !hiddenItems.isEmpty {
@@ -1698,6 +1714,24 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 "Memory pressure: Cleared \(tagsToRemove.count) items from cache"
             )
         }
+
+        // Per-display warm snapshots are independent of the standing LRU; drop
+        // non-standing displays first, then trim the standing copy to match.
+        let standing = lastCaptureDisplayID
+        for displayID in imagesByDisplay.keys where displayID != standing {
+            imagesByDisplay.removeValue(forKey: displayID)
+        }
+        if let standing, var standingImages = imagesByDisplay[standing] {
+            standingImages = standingImages.filter { images[$0.key] != nil }
+            if standingImages.count > images.count {
+                let excess = standingImages.count - images.count
+                let dropKeys = Array(standingImages.keys.prefix(excess))
+                for key in dropKeys {
+                    standingImages.removeValue(forKey: key)
+                }
+            }
+            imagesByDisplay[standing] = standingImages
+        }
     }
 
     /// Returns the `count` least recently used tags, sorted by access time (oldest first).
@@ -1731,19 +1765,29 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     /// exact tag (including windowID) is not found. This handles disk-loaded
     /// entries where the windowID is unavailable.
     func image(for tag: MenuBarItemTag) -> CapturedImage? {
-        if let image = images[tag] {
+        guard let image = Self.image(for: tag, in: images) else {
+            return nil
+        }
+        // Prefer the exact key when present so access-order tracks the live tag.
+        if images[tag] != nil {
             updateAccessOrder(for: tag)
+        } else if let matched = images.keys.first(where: { $0.matchesIgnoringWindowID(tag) }) {
+            updateAccessOrder(for: matched)
+        }
+        return image
+    }
+
+    /// Looks up `tag` in `store`, with the same exact-then-`matchesIgnoringWindowID`
+    /// fallback used by ``image(for:)``.
+    private static func image(
+        for tag: MenuBarItemTag,
+        in store: [MenuBarItemTag: CapturedImage]
+    ) -> CapturedImage? {
+        if let image = store[tag] {
             return image
         }
-        // Fallback: match by namespace and title only (ignoring windowID).
-        // This covers disk-loaded entries that were stored without a windowID.
-        if !tag.isSystemItem,
-           let entry = images.first(where: { $0.key.matchesIgnoringWindowID(tag) })
-        {
-            updateAccessOrder(for: entry.key)
-            return entry.value
-        }
-        return nil
+        guard !tag.isSystemItem else { return nil }
+        return store.first(where: { $0.key.matchesIgnoringWindowID(tag) })?.value
     }
 
     /// Returns the item's image with its transparent left and right margins
@@ -1884,12 +1928,41 @@ final class MenuBarItemImageCache: @unchecked Sendable {
 
     // MARK: Update Cache
 
+    /// Display to capture from while a consumer is visible.
+    ///
+    /// Prefer the Thaw Bar's screen when it is presented so a cross-display
+    /// open does not keep sampling the previous menu bar's icon tint.
+    @MainActor
+    private func preferredCaptureDisplayID(
+        appState: AppState,
+        override: CGDirectDisplayID? = nil
+    ) -> CGDirectDisplayID? {
+        if let override {
+            return override
+        }
+        if appState.navigationState.isIceBarPresented,
+           let iceBarDisplayID = appState.menuBarManager.iceBarPanel.screen?.displayID
+        {
+            return iceBarDisplayID
+        }
+        return appState.itemManager.itemCache.displayID
+    }
+
     /// Updates the cache for the given sections, without checking whether
     /// caching is necessary.
+    ///
+    /// - Parameter preferredDisplayID: When set (e.g. the Thaw Bar's screen),
+    ///   capture from that display instead of the standing item-cache display.
     @MainActor
-    func updateCacheWithoutChecks(sections: [MenuBarSection.Name]) async {
+    func updateCacheWithoutChecks(
+        sections: [MenuBarSection.Name],
+        preferredDisplayID: CGDirectDisplayID? = nil
+    ) async {
         await withCapturePermit {
-            await performCacheUpdateWithoutChecks(sections: sections)
+            await performCacheUpdateWithoutChecks(
+                sections: sections,
+                preferredDisplayID: preferredDisplayID
+            )
         }
     }
 
@@ -1906,7 +1979,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     }
 
     @MainActor
-    private func performCacheUpdateWithoutChecks(sections: [MenuBarSection.Name]) async {
+    private func performCacheUpdateWithoutChecks(
+        sections: [MenuBarSection.Name],
+        preferredDisplayID: CGDirectDisplayID? = nil
+    ) async {
         guard let appState else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: appState is nil, aborting")
             return
@@ -1918,15 +1994,15 @@ final class MenuBarItemImageCache: @unchecked Sendable {
             return
         }
 
-        let preferredDisplayID = appState.itemManager.itemCache.displayID
-        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+        let resolvedPreferred = preferredCaptureDisplayID(appState: appState, override: preferredDisplayID)
+        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: resolvedPreferred) else {
             MenuBarItemImageCache.diagLog.warning("updateCacheWithoutChecks: no connected screens available, aborting")
             return
         }
         let screen = resolvedScreen.screen
-        if resolvedScreen.usedFallback, let preferredDisplayID {
+        if resolvedScreen.usedFallback, let resolvedPreferred {
             MenuBarItemImageCache.diagLog.warning(
-                "updateCacheWithoutChecks: cached displayID \(preferredDisplayID) is not connected; using displayID \(screen.displayID)"
+                "updateCacheWithoutChecks: cached displayID \(resolvedPreferred) is not connected; using displayID \(screen.displayID)"
             )
         }
 
@@ -1972,8 +2048,9 @@ final class MenuBarItemImageCache: @unchecked Sendable {
         let allValidTags = Set(
             appState.itemManager.itemCache.managedItems.map(\.tag)
         )
+        let displayID = screen.displayID
 
-        await MainActor.run { [newImages, allValidTags] in
+        await MainActor.run { [newImages, allValidTags, displayID] in
             let beforeCount = images.count
 
             // Tags with recent capture failures should keep their cached images
@@ -2067,6 +2144,10 @@ final class MenuBarItemImageCache: @unchecked Sendable {
                 MenuBarItemImageCache.diagLog.warning(
                     "Cache inconsistency: \(afterCount) cached images vs \(finalAccessOrderCount) LRU entries"
                 )
+            }
+
+            if !newImages.isEmpty {
+                storeImages(for: displayID)
             }
         }
     }
@@ -2180,6 +2261,194 @@ final class MenuBarItemImageCache: @unchecked Sendable {
         for tag in tags {
             accessOrder.remove(tag)
         }
+        if images.isEmpty {
+            lastCaptureDisplayID = nil
+        }
+    }
+
+    /// Force-recaptures a section for a specific display, including off-screen
+    /// (hidden / always-hidden) items via SkyLight.
+    ///
+    /// Used when the Thaw Bar opens on a different screen than the standing
+    /// image cache: ``updateCacheWithoutChecks`` skips off-screen items, and
+    /// waiting for the live-refresh loop would leave a ~1s wrong-tint flash.
+    @MainActor
+    func recaptureSection(
+        _ section: MenuBarSection.Name,
+        preferredDisplayID: CGDirectDisplayID
+    ) async {
+        guard let appState else { return }
+        guard let resolvedScreen = Self.resolveScreen(preferredDisplayID: preferredDisplayID) else {
+            return
+        }
+        let screen = resolvedScreen.screen
+        let scale = screen.backingScaleFactor
+        let items = appState.itemManager.itemCache.managedItems(for: section)
+            .filter { !$0.isControlItem }
+        guard !items.isEmpty else { return }
+
+        MenuBarItemImageCache.diagLog.notice(
+            "recaptureSection: section=\(section.logString) displayID=\(screen.displayID) items=\(items.count)"
+        )
+
+        await withCapturePermit {
+            if section == .visible {
+                await refreshImages(of: items, scale: scale, viaSCK: true)
+                lastSCKRefreshAt = ContinuousClock.now
+            } else {
+                // Share the live-refresh offscreen cadence so IceBar opens
+                // cannot bypass the #759 SkyLight throttle.
+                await awaitOffscreenRefreshSlot(for: section)
+                await refreshImages(of: items, scale: scale, viaSCK: false)
+            }
+        }
+        storeImages(for: screen.displayID)
+    }
+
+    /// Waits for — then claims — the live-refresh offscreen slot for `section`.
+    @MainActor
+    private func awaitOffscreenRefreshSlot(for section: MenuBarSection.Name) async {
+        let interval = Duration.seconds(
+            MenuBarLiveRefreshPolicy.refreshInterval(
+                for: section,
+                target: Self.minIconRefreshInterval
+            ) ?? MenuBarCaptureService.minAlwaysHiddenInterval
+        )
+        let now = ContinuousClock.now
+        let lastCaptureAt: ContinuousClock.Instant? = switch section {
+        case .hidden: lastHiddenRefreshAt
+        case .alwaysHidden: lastAlwaysHiddenRefreshAt
+        case .visible: nil
+        }
+        if let lastCaptureAt, now - lastCaptureAt < interval {
+            try? await Task.sleep(for: interval - (now - lastCaptureAt))
+        }
+        let claimedAt = ContinuousClock.now
+        switch section {
+        case .hidden:
+            lastHiddenRefreshAt = claimedAt
+        case .alwaysHidden:
+            lastAlwaysHiddenRefreshAt = claimedAt
+        case .visible:
+            break
+        }
+    }
+
+    /// Restores a warm per-display snapshot for the Thaw Bar, or clears the
+    /// section when only another screen's bitmaps are available.
+    ///
+    /// Call before the panel is ordered front so the first paint either has
+    /// the correct tint or a loading state — never the wrong screen's icons.
+    ///
+    /// - Returns: `true` when a background recapture is still needed (cold or
+    ///   incomplete warm restore).
+    @MainActor
+    @discardableResult
+    func prepareImagesForDisplay(_ displayID: CGDirectDisplayID, section: MenuBarSection.Name) -> Bool {
+        guard let appState else { return true }
+        let sectionItems = appState.itemManager.itemCache[section]
+        guard !sectionItems.isEmpty else { return false }
+
+        if let stored = imagesByDisplay[displayID], !stored.isEmpty {
+            var applied = 0
+            var missingTags = [MenuBarItemTag]()
+            for item in sectionItems {
+                if let image = Self.image(for: item.tag, in: stored) {
+                    images[item.tag] = image
+                    updateAccessOrder(for: item.tag)
+                    applied += 1
+                } else {
+                    missingTags.append(item.tag)
+                }
+            }
+            // Drop unrestored tags so previous-display bitmaps cannot linger
+            // beside a partial warm restore.
+            for tag in missingTags {
+                images.removeValue(forKey: tag)
+                accessOrder.remove(tag)
+            }
+            if applied > 0 {
+                lastCaptureDisplayID = displayID
+                MenuBarItemImageCache.diagLog.notice(
+                    "prepareImagesForDisplay: restored \(applied)/\(sectionItems.count) icons for display \(displayID)"
+                )
+                return !missingTags.isEmpty
+            }
+        }
+
+        if lastCaptureDisplayID != displayID {
+            MenuBarItemImageCache.diagLog.notice(
+                "prepareImagesForDisplay: no warm cache for display \(displayID); clearing section \(section.logString) to avoid wrong tint"
+            )
+            clearImages(for: section)
+            return true
+        }
+        return !sectionHasCachedImages(section)
+    }
+
+    /// Snapshots the standing ``images`` under `displayID` for instant restore.
+    @MainActor
+    func storeImages(for displayID: CGDirectDisplayID) {
+        guard !images.isEmpty else { return }
+        // Replace the display snapshot with the standing cache rather than
+        // merging forever — otherwise every live-refresh tick accumulates
+        // tags that the main LRU / memory-pressure paths already dropped.
+        imagesByDisplay[displayID] = images
+        lastCaptureDisplayID = displayID
+        pruneDisconnectedDisplayCaches()
+        enforcePerDisplayCacheLimit()
+    }
+
+    @MainActor
+    private func pruneDisconnectedDisplayCaches() {
+        let connected = Set(NSScreen.screens.map(\.displayID))
+        imagesByDisplay = imagesByDisplay.filter { connected.contains($0.key) }
+    }
+
+    /// Caps total icons retained across per-display snapshots.
+    @MainActor
+    private func enforcePerDisplayCacheLimit() {
+        let total = imagesByDisplay.values.reduce(0) { $0 + $1.count }
+        let limit = Self.maxCacheSize * max(imagesByDisplay.count, 1)
+        guard total > limit else { return }
+
+        let standing = lastCaptureDisplayID
+        let victims = imagesByDisplay.keys.filter { $0 != standing }
+        for displayID in victims {
+            imagesByDisplay.removeValue(forKey: displayID)
+            let remaining = imagesByDisplay.values.reduce(0) { $0 + $1.count }
+            if remaining <= limit { return }
+        }
+
+        if var standingImages = standing.flatMap({ imagesByDisplay[$0] }),
+           standingImages.count > Self.maxCacheSize
+        {
+            let keys = Array(standingImages.keys.prefix(standingImages.count - Self.maxCacheSize))
+            for key in keys {
+                standingImages.removeValue(forKey: key)
+            }
+            if let standing {
+                imagesByDisplay[standing] = standingImages
+            }
+        }
+    }
+
+    /// Prepares icons for `displayID` and reports whether a fresh capture is needed.
+    @MainActor
+    func prepareImagesForThawBar(
+        displayID: CGDirectDisplayID,
+        section: MenuBarSection.Name
+    ) -> Bool {
+        prepareImagesForDisplay(displayID, section: section)
+    }
+
+    @MainActor
+    private func sectionHasCachedImages(_ section: MenuBarSection.Name) -> Bool {
+        guard let appState else { return false }
+        let items = appState.itemManager.itemCache[section]
+        guard !items.isEmpty else { return true }
+        let keys = Set(images.keys)
+        return items.contains { keys.contains($0.tag) }
     }
 
     /// Clears all cached images and failure tracking.
@@ -2187,6 +2456,8 @@ final class MenuBarItemImageCache: @unchecked Sendable {
     func clearAll() {
         images.removeAll()
         accessOrder.removeAll()
+        imagesByDisplay.removeAll()
+        lastCaptureDisplayID = nil
         failedCapturesLock.withLock { $0.removeAll() }
     }
 


### PR DESCRIPTION
## Summary
- Remove `screen == .main` guards in `IceBarColorManager` so secondary-display Thaw Bar opens sample the panel's own screen for icon contrast.
- Keep per-display warm icon snapshots in `MenuBarItemImageCache`, restore them before `orderFront`, and recapture through the existing offscreen SkyLight cadence (no hand-stamped bypass of the #759 throttle).
- Keep the 500 ms settle delay. Color sample timer stays at 5 s.

## Notes for review
- `storedImage` was removed in favor of a shared `image(for:in:)` helper used by both `image(for:)` and warm-restore.
- Appearance model / editor and local codesign scripts are **not** in this PR (split out per review on #1009).

## Test plan
- [ ] Dual-display: open Thaw Bar on the main screen, then on the secondary screen — icons should not flash the other display's light/dark tint
- [ ] Same-display reopen still settles without an empty "No items…" flash
- [ ] Hidden / always-hidden sections still populate after the settle delay

Closes: N/A

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu bar appearance when opening the panel on a different screen.
  * Prevented brief flashes of incorrect light or dark icon tints during screen changes.
  * Added a loading state while the correct screen-specific colors and icons are refreshed.
  * Preserved recently captured icon appearances per display for faster, smoother switching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->